### PR TITLE
Implement `put_report` and test `http_post_upload`

### DIFF
--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -204,6 +204,7 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
             return Err(DapAbort::UnrecognizedHpkeConfig);
         }
 
+        // NOTE spec: Currently it is up to the backend to reject or accept a report.
         Ok(self.put_report(&report).await?)
     }
 


### PR DESCRIPTION
This implements the `put_report` method called within `http_post_upload`.
`http_post_upload` is used by the Leader to handle http post requests from Clients.

The changes include unit tests that check for malformed reports as well as a test that successfully receives a report.

Ref: #20.