### PR TITLE
Update agg request serialization

### DIFF
--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -36,8 +36,8 @@ pub fn media_type_for(content_type: &str) -> Option<&'static str> {
 
 /// Returns true if the given media type is for a DAP request sent by the Leader.
 pub(crate) fn media_type_from_leader(media_type: &'static str) -> bool {
-    match media_type {
-        MEDIA_TYPE_AGG_INIT_REQ | MEDIA_TYPE_AGG_CONT_REQ | MEDIA_TYPE_AGG_SHARE_REQ => true,
-        _ => false,
-    }
+    matches!(
+        media_type,
+        MEDIA_TYPE_AGG_INIT_REQ | MEDIA_TYPE_AGG_CONT_REQ | MEDIA_TYPE_AGG_SHARE_REQ
+    )
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -12,10 +12,6 @@
 //! Daphne is not compatible with DAP tasks whose batch lifetime is longer than one aggregation.
 
 use crate::{
-    constants::{
-        MEDIA_TYPE_AGG_CONT_REQ, MEDIA_TYPE_AGG_INIT_REQ, MEDIA_TYPE_AGG_SHARE_REQ,
-        MEDIA_TYPE_COLLECT_REQ,
-    },
     messages::{CollectResp, HpkeConfig, Interval, Nonce, TransitionFailure},
     vdaf::{
         prio3::{prio3_append_prepare_state, prio3_decode_prepare_state, Prio3Error},
@@ -479,26 +475,6 @@ pub struct DapRequest<S> {
     pub payload: Vec<u8>,
     pub url: Url,
     pub sender_auth: Option<S>,
-}
-
-impl<S> DapRequest<S> {
-    /// Returns true if the request has a media type that suggests it was sent by the Leader.
-    pub(crate) fn from_leader(&self) -> bool {
-        match self.media_type {
-            Some(MEDIA_TYPE_AGG_INIT_REQ)
-            | Some(MEDIA_TYPE_AGG_CONT_REQ)
-            | Some(MEDIA_TYPE_AGG_SHARE_REQ) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns true if the request has a media type that suggests it was sent by the Collector.
-    pub(crate) fn from_collector(&self) -> bool {
-        match self.media_type {
-            Some(MEDIA_TYPE_COLLECT_REQ) => true,
-            _ => false,
-        }
-    }
 }
 
 /// DAP response.

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -300,24 +300,23 @@ impl std::fmt::Display for TransitionFailure {
     }
 }
 
-/// An aggregate response sent from the Helper to the Leader in response to an (initial) aggregate
-/// request. The contents of this structure pertain to a single task and batch.
+/// An aggregate response sent from the Helper to the Leader.
 #[derive(Debug, PartialEq, Default)]
 #[allow(missing_docs)]
 pub struct AggregateResp {
-    pub seq: Vec<Transition>,
+    pub transitions: Vec<Transition>,
 }
 
 impl Encode for AggregateResp {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_u16_items(bytes, &(), &self.seq);
+        encode_u16_items(bytes, &(), &self.transitions);
     }
 }
 
 impl Decode for AggregateResp {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         Ok(Self {
-            seq: decode_u16_items(&(), bytes)?,
+            transitions: decode_u16_items(&(), bytes)?,
         })
     }
 }

--- a/daphne/src/messages_test.rs
+++ b/daphne/src/messages_test.rs
@@ -117,7 +117,7 @@ fn read_agg_cont_req() {
 #[test]
 fn read_agg_resp() {
     let want = AggregateResp {
-        seq: vec![
+        transitions: vec![
             Transition {
                 nonce: Nonce {
                     time: 1637361337,

--- a/daphne/src/messages_test.rs
+++ b/daphne/src/messages_test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::messages::{
-    AggregateReq, AggregateReqVar, AggregateResp, HpkeAeadId, HpkeCiphertext, HpkeConfig,
-    HpkeKdfId, HpkeKemId, Id, Nonce, Report, ReportShare, Transition, TransitionVar,
+    AggregateContinueReq, AggregateInitializeReq, AggregateResp, HpkeAeadId, HpkeCiphertext,
+    HpkeConfig, HpkeKdfId, HpkeKemId, Id, Nonce, Report, ReportShare, Transition, TransitionVar,
 };
 use prio::codec::{Decode, Encode};
 
@@ -49,72 +49,68 @@ fn read_report() {
 
 #[test]
 fn read_agg_init_req() {
-    let want = AggregateReq {
+    let want = AggregateInitializeReq {
         task_id: Id([23; 32]),
         agg_job_id: Id([1; 32]),
-        var: AggregateReqVar::Init {
-            agg_param: b"this is an aggregation parameter".to_vec(),
-            seq: vec![
-                ReportShare {
-                    nonce: Nonce {
-                        time: 1637361337,
-                        rand: 10496152761178246059,
-                    },
-                    ignored_extensions: b"these are extensions".to_vec(),
-                    encrypted_input_share: HpkeCiphertext {
-                        config_id: 23,
-                        enc: b"encapsulated key".to_vec(),
-                        payload: b"ciphertext".to_vec(),
-                    },
+        agg_param: b"this is an aggregation parameter".to_vec(),
+        report_shares: vec![
+            ReportShare {
+                nonce: Nonce {
+                    time: 1637361337,
+                    rand: 10496152761178246059,
                 },
-                ReportShare {
-                    nonce: Nonce {
-                        time: 163736423,
-                        rand: 123897432897439,
-                    },
-                    ignored_extensions: vec![],
-                    encrypted_input_share: HpkeCiphertext {
-                        config_id: 0,
-                        enc: vec![],
-                        payload: b"ciphertext".to_vec(),
-                    },
+                ignored_extensions: b"these are extensions".to_vec(),
+                encrypted_input_share: HpkeCiphertext {
+                    config_id: 23,
+                    enc: b"encapsulated key".to_vec(),
+                    payload: b"ciphertext".to_vec(),
                 },
-            ],
-        },
+            },
+            ReportShare {
+                nonce: Nonce {
+                    time: 163736423,
+                    rand: 123897432897439,
+                },
+                ignored_extensions: vec![],
+                encrypted_input_share: HpkeCiphertext {
+                    config_id: 0,
+                    enc: vec![],
+                    payload: b"ciphertext".to_vec(),
+                },
+            },
+        ],
     };
 
-    let got = AggregateReq::get_decoded(&want.get_encoded()).unwrap();
+    let got = AggregateInitializeReq::get_decoded(&want.get_encoded()).unwrap();
     assert_eq!(got, want);
 }
 
 #[test]
-fn read_agg_req() {
-    let want = AggregateReq {
+fn read_agg_cont_req() {
+    let want = AggregateContinueReq {
         task_id: Id([23; 32]),
         agg_job_id: Id([1; 32]),
-        var: AggregateReqVar::Continue {
-            seq: vec![
-                Transition {
-                    nonce: Nonce {
-                        time: 1637361337,
-                        rand: 10496152761178246059,
-                    },
-                    var: TransitionVar::Continued(b"this is a VDAF-specific message".to_vec()),
+        transitions: vec![
+            Transition {
+                nonce: Nonce {
+                    time: 1637361337,
+                    rand: 10496152761178246059,
                 },
-                Transition {
-                    nonce: Nonce {
-                        time: 163736423,
-                        rand: 123897432897439,
-                    },
-                    var: TransitionVar::Continued(
-                        b"believe it or not this is *also* a VDAF-specific message".to_vec(),
-                    ),
+                var: TransitionVar::Continued(b"this is a VDAF-specific message".to_vec()),
+            },
+            Transition {
+                nonce: Nonce {
+                    time: 163736423,
+                    rand: 123897432897439,
                 },
-            ],
-        },
+                var: TransitionVar::Continued(
+                    b"believe it or not this is *also* a VDAF-specific message".to_vec(),
+                ),
+            },
+        ],
     };
 
-    let got = AggregateReq::get_decoded(&want.get_encoded()).unwrap();
+    let got = AggregateContinueReq::get_decoded(&want.get_encoded()).unwrap();
     assert_eq!(got, want);
 }
 

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::{MEDIA_TYPE_AGG_INIT_REQ, MEDIA_TYPE_AGG_SHARE_REQ, MEDIA_TYPE_COLLECT_REQ},
     hpke::HpkeDecrypter,
     messages::{
-        AggregateReq, AggregateReqVar, AggregateShareReq, CollectReq, CollectResp, HpkeCiphertext,
+        AggregateInitializeReq, AggregateShareReq, CollectReq, CollectResp, HpkeCiphertext,
         HpkeConfig, Id, Interval, Nonce, Report, ReportShare, TransitionFailure,
     },
     roles::{DapAggregator, DapAuthorizedSender, DapHelper, DapLeader},
@@ -231,10 +231,11 @@ async fn http_post_aggregate_unauthorized_request() {
 
     let mut req = DapRequest {
         media_type: Some(MEDIA_TYPE_AGG_INIT_REQ),
-        payload: AggregateReq {
+        payload: AggregateInitializeReq {
             task_id: task_id.clone(),
             agg_job_id: Id(rng.gen()),
-            var: AggregateReqVar::default(),
+            agg_param: Vec::default(),
+            report_shares: Vec::default(),
         }
         .get_encoded(),
         url: task_config.helper_url.join("/aggregate").unwrap(),

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -169,7 +169,7 @@ pub(crate) fn prio3_leader_prepare_finish(
             VdafState::Prio3Field128(state),
             VdafMessage::Prio3ShareField128(share),
         ) => {
-            let vdaf = Prio3::new_aes128_histogram(2, &buckets)?;
+            let vdaf = Prio3::new_aes128_histogram(2, buckets)?;
             let (out_share, outbound) = leader_prep_fin!(vdaf, state, share, helper_share_data);
             let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
             (agg_share, outbound)
@@ -224,7 +224,7 @@ pub(crate) fn prio3_helper_prepare_finish(
             VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?)
         }
         (Prio3Config::Histogram { buckets }, VdafState::Prio3Field128(state)) => {
-            let vdaf = Prio3::new_aes128_histogram(2, &buckets)?;
+            let vdaf = Prio3::new_aes128_histogram(2, buckets)?;
             let out_share = helper_prep_fin!(vdaf, state, peer_message_data);
             VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
         }
@@ -273,7 +273,7 @@ pub(crate) fn prio3_decode_prepare_state(
             ))
         }
         Prio3Config::Histogram { buckets } => {
-            let vdaf = Prio3::new_aes128_histogram(2, &buckets)?;
+            let vdaf = Prio3::new_aes128_histogram(2, buckets)?;
             Ok(VdafState::Prio3Field128(
                 Prio3PrepareState::decode_with_param(&(&vdaf, agg_id), bytes)?,
             ))
@@ -322,7 +322,7 @@ pub(crate) fn prio3_unshard<M: IntoIterator<Item = Vec<u8>>>(
             Ok(DapAggregateResult::U64(agg_res))
         }
         Prio3Config::Histogram { buckets } => {
-            let vdaf = Prio3::new_aes128_histogram(2, &buckets)?;
+            let vdaf = Prio3::new_aes128_histogram(2, buckets)?;
             let agg_res = unshard!(vdaf, agg_shares)?;
             Ok(DapAggregateResult::U128Vec(agg_res))
         }

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -63,10 +63,7 @@ pub(crate) async fn worker_request_to_dap(mut req: Request) -> Result<DapRequest
         None
     };
 
-    let sender_auth = req
-        .headers()
-        .get("DAP-Auth-Token")?
-        .map(|token| BearerToken::from(token));
+    let sender_auth = req.headers().get("DAP-Auth-Token")?.map(BearerToken::from);
 
     Ok(DapRequest {
         payload: req.bytes().await?,
@@ -127,12 +124,9 @@ impl<D> BearerTokenProvider for DaphneConfig<D> {
         &self,
         task_id: &Id,
     ) -> std::result::Result<Option<BearerToken>, DapError> {
-        let tokens = self
-            .collector_bearer_tokens
-            .as_ref()
-            .ok_or(DapError::Fatal(
-                "helper cannot authorize requests from collector".into(),
-            ))?;
+        let tokens = self.collector_bearer_tokens.as_ref().ok_or_else(|| {
+            DapError::Fatal("helper cannot authorize requests from collector".into())
+        })?;
         Ok(tokens.get(task_id).cloned())
     }
 }


### PR DESCRIPTION
Partially addresses #8.
Based on #13 (merge that first).

Aligns agg request serialization with draft-ietf-ppm-dap-01. The main
thing that has changed is that the media type is used to distinguish agg
init requests from agg cont requests, rather than a byte encoded in the
message payload itself.

While at it, pick up some clippy fixes.