### PR TITLE
Update Cargo.lock to match version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "daphne"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "daphne_worker"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "assert_matches",
  "async-trait",


### PR DESCRIPTION
In general, always update the Cargo.lock to match changes to any
Cargo.toml.