### PR TITLE
Merge `HpkeSecretKey` with `HpkeConfig` via `HpkeReceiverConfig`

### DIFF
--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -4,14 +4,30 @@
 //! Hybrid Public-Key Encryption ([HPKE](https://datatracker.ietf.org/doc/rfc9180/)).
 
 use crate::{
-    messages::{HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId, HpkeKemId, Id},
+    messages::{
+        decode_u16_bytes, encode_u16_bytes, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId,
+        HpkeKemId, Id,
+    },
     DapError,
 };
 use hpke::{aead, kdf, kem, Deserializable, HpkeError, Kem, OpModeR};
+use prio::codec::{CodecError, Decode, Encode};
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::io::Cursor;
 
 impl HpkeConfig {
+    fn check_suite(&self) -> Result<(), DapError> {
+        match (self.kem_id, self.kdf_id, self.aead_id) {
+            (HpkeKemId::X25519HkdfSha256, HpkeKdfId::HkdfSha256, HpkeAeadId::Aes128Gcm) => Ok(()),
+            (kem_id, kdf_id, aead_id) => Err(DapError::Fatal(format!(
+                "HPKE ciphersuite not implemented ({}, {}, {})",
+                u16::from(kem_id),
+                u16::from(kdf_id),
+                u16::from(aead_id)
+            ))),
+        }
+    }
+
     /// Encrypt `plaintext` with info string `info` and associated data `aad` using this HPKE
     /// configuration. The return values are the encapsulated key and the ciphertext.
     pub fn encrypt(
@@ -22,7 +38,7 @@ impl HpkeConfig {
     ) -> Result<(Vec<u8>, Vec<u8>), DapError> {
         use hpke::{OpModeS, Serializable};
 
-        check_suite(self)?;
+        self.check_suite()?;
         let pk = <kem::X25519HkdfSha256 as Kem>::PublicKey::from_bytes(&self.public_key)?;
         let (enc, mut sender) = hpke::setup_sender::<
             aead::AesGcm128,
@@ -32,102 +48,6 @@ impl HpkeConfig {
         >(&OpModeS::Base, &pk, info, &mut rand::thread_rng())?;
 
         Ok((enc.to_bytes().to_vec(), sender.seal(plaintext, aad)?))
-    }
-}
-
-/// An HPKE configuration and corresponding secret key.
-#[derive(Deserialize, Serialize)]
-#[serde(try_from = "ShadowHpkeSecretKey")]
-pub struct HpkeSecretKey {
-    pub id: u8,
-    sk: <kem::X25519HkdfSha256 as Kem>::PrivateKey,
-}
-
-// Workaround struct for allowing the secret key to be encoded in hex.
-#[derive(Deserialize, Serialize)]
-struct ShadowHpkeSecretKey {
-    id: u8,
-    #[serde(with = "hex")]
-    sk: Vec<u8>,
-}
-
-impl TryFrom<ShadowHpkeSecretKey> for HpkeSecretKey {
-    type Error = HpkeError;
-
-    fn try_from(shadow: ShadowHpkeSecretKey) -> Result<Self, Self::Error> {
-        let sk = <kem::X25519HkdfSha256 as Kem>::PrivateKey::from_bytes(&shadow.sk)?;
-        Ok(HpkeSecretKey { id: shadow.id, sk })
-    }
-}
-
-impl HpkeSecretKey {
-    /// Decrypt `ciphertext` with info string `info` and associated data `aad` using this HPKE
-    /// configuration and corresponding secret key. The return value is the plaintext.
-    #[allow(dead_code)]
-    pub fn decrypt(
-        &self,
-        info: &[u8],
-        aad: &[u8],
-        enc: &[u8],
-        ciphertext: &[u8],
-    ) -> Result<Vec<u8>, HpkeError> {
-        let enc = <kem::X25519HkdfSha256 as Kem>::EncappedKey::from_bytes(enc)?;
-        let mut receiver = hpke::setup_receiver::<
-            aead::AesGcm128,
-            kdf::HkdfSha256,
-            kem::X25519HkdfSha256,
-        >(&OpModeR::Base, &self.sk, &enc, info)?;
-        receiver.open(ciphertext, aad)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn gen(id: u8) -> (HpkeConfig, Self) {
-        use hpke::Serializable;
-        let (sk, pk) = kem::X25519HkdfSha256::gen_keypair(&mut rand::thread_rng());
-        (
-            HpkeConfig {
-                id,
-                kem_id: HpkeKemId::X25519HkdfSha256,
-                kdf_id: HpkeKdfId::HkdfSha256,
-                aead_id: HpkeAeadId::Aes128Gcm,
-                public_key: pk.to_bytes().to_vec(),
-            },
-            Self { id, sk },
-        )
-    }
-}
-
-impl HpkeDecrypter for HpkeSecretKey {
-    fn get_hpke_config_for(&self, _task_id: &Id) -> Option<&HpkeConfig> {
-        // TODO(issue#12) Have HpkeSecretKey subsume the config.
-        unreachable!("not implemented");
-    }
-
-    fn can_hpke_decrypt(&self, _task_id: &Id, config_id: u8) -> bool {
-        config_id == self.id
-    }
-
-    fn hpke_decrypt(
-        &self,
-        _task_id: &Id,
-        info: &[u8],
-        aad: &[u8],
-        ciphertext: &HpkeCiphertext,
-    ) -> std::result::Result<Vec<u8>, DapError> {
-        Ok(self.decrypt(info, aad, &ciphertext.enc, &ciphertext.payload)?)
-    }
-}
-
-// Check that the cipher suite is the one we support.
-fn check_suite(config: &HpkeConfig) -> Result<(), DapError> {
-    match (config.kem_id, config.kdf_id, config.aead_id) {
-        (HpkeKemId::X25519HkdfSha256, HpkeKdfId::HkdfSha256, HpkeAeadId::Aes128Gcm) => Ok(()),
-        (kem_id, kdf_id, aead_id) => Err(DapError::Fatal(format!(
-            "HPKE ciphersuite not implemented ({}, {}, {})",
-            u16::from(kem_id),
-            u16::from(kdf_id),
-            u16::from(aead_id)
-        ))),
     }
 }
 
@@ -150,8 +70,116 @@ pub trait HpkeDecrypter {
 }
 
 /// Struct that combines HpkeConfig and HpkeSecretKey
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct HpkeReceiverConfig {
     pub config: HpkeConfig,
-    pub secret_key: HpkeSecretKey,
+    #[serde(with = "hex")]
+    secret_key: Vec<u8>,
+}
+
+impl HpkeReceiverConfig {
+    // Check that the cipher suite is the one we support.
+    fn check_suite(&self) -> Result<(), DapError> {
+        match (self.config.kem_id, self.config.kdf_id, self.config.aead_id) {
+            (HpkeKemId::X25519HkdfSha256, HpkeKdfId::HkdfSha256, HpkeAeadId::Aes128Gcm) => Ok(()),
+            (kem_id, kdf_id, aead_id) => Err(DapError::Fatal(format!(
+                "HPKE ciphersuite not implemented ({}, {}, {})",
+                u16::from(kem_id),
+                u16::from(kdf_id),
+                u16::from(aead_id)
+            ))),
+        }
+    }
+
+    pub fn encrypt(
+        &self,
+        info: &[u8],
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), DapError> {
+        use hpke::{OpModeS, Serializable};
+
+        self.check_suite()?;
+        let pk = <kem::X25519HkdfSha256 as Kem>::PublicKey::from_bytes(&self.config.public_key)?;
+        let (enc, mut sender) = hpke::setup_sender::<
+            aead::AesGcm128,
+            kdf::HkdfSha256,
+            kem::X25519HkdfSha256,
+            _,
+        >(&OpModeS::Base, &pk, info, &mut rand::thread_rng())?;
+
+        Ok((enc.to_bytes().to_vec(), sender.seal(plaintext, aad)?))
+    }
+
+    /// Decrypt `ciphertext` with info string `info` and associated data `aad` using this HPKE
+    /// configuration and corresponding secret key. The return value is the plaintext.
+    pub fn decrypt(
+        &self,
+        info: &[u8],
+        aad: &[u8],
+        enc: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, HpkeError> {
+        let sk = <kem::X25519HkdfSha256 as Kem>::PrivateKey::from_bytes(&self.secret_key)?;
+        let enc = <kem::X25519HkdfSha256 as Kem>::EncappedKey::from_bytes(enc)?;
+        let mut receiver = hpke::setup_receiver::<
+            aead::AesGcm128,
+            kdf::HkdfSha256,
+            kem::X25519HkdfSha256,
+        >(&OpModeR::Base, &sk, &enc, info)?;
+        receiver.open(ciphertext, aad)
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn gen(id: u8) -> Self {
+        use hpke::Serializable;
+        let (sk, pk) = kem::X25519HkdfSha256::gen_keypair(&mut rand::thread_rng());
+        HpkeReceiverConfig {
+            config: HpkeConfig {
+                id: id,
+                kem_id: HpkeKemId::X25519HkdfSha256,
+                kdf_id: HpkeKdfId::HkdfSha256,
+                aead_id: HpkeAeadId::Aes128Gcm,
+                public_key: pk.to_bytes().to_vec(),
+            },
+            secret_key: sk.to_bytes().to_vec(),
+        }
+    }
+}
+
+impl HpkeDecrypter for HpkeReceiverConfig {
+    fn get_hpke_config_for(&self, _task_id: &Id) -> Option<&HpkeConfig> {
+        unreachable!("not implemented");
+    }
+
+    fn can_hpke_decrypt(&self, _task_id: &Id, config_id: u8) -> bool {
+        config_id == self.config.id
+    }
+
+    fn hpke_decrypt(
+        &self,
+        _task_id: &Id,
+        info: &[u8],
+        aad: &[u8],
+        ciphertext: &HpkeCiphertext,
+    ) -> Result<Vec<u8>, DapError> {
+        Ok(self.decrypt(info, aad, &ciphertext.enc, &ciphertext.payload)?)
+    }
+}
+
+impl Encode for HpkeReceiverConfig {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.config.encode(bytes);
+        encode_u16_bytes(bytes, &self.secret_key);
+    }
+}
+
+impl Decode for HpkeReceiverConfig {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        Ok(Self {
+            config: HpkeConfig::decode(bytes)?,
+            secret_key: decode_u16_bytes(bytes)?,
+        })
+    }
 }

--- a/daphne/src/hpke_test.rs
+++ b/daphne/src/hpke_test.rs
@@ -1,14 +1,17 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use crate::hpke::HpkeSecretKey;
+use crate::hpke::HpkeReceiverConfig;
 
 #[test]
 fn encrypt_roundtrip() {
     let info = b"info string";
     let aad = b"associated data";
     let plaintext = b"plaintext";
-    let (config, sk) = HpkeSecretKey::gen(23);
+    let config = HpkeReceiverConfig::gen(23);
     let (enc, ciphertext) = config.encrypt(info, aad, plaintext).unwrap();
-    assert_eq!(sk.decrypt(info, aad, &enc, &ciphertext).unwrap(), plaintext);
+    assert_eq!(
+        config.decrypt(info, aad, &enc, &ciphertext).unwrap(),
+        plaintext
+    );
 }

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -653,7 +653,7 @@ pub(crate) fn encode_u16_bytes(bytes: &mut Vec<u8>, input: &[u8]) {
     bytes.extend_from_slice(input);
 }
 
-fn decode_u16_bytes(bytes: &mut Cursor<&[u8]>) -> Result<Vec<u8>, CodecError> {
+pub(crate) fn decode_u16_bytes(bytes: &mut Cursor<&[u8]>) -> Result<Vec<u8>, CodecError> {
     let len = u16::decode(bytes)? as usize;
     let mut out = vec![0; len];
     bytes.read_exact(&mut out)?;

--- a/daphne_worker/src/config_test.rs
+++ b/daphne_worker/src/config_test.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::config::DaphneWorkerConfig;
-use daphne::{
-    hpke::HpkeDecrypter,
-    messages::{Interval, Nonce},
-};
+use daphne::messages::{Interval, Nonce};
 
 const DAP_TASK_LIST: &str = r#"{
   "f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f": {
@@ -25,16 +22,26 @@ const DAP_TASK_LIST: &str = r#"{
   }
 }"#;
 
-const DAP_HPKE_CONFIG_LIST: &str = r#"[
-    "1700200001000100205dc71373c6aa7b0af67944a370ab96d8b8216832579c19159ca35d10f25a2765"
-]"#;
-
-// TODO Encode the secret key as a hex string. Unfortunately it's not as simple as adding
-// #[serde(with = "hex")] to the struct definition.
-const DAP_HPKE_SECRET_KEY_LIST: &str = r#"[
+const DAP_HPKE_RECEIVER_CONFIG_LIST: &str = r#"[
     {
-        "id": 23,
-        "sk": "888e94344585f44530d03e250268be6c6a5caca5314513dcec488cc431486c69"
+        "config": {
+            "id": 23,
+            "kem_id": "X25519HkdfSha256",
+            "kdf_id": "HkdfSha256",
+            "aead_id": "Aes128Gcm",
+            "public_key": "5dc71373c6aa7b0af67944a370ab96d8b8216832579c19159ca35d10f25a2765"
+        },
+        "secret_key": "888e94344585f44530d03e250268be6c6a5caca5314513dcec488cc431486c69"
+    },
+    {
+        "config": {
+            "id": 14,
+            "kem_id": "X25519HkdfSha256",
+            "kdf_id": "HkdfSha256",
+            "aead_id": "Aes128Gcm",
+            "public_key": "b07126295bcfcdeaec61b310fd7ffbf8c6ca7f6c17e3e0a80a5405a242e5084b"
+        },
+        "secret_key": "b809a4df399548f56c3a15ebaa4925dd292637f0b7e2f6bc3ba60376b69aa05e"
     }
 ]"#;
 
@@ -46,8 +53,7 @@ fn daphne_param() {
     let bucket_count = 5;
     let config: DaphneWorkerConfig<String> = DaphneWorkerConfig::from_test_config(
         DAP_TASK_LIST,
-        DAP_HPKE_CONFIG_LIST,
-        DAP_HPKE_SECRET_KEY_LIST,
+        DAP_HPKE_RECEIVER_CONFIG_LIST,
         DAP_BUCKET_KEY,
         bucket_count,
     )
@@ -89,8 +95,4 @@ fn daphne_param() {
             "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/4",
         ]
     );
-
-    // Try fetching the first HPKE config.
-    config.get_hpke_config_for(&task_id).unwrap();
-    // TODO Test that hpke_config() checks that the output can be parsed.
 }

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -2,11 +2,13 @@ DAP_AGGREGATOR_ROLE = "helper"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the
 # Aggregator, but the Aggregator will decrypt input shares using any of them.
-DAP_HPKE_CONFIG_LIST = '["0e0020000100010020b07126295bcfcdeaec61b310fd7ffbf8c6ca7f6c17e3e0a80a5405a242e5084b"]'
+# DAP_HPKE_CONFIG_LIST = '["0e0020000100010020b07126295bcfcdeaec61b310fd7ffbf8c6ca7f6c17e3e0a80a5405a242e5084b"]'
 
 # A list of HPKE secret keys, each corresponding to an HPKE config in
 # DAP_HPKE_CONFIG_LIST.
-DAP_HPKE_SECRET_KEY_LIST = '[{"id":14,"sk":"b809a4df399548f56c3a15ebaa4925dd292637f0b7e2f6bc3ba60376b69aa05e"}]'
+# DAP_HPKE_SECRET_KEY_LIST = '[{"id":14,"sk":"b809a4df399548f56c3a15ebaa4925dd292637f0b7e2f6bc3ba60376b69aa05e"}]'
+
+DAP_HPKE_RECEIVER_CONFIG_LIST = '[{"config":{"id":14,"kem_id":"X25519HkdfSha256","kdf_id":"HkdfSha256","aead_id":"Aes128Gcm","public_key":"b07126295bcfcdeaec61b310fd7ffbf8c6ca7f6c17e3e0a80a5405a242e5084b"},"secret_key":"b809a4df399548f56c3a15ebaa4925dd292637f0b7e2f6bc3ba60376b69aa05e"}]'
 
 # Bucket key used to derive the bucket name for a report.
 DAP_BUCKET_KEY = 'f79c352056982bae1737e34bdac24d63'

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -2,11 +2,13 @@ DAP_AGGREGATOR_ROLE = "leader"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the
 # Aggregator, but the Aggregator will decrypt input shares using any of them.
-DAP_HPKE_CONFIG_LIST = '["1700200001000100205dc71373c6aa7b0af67944a370ab96d8b8216832579c19159ca35d10f25a2765"]'
+# DAP_HPKE_CONFIG_LIST = '["1700200001000100205dc71373c6aa7b0af67944a370ab96d8b8216832579c19159ca35d10f25a2765"]'
 
 # A list of HPKE secret keys, each corresponding to an HPKE config in
 # DAP_HPKE_CONFIG_LIST.
-DAP_HPKE_SECRET_KEY_LIST = '[{"id":23,"sk":"888e94344585f44530d03e250268be6c6a5caca5314513dcec488cc431486c69"}]'
+# DAP_HPKE_SECRET_KEY_LIST = '[{"id":23,"sk":"888e94344585f44530d03e250268be6c6a5caca5314513dcec488cc431486c69"}]'
+
+DAP_HPKE_RECEIVER_CONFIG_LIST = '[{"config":{"id":23,"kem_id":"X25519HkdfSha256","kdf_id":"HkdfSha256","aead_id":"Aes128Gcm","public_key":"5dc71373c6aa7b0af67944a370ab96d8b8216832579c19159ca35d10f25a2765"},"secret_key":"888e94344585f44530d03e250268be6c6a5caca5314513dcec488cc431486c69"}]'
 
 # Bucket key used to derive the bucket name for a report.
 DAP_BUCKET_KEY = '61cd9685547370cfea76c2eb8d156ad9'

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -7,7 +7,7 @@ mod test_runner;
 
 use daphne::{
     constants,
-    hpke::HpkeSecretKey,
+    hpke::HpkeReceiverConfig,
     messages::{CollectReq, CollectResp, Id, Interval},
     DapAggregateResult, DapMeasurement,
 };
@@ -15,7 +15,7 @@ use daphne_worker::InternalAggregateInfo;
 use prio::codec::{Decode, Encode};
 use rand::prelude::*;
 use std::time::SystemTime;
-use test_runner::{TestRunner, COLLECTOR_BEARER_TOKEN, COLLECTOR_HPKE_SECRET_KEY};
+use test_runner::{TestRunner, COLLECTOR_BEARER_TOKEN, COLLECTOR_HPKE_RECEIVER_CONFIG};
 
 #[tokio::test]
 #[cfg_attr(not(feature = "test_e2e"), ignore)]
@@ -287,7 +287,8 @@ async fn e2e_leader_collect_ok() {
     let resp = client.get(collect_uri.as_str()).send().await.unwrap();
     assert_eq!(resp.status(), 200);
 
-    let decrypter: HpkeSecretKey = serde_json::from_str(COLLECTOR_HPKE_SECRET_KEY).unwrap();
+    let decrypter: HpkeReceiverConfig =
+        serde_json::from_str(COLLECTOR_HPKE_RECEIVER_CONFIG).unwrap();
     let collect_resp = CollectResp::get_decoded(&resp.bytes().await.unwrap()).unwrap();
     let agg_res = t
         .vdaf

--- a/daphne_worker_test/tests/janus.rs
+++ b/daphne_worker_test/tests/janus.rs
@@ -13,7 +13,7 @@ use prio::{
     vdaf::prio3::Prio3,
 };
 use rand::prelude::*;
-use test_runner::{TestRunner, COLLECTOR_HPKE_SECRET_KEY};
+use test_runner::{TestRunner, COLLECTOR_HPKE_RECEIVER_CONFIG};
 
 // Test that daphne can aggregate a report from a Janus client.
 #[tokio::test]
@@ -129,8 +129,8 @@ async fn janus_helper() {
     let resp = client.get(collect_uri).send().await.unwrap();
     assert_eq!(resp.status(), 200);
 
-    let decrypter: daphne::hpke::HpkeSecretKey =
-        serde_json::from_str(COLLECTOR_HPKE_SECRET_KEY).unwrap();
+    let decrypter: daphne::hpke::HpkeReceiverConfig =
+        serde_json::from_str(COLLECTOR_HPKE_RECEIVER_CONFIG).unwrap();
     let collect_resp =
         daphne::messages::CollectResp::get_decoded(&resp.bytes().await.unwrap()).unwrap();
     let agg_res = t

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -112,9 +112,15 @@ const JANUS_HELPER_TASK_LEADER_BEARER_TOKEN: &str =
 pub(crate) const COLLECTOR_BEARER_TOKEN: &str = "this is the bearer token of the Collector";
 
 #[allow(dead_code)]
-pub(crate) const COLLECTOR_HPKE_SECRET_KEY: &str = r#"{
-    "id": 244,
-    "sk": "68db815a534d3f92a6224c4cbbc2dd301be48ef32f112dbfb3709a4cbfe5f372"
+pub(crate) const COLLECTOR_HPKE_RECEIVER_CONFIG: &str = r#"{
+    "config": {
+        "id": 244,
+        "kem_id": "X25519HkdfSha256",
+        "kdf_id": "HkdfSha256",
+        "aead_id": "Aes128Gcm",
+        "public_key": "a761d90c8c76d3d76349a3794a439a1572ab1fb8f13531d69744c92ea7757d7f"
+    },
+    "secret_key": "68db815a534d3f92a6224c4cbbc2dd301be48ef32f112dbfb3709a4cbfe5f372"
 }"#;
 
 #[allow(dead_code)]


### PR DESCRIPTION
This pull request introduces `HpkeReceiverConfig`, which is represented as below:
```rust
HpkeReceiverConfig {
config: HpkeConfig,
secret_key: Vec<u8>
}
```
Reference: #12

This allows us to index an HPKE public key and its corresponding secret key using a single config ID.
Both `public_key` and `secret_key` are represented as `Vec<u8>` as neither `kem::X25519HkdfSha256 as Kem>::PublicKey` nor `kem::X25519HkdfSha256 as Kem>::PrivateKey` implement `PartialEq` and `Debug`.

Please ignore the comment in the most recent commit (ref: #36).