### PR TITLE
Implement `get_agg_share()` and test `http_post_aggregate_share()`

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -366,7 +366,7 @@ pub struct DapOutputShare {
 }
 
 /// An aggregate share computed by combining a set of output shares.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DapAggregateShare {
     pub(crate) report_count: u64,
     pub(crate) checksum: [u8; 32],

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -55,7 +55,7 @@ pub(crate) enum VdafMessage {
     Prio3ShareField128(Prio3PrepareShare<Field128, 16>),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) enum VdafAggregateShare {
     Field64(prio::vdaf::AggregateShare<Field64>),
     Field128(prio::vdaf::AggregateShare<Field128>),


### PR DESCRIPTION
This PR implements necessary methods to test the aggregate share request/response procedure between leader/helper.

It also add a unit test that tests when a leader obtains an empty aggregate share.
The e2e unit test add the procedure where the Leader picks a collect job, produces its encrypted aggregate share, and lastly prepares an AggregateShareReq and sends it to the Helper to obtain the helper's encrypted aggregate share.

This partially implements #20, in particular the beginning of the Collection phase.