### PR TITLE
Update Janus interop tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ dependencies = [
  "deadpool-postgres",
  "futures",
  "hex",
- "janus",
+ "janus_client",
+ "janus_core",
  "janus_server",
- "janus_test_util",
  "lazy_static",
  "prio",
  "rand",
@@ -1226,14 +1226,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "janus"
-version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
+name = "janus_client"
+version = "0.1.2"
+source = "git+https://github.com/divviup/janus?rev=e5ed423cfc96051894de2997aa013b77b322e2b9#e5ed423cfc96051894de2997aa013b77b322e2b9"
+dependencies = [
+ "http",
+ "janus_core",
+ "prio",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "janus_core"
+version = "0.1.2"
+source = "git+https://github.com/divviup/janus?rev=e5ed423cfc96051894de2997aa013b77b322e2b9#e5ed423cfc96051894de2997aa013b77b322e2b9"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "base64",
  "bytes",
  "chrono",
+ "futures",
  "hex",
  "hpke-dispatch",
  "num_enum",
@@ -1243,14 +1260,18 @@ dependencies = [
  "rand",
  "ring",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "janus_server"
 version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
+source = "git+https://github.com/divviup/janus?rev=e5ed423cfc96051894de2997aa013b77b322e2b9#e5ed423cfc96051894de2997aa013b77b322e2b9"
 dependencies = [
  "anyhow",
  "atty",
@@ -1265,7 +1286,8 @@ dependencies = [
  "http",
  "hyper",
  "itertools",
- "janus",
+ "janus_core",
+ "lazy_static",
  "num_enum",
  "opentelemetry",
  "postgres-types",
@@ -1279,6 +1301,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-tokio",
  "structopt",
+ "testcontainers",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -1288,21 +1311,6 @@ dependencies = [
  "url",
  "uuid",
  "warp",
-]
-
-[[package]]
-name = "janus_test_util"
-version = "0.1.0"
-source = "git+https://github.com/divviup/janus?rev=6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4#6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4"
-dependencies = [
- "assert_matches",
- "chrono",
- "futures",
- "janus",
- "prio",
- "rand",
- "ring",
- "tokio",
 ]
 
 [[package]]
@@ -2208,18 +2216,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.56"
 base64 = "0.13.0"
 getrandom = { version = "0.2", features = ["js"] } # Required for prio
 worker = "0.0.10"
-serde_json = "1.0.67"
+serde_json = "1.0.82"
 prio = "0.8.0"
 hpke = { version = "0.8.0", features = ["std", "serde_impls"] }
 ring = "0.16.20"

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,7 +18,7 @@ daphne = { path = "../daphne" }
 async-trait = "0.1.56"
 base64 = "0.13.0"
 worker = "0.0.10"
-serde_json = "1.0.67"
+serde_json = "1.0.82"
 getrandom = { version = "0.2", features = ["js"] } # Required for prio
 prio = "0.8.0"
 hpke = { version = "0.8.0", features = ["std", "serde_impls"] }

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -22,7 +22,7 @@ test_janus = []
 daphne_worker = { path = "../daphne_worker" }
 cfg-if = "0.1.2"
 worker = "0.0.10"
-serde_json = "1.0.67"
+serde_json = "1.0.82"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -41,9 +41,9 @@ daphne = { path = "../daphne" }
 hex = { version = "0.4.3", features = ["serde"] }
 lazy_static = "1.4.0"
 futures = "0.3.21"
-janus = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
-janus_server = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
-janus_test_util = { git = "https://github.com/divviup/janus", rev = "6bb0e992da50afc8a5eb602ad5ce559fe78cf2c4" }
+janus_core = { git = "https://github.com/divviup/janus", rev = "e5ed423cfc96051894de2997aa013b77b322e2b9", features = ["test-util"] }
+janus_client = { git = "https://github.com/divviup/janus", rev = "e5ed423cfc96051894de2997aa013b77b322e2b9"}
+janus_server = { git = "https://github.com/divviup/janus", rev = "e5ed423cfc96051894de2997aa013b77b322e2b9", features = ["test-util"] }
 prio = "0.8.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.7", features = ["json"] }


### PR DESCRIPTION
Based on #44 (merge that first).
Closes #8.

Updates Janus interop tests and confirms interop for draft-ietf-ppm-dap-01 (at least Janus Client -> Daphne Leader and Daphne Leader -> Janus helper).