### PR TITLE
Triggers CI in each pull request

### DIFF
--- a/.github/workflows/daphneci.yml
+++ b/.github/workflows/daphneci.yml
@@ -4,10 +4,8 @@ name: DaphneCI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
-    branches:
-      - master
 
 jobs:
   Testing:


### PR DESCRIPTION
This allows run CI test from all pull request, not only those targeting the main branch. 