### PR TITLE
Remove ignored profile stanza

### DIFF
--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -30,10 +30,6 @@ serde_json = "1.0.82"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.1", optional = true }
 
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
-
 [dev-dependencies]
 assert_matches = "1.5.0"
 base64 = "0.13.0"


### PR DESCRIPTION
I see the following warning when building:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /tmp/dap_test/daphne_worker_test/Cargo.toml
workspace: /tmp/dap_test/Cargo.toml
```

This same setting is already present in the workspace root `Cargo.toml`, so we can just remove the stanza under `daphne_worker_test/`.