### PR TITLE
Update Janus integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +370,18 @@ name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -425,8 +449,8 @@ dependencies = [
  "base64",
  "getrandom",
  "hex",
- "hpke",
- "prio 0.8.0",
+ "hpke 0.8.0",
+ "prio",
  "rand",
  "ring",
  "serde",
@@ -451,13 +475,12 @@ dependencies = [
  "futures",
  "getrandom",
  "hex",
- "hpke",
+ "hpke 0.8.0",
  "janus",
  "janus_server",
  "janus_test_util",
  "lazy_static",
- "prio 0.7.0",
- "prio 0.8.0",
+ "prio",
  "rand",
  "reqwest",
  "reqwest-wasm",
@@ -562,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,11 +636,29 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "crypto-bigint",
- "ff",
+ "crypto-bigint 0.2.11",
+ "ff 0.10.1",
  "generic-array",
- "group",
+ "group 0.10.0",
  "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.3.2",
+ "der",
+ "ff 0.11.1",
+ "generic-array",
+ "group 0.11.0",
+ "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -642,6 +692,16 @@ name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -807,7 +867,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
- "ff",
+ "ff 0.10.1",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff 0.11.1",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -900,6 +971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,8 +1010,8 @@ dependencies = [
  "chacha20poly1305",
  "digest 0.9.0",
  "generic-array",
- "hkdf",
- "p256",
+ "hkdf 0.11.0",
+ "p256 0.9.0",
  "paste",
  "rand_core 0.6.3",
  "serde",
@@ -942,14 +1022,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "hpke-dispatch"
-version = "0.2.0"
+name = "hpke"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7268f63af83ef8f8fee20940493212d2bb8f602fc5b8ec14a644b5b7194a7b"
+checksum = "0c7f2ce6f102e00eaddce2801e237a781b67aeaae8c5733ff95ac03e52f22abf"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "byteorder",
+ "chacha20poly1305",
+ "digest 0.10.3",
+ "generic-array",
+ "hkdf 0.12.3",
+ "hmac 0.12.1",
+ "p256 0.10.1",
+ "rand_core 0.6.3",
+ "sha2 0.10.2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-dispatch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e77972dc32fc547aae091c4ea763ae8c7950b5e3c1a1c3639cca1812f18f0b6"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
- "hpke",
+ "hpke 0.9.0",
  "num_enum",
  "rand",
  "wasm-bindgen",
@@ -993,9 +1095,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.18"
+version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1110,26 +1212,29 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "janus"
 version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=54ba8e759e35996a6ea8773aa5f72973d19d4712#54ba8e759e35996a6ea8773aa5f72973d19d4712"
+source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
 dependencies = [
  "anyhow",
  "base64",
+ "bytes",
  "chrono",
  "hex",
- "hpke",
  "hpke-dispatch",
  "num_enum",
- "prio 0.7.0",
+ "postgres-protocol",
+ "postgres-types",
+ "prio",
  "rand",
  "ring",
  "serde",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "janus_server"
 version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=54ba8e759e35996a6ea8773aa5f72973d19d4712#54ba8e759e35996a6ea8773aa5f72973d19d4712"
+source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
 dependencies = [
  "anyhow",
  "atty",
@@ -1140,7 +1245,6 @@ dependencies = [
  "derivative",
  "futures",
  "hex",
- "hpke",
  "hpke-dispatch",
  "http",
  "hyper",
@@ -1149,7 +1253,7 @@ dependencies = [
  "num_enum",
  "opentelemetry",
  "postgres-types",
- "prio 0.7.0",
+ "prio",
  "rand",
  "reqwest",
  "ring",
@@ -1173,12 +1277,16 @@ dependencies = [
 [[package]]
 name = "janus_test_util"
 version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=54ba8e759e35996a6ea8773aa5f72973d19d4712#54ba8e759e35996a6ea8773aa5f72973d19d4712"
+source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
 dependencies = [
+ "assert_matches",
  "chrono",
+ "futures",
  "janus",
+ "prio",
  "rand",
  "ring",
+ "tokio",
 ]
 
 [[package]]
@@ -1489,7 +1597,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.10.6",
+]
+
+[[package]]
+name = "p256"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
+dependencies = [
+ "elliptic-curve 0.11.12",
+ "sec1",
 ]
 
 [[package]]
@@ -1690,25 +1808,6 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prio"
-version = "0.7.0"
-source = "git+https://github.com/divviup/libprio-rs?rev=229cd9c45924c7dae3ba754a6eb46b2a05ca8451#229cd9c45924c7dae3ba754a6eb46b2a05ca8451"
-dependencies = [
- "aes 0.8.1",
- "aes-gcm",
- "base64",
- "byteorder",
- "cipher 0.4.3",
- "cmac",
- "ctr 0.9.1",
- "getrandom",
- "ring",
- "serde",
- "static_assertions",
- "thiserror",
-]
-
-[[package]]
-name = "prio"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e58420a9eed730ff64632a63d8f01becd86367999562978c2ac891582ebb720"
@@ -1865,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64",
  "bytes",
@@ -1896,6 +1995,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.23.4",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1988,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
  "base64",
 ]
@@ -2053,6 +2153,18 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2215,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2375,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a84ae0aabaffcef7d052a366788ecdc6cc8190b49e629ed34a9c66637cadd70"
+checksum = "0e2b1567ca8a2b819ea7b28c92be35d9f76fb9edb214321dcc86eb96023d1f87"
 dependencies = [
  "bollard-stubs",
  "futures",
@@ -2817,9 +2929,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
 ]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ platform locally using [miniflare](https://github.com/cloudflare/miniflare). To
 get it to work you'll also need to upgrade node to the latest version.
 
 ```
-$ nvm use 17.1.0 && npm install -g miniflare@2.5.0
+$ nvm use 18.4.0 && npm install -g miniflare@2.5.1
 ```
 
 To run the Leader: from the `daphne_worker` directory, do

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -21,7 +21,7 @@ use std::{convert::TryFrom, fmt::Debug, io::Cursor};
 pub(crate) enum Prio3Error {
     #[error("Codec error: {0}")]
     Codec(#[from] CodecError),
-    #[error("VDAF error: {0}")]
+    #[error("{0}")]
     Vdaf(#[from] VdafError),
 }
 

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -51,12 +51,9 @@ reqwest = { version = "0.11.7", features = ["json"] }
 assert_matches = "1.5.0"
 lazy_static = "1.4.0"
 futures = "0.3.21"
-janus = { git = "https://github.com/divviup/janus", rev = "54ba8e759e35996a6ea8773aa5f72973d19d4712" }
-janus_server = { git = "https://github.com/divviup/janus", rev = "54ba8e759e35996a6ea8773aa5f72973d19d4712" }
-janus_test_util = { git = "https://github.com/divviup/janus", rev = "54ba8e759e35996a6ea8773aa5f72973d19d4712" }
-# TODO Resolve this hack once the Janus team has finished their implementation
-# and are ready to cut a new version of libprio.
-janus_prio = { git = "https://github.com/divviup/libprio-rs", rev = "229cd9c45924c7dae3ba754a6eb46b2a05ca8451", package = "prio" }
+janus = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
+janus_server = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
+janus_test_util = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
 tokio = { version = "^1.9", features = ["full"] }
 
 # Dependencies for running janus_server.
@@ -67,5 +64,5 @@ tokio = { version = "^1.9", features = ["full"] }
 # away.
 deadpool-postgres = "0.10.1"
 tracing = "0.1.34"
-testcontainers = "0.13.0"
-tokio-postgres = { version = "0.7.6", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+testcontainers = "0.14.0"
+tokio-postgres = { version = "0.7.6", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1", "array-impls"] }

--- a/daphne_worker/tests/backend/leader.env
+++ b/daphne_worker/tests/backend/leader.env
@@ -20,4 +20,6 @@ DAP_TASK_LIST = '{"f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264
 
 DAP_LEADER_BEARER_TOKEN_LIST = '{"f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f":"This is an auth token ivA1e7LpnySDNn1AulaZggFLQ1n7jZ8GWOUO7GY4hgs=","410d5e0abd94a88b8435a192cc458cc1667da2989827584cbf8a591626d5a61f":"This is a differnt token 72938088f14b7ef318ef42ba72395a22"}'
 
-DAP_COLLECTOR_BEARER_TOKEN_LIST = '{"f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f":"this is the bearer token of the Collector"}'
+# TODO The same token is used for both tasks for convenience. Use different
+# tokens for each in order to properly illustrate secure deployment.
+DAP_COLLECTOR_BEARER_TOKEN_LIST = '{"f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f":"this is the bearer token of the Collector", "410d5e0abd94a88b8435a192cc458cc1667da2989827584cbf8a591626d5a61f":"this is the bearer token of the Collector"}'


### PR DESCRIPTION
Partially addresses #8.

Updates Janus to the latest version and confirms interop. This revealed
a minor issue around error handling when an HTTP request to the Helper
fails. In particular, we expected the Helper to respond with a "Problem
Details" document, but it might not always do so.