### PR TITLE
Update DAP message media types

### DIFF
--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -7,15 +7,16 @@
 //
 // TODO spec: Decide if media type should be enforced. (We currently don't.) In any case, it may be
 // useful to enforce this for testing purposes.
-pub const MEDIA_TYPE_HPKE_CONFIG: &str = "application/ppm-hpke-config";
-pub const MEDIA_TYPE_REPORT: &str = "message/ppm-report";
-pub const MEDIA_TYPE_AGG_INIT_REQ: &str = "message/ppm-aggregate-init-req";
-pub const MEDIA_TYPE_AGG_CONT_REQ: &str = "message/ppm-aggregate-continue-req";
-pub const MEDIA_TYPE_AGG_RESP: &str = "message/ppm-aggregate-resp";
-pub const MEDIA_TYPE_AGG_SHARE_REQ: &str = "message/ppm-aggregate-share-req";
-pub const MEDIA_TYPE_AGG_SHARE_RESP: &str = "message/ppm-aggregate-share-resp";
-pub const MEDIA_TYPE_COLLECT_REQ: &str = "message/ppm-collect-req";
-pub const MEDIA_TYPE_COLLECT_RESP: &str = "message/ppm-collect-resp";
+pub const MEDIA_TYPE_HPKE_CONFIG: &str = "application/dap-hpke-config";
+pub const MEDIA_TYPE_REPORT: &str = "application/dap-report";
+pub const MEDIA_TYPE_AGG_INIT_REQ: &str = "application/dap-aggregate-initialize-req";
+pub const MEDIA_TYPE_AGG_INIT_RESP: &str = "application/dap-aggregate-initialize-resp";
+pub const MEDIA_TYPE_AGG_CONT_REQ: &str = "application/dap-aggregate-continue-req";
+pub const MEDIA_TYPE_AGG_CONT_RESP: &str = "application/dap-aggregate-continue-resp";
+pub const MEDIA_TYPE_AGG_SHARE_REQ: &str = "application/dap-aggregate-share-req";
+pub const MEDIA_TYPE_AGG_SHARE_RESP: &str = "application/dap-aggregate-share-resp";
+pub const MEDIA_TYPE_COLLECT_REQ: &str = "application/dap-collect-req";
+pub const MEDIA_TYPE_COLLECT_RESP: &str = "application/dap-collect-resp";
 
 /// Check if the provided value for the HTTP Content-Type is valid media type for DAP. If so, then
 /// return a static reference to the media type.
@@ -24,8 +25,9 @@ pub fn media_type_for(content_type: &str) -> Option<&'static str> {
         MEDIA_TYPE_HPKE_CONFIG => Some(MEDIA_TYPE_HPKE_CONFIG),
         MEDIA_TYPE_REPORT => Some(MEDIA_TYPE_REPORT),
         MEDIA_TYPE_AGG_INIT_REQ => Some(MEDIA_TYPE_AGG_INIT_REQ),
+        MEDIA_TYPE_AGG_INIT_RESP => Some(MEDIA_TYPE_AGG_INIT_RESP),
         MEDIA_TYPE_AGG_CONT_REQ => Some(MEDIA_TYPE_AGG_CONT_REQ),
-        MEDIA_TYPE_AGG_RESP => Some(MEDIA_TYPE_AGG_RESP),
+        MEDIA_TYPE_AGG_CONT_RESP => Some(MEDIA_TYPE_AGG_CONT_RESP),
         MEDIA_TYPE_AGG_SHARE_REQ => Some(MEDIA_TYPE_AGG_SHARE_REQ),
         MEDIA_TYPE_AGG_SHARE_RESP => Some(MEDIA_TYPE_AGG_SHARE_RESP),
         MEDIA_TYPE_COLLECT_REQ => Some(MEDIA_TYPE_COLLECT_REQ),

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     constants::{
-        MEDIA_TYPE_AGG_CONT_REQ, MEDIA_TYPE_AGG_INIT_REQ, MEDIA_TYPE_AGG_RESP,
-        MEDIA_TYPE_AGG_SHARE_REQ, MEDIA_TYPE_AGG_SHARE_RESP,
+        MEDIA_TYPE_AGG_CONT_REQ, MEDIA_TYPE_AGG_CONT_RESP, MEDIA_TYPE_AGG_INIT_REQ,
+        MEDIA_TYPE_AGG_INIT_RESP, MEDIA_TYPE_AGG_SHARE_REQ, MEDIA_TYPE_AGG_SHARE_RESP,
     },
     hpke::HpkeDecrypter,
     messages::{
@@ -449,7 +449,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
                 };
 
                 Ok(DapResponse {
-                    media_type: Some(MEDIA_TYPE_AGG_RESP),
+                    media_type: Some(MEDIA_TYPE_AGG_INIT_RESP),
                     payload: agg_resp.get_encoded(),
                 })
             }
@@ -476,7 +476,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
                 };
 
                 Ok(DapResponse {
-                    media_type: Some(MEDIA_TYPE_AGG_RESP),
+                    media_type: Some(MEDIA_TYPE_AGG_CONT_RESP),
                     payload: agg_resp.get_encoded(),
                 })
             }


### PR DESCRIPTION
Partially addresses #8.
Based on #16 (merge that first).

Aligns the DAP message media types with draft-ietf-ppm-dap-01.