### PR TITLE
Ensure all durable object state is persistent

### DIFF
--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -25,6 +25,11 @@ impl Id {
     pub fn to_base64url(&self) -> String {
         base64::encode_config(&self.0, base64::URL_SAFE_NO_PAD)
     }
+
+    /// Return the ID encoded as a hex string.
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
 }
 
 impl Encode for Id {

--- a/daphne_worker/src/durable/leader_state_store.rs
+++ b/daphne_worker/src/durable/leader_state_store.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use crate::int_err;
+use crate::{
+    durable::{state_get, state_get_or_default},
+    int_err,
+};
 use daphne::{
     messages::{CollectReq, CollectResp, Id},
     DapCollectJob,
@@ -9,7 +12,7 @@ use daphne::{
 use prio::codec::Encode;
 use ring::digest::{digest, SHA256};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryInto};
+use std::convert::TryInto;
 use worker::*;
 
 pub(crate) fn durable_leader_state_name(task_id: &Id) -> String {
@@ -32,6 +35,7 @@ pub(crate) struct LeaderStateStoreUpdateCollectReq {
     pub(crate) collect_resp: CollectResp,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
 struct OrderedCollectReq {
     priority: usize,
     collect_req: CollectReq,
@@ -43,10 +47,6 @@ struct OrderedCollectReq {
 /// the task ID.
 #[durable_object]
 pub struct LeaderStateStore {
-    // TODO Write this to persistent storage instead of keeping it in memory.
-    collect_req_pending: HashMap<Id, OrderedCollectReq>,
-    collect_req_processed: HashMap<Id, CollectResp>,
-    next_priority: usize,
     #[allow(dead_code)]
     state: State,
 }
@@ -54,58 +54,77 @@ pub struct LeaderStateStore {
 #[durable_object]
 impl DurableObject for LeaderStateStore {
     fn new(state: State, _env: Env) -> Self {
-        Self {
-            collect_req_pending: HashMap::new(),
-            collect_req_processed: HashMap::new(),
-            next_priority: 0,
-            state,
-        }
+        Self { state }
     }
 
     async fn fetch(&mut self, mut req: Request) -> Result<Response> {
         match (req.path().as_ref(), req.method()) {
             (DURABLE_LEADER_STATE_DELETE_ALL, Method::Post) => {
-                self.collect_req_pending.drain();
-                self.collect_req_processed.drain();
-                self.next_priority = 0;
+                self.state.storage().delete_all().await?;
                 Response::empty()
             }
 
             // Store a CollectReq issued by the collector.
             (DURABLE_LEADER_STATE_PUT_COLLECT_REQ, Method::Post) => {
-                // TODO Consider disallowing overlapping collect requests. Would this require a
-                // spec change?
-                //
-                // TODO Figure out if we can avoid re-serializing by passing raw bytes here instead
-                // of JSON.
+                // TODO Disallow overlapping collect requests, as required by
+                // draft-ietf-ppm-dap-01.
                 let collect_req: CollectReq = req.json().await?;
                 let collect_req_digest = digest(&SHA256, &collect_req.get_encoded());
                 let collect_id = Id(collect_req_digest.as_ref().try_into().unwrap());
+                let collect_id_hex = hex::encode(collect_req_digest);
+                let pending_key = format!("pending/{}", collect_id_hex);
+                let pending: Option<OrderedCollectReq> =
+                    state_get(&self.state, &pending_key).await?;
+                let processed: Option<CollectResp> =
+                    state_get(&self.state, &format!("processed/{}", collect_id_hex)).await?;
                 let resp = Response::from_json(&collect_id);
-                if self.collect_req_processed.get(&collect_id).is_none()
-                    && self.collect_req_pending.get(&collect_id).is_none()
-                {
-                    self.collect_req_pending.insert(
-                        collect_id,
-                        OrderedCollectReq {
-                            priority: self.next_priority,
-                            collect_req,
-                        },
-                    );
-                    self.next_priority += 1;
+                if processed.is_none() && pending.is_none() {
+                    let next_priority: usize =
+                        state_get_or_default(&self.state, "next_priority").await?;
+                    self.state
+                        .storage()
+                        .put(
+                            &pending_key,
+                            OrderedCollectReq {
+                                priority: next_priority,
+                                collect_req,
+                            },
+                        )
+                        .await?;
+                    self.state
+                        .storage()
+                        .put("next_priority", next_priority + 1)
+                        .await?;
                 }
                 resp
             }
 
             // Retrieve the list of pending CollectReqs.
             (DURABLE_LEADER_STATE_GET_COLLECT_REQS, Method::Get) => {
-                // Return a list of (Id, CollectReq) in order of arrival.
-                let mut res: Vec<(&Id, &OrderedCollectReq)> =
-                    self.collect_req_pending.iter().collect();
+                // Return the list of (Id, CollectReq) in order of arrival.
+                //
+                // TODO Consider limting the length of the response.
+                let opt = ListOptions::new().prefix("pending/");
+                let iter = self.state.storage().list_with_options(opt).await?.entries();
+                let mut item = iter.next()?;
+                let mut res = Vec::new();
+                while !item.done() {
+                    let (pending_key, ordered_collect_req): (String, OrderedCollectReq) =
+                        item.value().into_serde()?;
+                    let collect_id_hex = &pending_key["pending/".len()..];
+                    let collect_id =
+                        Id(hex::decode(collect_id_hex)
+                            .map_err(int_err)?
+                            .try_into()
+                            .map_err(|_| int_err("malformed key for pending CollectReq"))?);
+                    res.push((collect_id, ordered_collect_req));
+                    item = iter.next()?;
+                }
+
                 res.sort_unstable_by_key(|(_id, prioritized)| prioritized.priority);
-                let res: Vec<(&Id, &CollectReq)> = res
-                    .iter()
-                    .map(|(id, prioritized)| (*id, &prioritized.collect_req))
+                let res: Vec<(Id, CollectReq)> = res
+                    .into_iter()
+                    .map(|(id, prioritized)| (id, prioritized.collect_req))
                     .collect();
                 Response::from_json(&res)
             }
@@ -113,32 +132,46 @@ impl DurableObject for LeaderStateStore {
             // Store a CollectResp corresponding to a pending CollectReq.
             (DURABLE_LEADER_STATE_FINISH_COLLECT_REQ, Method::Post) => {
                 let update: LeaderStateStoreUpdateCollectReq = req.json().await?;
-                if self.collect_req_processed.get(&update.collect_id).is_some() {
+                let collect_id_hex = update.collect_id.to_hex();
+                let processed_key = format!("processed/{}", collect_id_hex);
+                let processed: Option<CollectResp> = state_get(&self.state, &processed_key).await?;
+                if processed.is_some() {
                     return Err(int_err(
                         "LeaderStateStore: tried to overwrite collect response",
                     ));
                 }
 
-                if self.collect_req_pending.get(&update.collect_id).is_none() {
+                let pending: Option<OrderedCollectReq> =
+                    state_get(&self.state, &format!("pending/{}", collect_id_hex)).await?;
+                if pending.is_none() {
                     return Err(int_err("LeaderStateStore: missing collect request"));
                 }
 
-                self.collect_req_processed
-                    .insert(update.collect_id, update.collect_resp);
+                self.state
+                    .storage()
+                    .put(&processed_key, update.collect_resp)
+                    .await?;
                 Response::empty()
             }
 
             // Retrieve a completed CollectResp.
             (DURABLE_LEADER_STATE_GET_COLLECT_RESP, Method::Post) => {
-                let collect_id = req.json().await?;
-                if self.collect_req_pending.get(&collect_id).is_none() {
+                let collect_id: Id = req.json().await?;
+                let collect_id_hex = collect_id.to_hex();
+                let pending_key = format!("pending/{}", collect_id_hex);
+                let pending: Option<OrderedCollectReq> =
+                    state_get(&self.state, &pending_key).await?;
+                if pending.is_none() {
                     return Response::from_json(&DapCollectJob::Unknown);
                 }
 
-                if let Some((_, collect_resp)) =
-                    self.collect_req_processed.remove_entry(&collect_id)
-                {
-                    self.collect_req_pending.remove(&collect_id);
+                let processed_key = format!("processed/{}", collect_id_hex);
+                let processed: Option<CollectResp> = state_get(&self.state, &processed_key).await?;
+                if let Some(collect_resp) = processed {
+                    self.state
+                        .storage()
+                        .delete_multiple(vec![pending_key, processed_key])
+                        .await?;
                     Response::from_json(&DapCollectJob::Done(collect_resp))
                 } else {
                     Response::from_json(&DapCollectJob::Pending)

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -1,6 +1,37 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+use serde::Deserialize;
+use worker::*;
+
+const ERR_NO_VALUE: &str = "No such value in storage.";
+
+pub(crate) async fn state_get_or_default<T: Default + for<'a> Deserialize<'a>>(
+    state: &State,
+    key: &str,
+) -> Result<T> {
+    state.storage().get(key).await.or_else(|e| {
+        if matches!(e, Error::JsError(ref s) if s == ERR_NO_VALUE) {
+            Ok(T::default())
+        } else {
+            Err(e)
+        }
+    })
+}
+
+pub(crate) async fn state_get<T: for<'a> Deserialize<'a>>(
+    state: &State,
+    key: &str,
+) -> Result<Option<T>> {
+    state.storage().get(key).await.or_else(|e| {
+        if matches!(e, Error::JsError(ref s) if s == ERR_NO_VALUE) {
+            Ok(None)
+        } else {
+            Err(e)
+        }
+    })
+}
+
 pub(crate) mod aggregate_store;
 pub(crate) mod helper_state_store;
 pub(crate) mod leader_state_store;


### PR DESCRIPTION
Based on #41 (merge that first).

Use storage API to store the state of `LeaderStateStore`,
`HelperStateStore`, and `AggregateStore`.