### PR TITLE
Move `task_id` out of `DapLeader::get_reports()`

### DIFF
--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -174,6 +174,7 @@ async fn e2e_internal_leader_process() {
     let hpke_config_list = t.get_hpke_configs(&client).await;
 
     let agg_info = InternalAggregateInfo {
+        task_id: t.task_id.clone(),
         batch_info: t.batch_info(),
         agg_rate: t.min_batch_size,
     };
@@ -225,6 +226,7 @@ async fn e2e_internal_leader_process_current_batch_window() {
     let hpke_config_list = t.get_hpke_configs(&client).await;
 
     let agg_info = InternalAggregateInfo {
+        task_id: t.task_id.clone(),
         batch_info: None,
         agg_rate: 1,
     };
@@ -296,6 +298,7 @@ async fn e2e_leader_collect_ok() {
         .internal_process(
             &client,
             &InternalAggregateInfo {
+                task_id: t.task_id.clone(),
                 batch_info: batch_info.clone(),
                 agg_rate: 100,
             },
@@ -388,6 +391,7 @@ async fn e2e_leader_collect_not_ready_min_batch_size() {
         .internal_process(
             &client,
             &InternalAggregateInfo {
+                task_id: t.task_id.clone(),
                 batch_info,
                 agg_rate: 100,
             },

--- a/daphne_worker_test/tests/janus.rs
+++ b/daphne_worker_test/tests/janus.rs
@@ -60,6 +60,7 @@ async fn janus_client() {
     janus_client.upload(&23).await.unwrap();
 
     let agg_info = InternalAggregateInfo {
+        task_id: t.task_id.clone(),
         batch_info: t.batch_info(),
         agg_rate: 1,
     };
@@ -79,6 +80,7 @@ async fn janus_helper() {
     let client = t.http_client();
     let hpke_config_list = t.get_hpke_configs(&client).await;
     let agg_info = InternalAggregateInfo {
+        task_id: t.task_id.clone(),
         batch_info: t.batch_info(),
         agg_rate: t.min_batch_size,
     };

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -330,14 +330,7 @@ impl TestRunner {
         client: &reqwest::Client,
         agg_info: &InternalAggregateInfo,
     ) -> DapLeaderProcessTelemetry {
-        let url = self
-            .leader_url
-            .join(&format!(
-                "/internal/process/task/{}",
-                self.task_id.to_base64url()
-            ))
-            .unwrap();
-
+        let url = self.leader_url.join("/internal/process").unwrap();
         let resp = client
             .post(url.as_str())
             .body(serde_json::to_string(&agg_info).unwrap())


### PR DESCRIPTION
Partially addresses #25.

Moves `task_id` out of the function parameters. Existing implementors of
`DapLeader` can put this field intp the report selector. This allows for
deployments in which work is scheduled not per task but for the entire
deployment. In particular, this unblocks progress on scaling up
Daphne-Worker.