### PR TITLE
daphne_worker: Process reports in order of arrival

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -9,7 +9,8 @@ use crate::{
     dap,
     durable::{
         aggregate_store::{durable_agg_store_name, DURABLE_AGGREGATE_STORE_DELETE_ALL},
-        leader_state_store::{durable_leader_state_name, DURABLE_LEADER_STATE_DELETE_ALL},
+        durable_queue_name,
+        leader_state_store::DURABLE_LEADER_STATE_DELETE_ALL,
         report_store::{durable_report_store_name, DURABLE_REPORT_STORE_DELETE_ALL},
     },
     int_err, now,
@@ -307,13 +308,9 @@ impl<D> DaphneWorkerConfig<D> {
 
         // Clear the leader's state.
         let namespace = self.durable_object("DAP_LEADER_STATE_STORE")?;
-        for task_id in self.tasks.keys() {
-            let stub = namespace
-                .id_from_name(&durable_leader_state_name(task_id))?
-                .get_stub()?;
-            // TODO Don't block on DO requests (issue multiple requests simultaneously).
-            durable_post!(stub, DURABLE_LEADER_STATE_DELETE_ALL, &()).await?;
-        }
+        let stub = namespace.id_from_name(&durable_queue_name(0))?.get_stub()?;
+        // TODO Don't block on DO requests (issue multiple requests simultaneously).
+        durable_post!(stub, DURABLE_LEADER_STATE_DELETE_ALL, &()).await?;
 
         Ok(())
     }

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::int_err;
+use serde::{Deserialize, Serialize};
+use worker::*;
+
+pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_DELETE_ALL: &str =
+    "/internal/do/agg_job_queue/delete_all";
+pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_PUT_PENDING: &str =
+    "/internal/do/agg_job_queue/put_pending";
+pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_GET_PENDING: &str =
+    "/internal/do/agg_job_queue/get_pending";
+pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_FINISH: &str = "/internal/do/agg_job_queue/finish";
+
+/// An aggregation job.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct AggregationJob {
+    /// Durable object ID of the [`ReportStore`](crate::durable::ReportStore) instance with reports
+    /// to be aggregated.
+    pub(crate) report_store_id_hex: String,
+
+    /// The time at which the aggregation job was scheduled. Aggregation jobs are processed in
+    /// order of arrival. [`ReportStore`](crate::durable::ReportStore) sets this to the time the
+    /// first report arrived in the bucket.
+    pub(crate) time: u64,
+
+    /// A random value used to break ties between jobs with the same time stamp.
+    pub(crate) rand: u64,
+}
+
+/// Durable Object (DO) representing an aggregation job queue.
+///
+/// An instance of the [`LeaderAggregationJobQueue`] DO is named `/queue/<queue_num>` where
+/// `<queue_num>` is an integer idnentifying a specific queue.
+#[durable_object]
+pub struct LeaderAggregationJobQueue {
+    #[allow(dead_code)]
+    state: State,
+}
+
+#[durable_object]
+impl DurableObject for LeaderAggregationJobQueue {
+    fn new(state: State, _env: Env) -> Self {
+        Self { state }
+    }
+
+    async fn fetch(&mut self, mut req: Request) -> Result<Response> {
+        match (req.path().as_ref(), req.method()) {
+            (DURABLE_LEADER_AGG_JOB_QUEUE_DELETE_ALL, Method::Post) => {
+                self.state.storage().delete_all().await?;
+                Response::empty()
+            }
+
+            (DURABLE_LEADER_AGG_JOB_QUEUE_PUT_PENDING, Method::Post) => {
+                let agg_job: AggregationJob = req.json().await?;
+                self.state
+                    .storage()
+                    .put(&bucket_key_for(&agg_job), agg_job.report_store_id_hex)
+                    .await?;
+                Response::empty()
+            }
+
+            (DURABLE_LEADER_AGG_JOB_QUEUE_GET_PENDING, Method::Post) => {
+                let num_buckets: usize = req.json().await?;
+                let opt = ListOptions::new().prefix("bucket/").limit(num_buckets);
+                let iter = self.state.storage().list_with_options(opt).await?.entries();
+                let mut item = iter.next()?;
+                let mut res = Vec::new();
+                while !item.done() {
+                    let (_bucket_key, report_store_id_hex): (String, String) =
+                        item.value().into_serde()?;
+                    res.push(report_store_id_hex);
+                    item = iter.next()?;
+                }
+
+                // Results are in order of the oldest bucket first.
+                Response::from_json(&res)
+            }
+
+            (DURABLE_LEADER_AGG_JOB_QUEUE_FINISH, Method::Post) => {
+                let agg_job: AggregationJob = req.json().await?;
+                self.state
+                    .storage()
+                    .delete(&bucket_key_for(&agg_job))
+                    .await?;
+                Response::empty()
+            }
+
+            _ => Err(int_err(format!(
+                "LeaderAggregationJobQueue: unexpected request: method={:?}; path={:?}",
+                req.method(),
+                req.path()
+            ))),
+        }
+    }
+}
+
+fn bucket_key_for(agg_job: &AggregationJob) -> String {
+    // Format the bucket so that they are processed in order of arrival (oldest first). The
+    // timestamp is used for this purpose; the randomm value is used for breaking ties.
+    format!("bucket/time/{:020}/rand/{:020}", agg_job.time, agg_job.rand)
+}

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -32,8 +32,13 @@ pub(crate) async fn state_get<T: for<'a> Deserialize<'a>>(
     })
 }
 
+pub(crate) fn durable_queue_name(queue_num: usize) -> String {
+    format!("/queue/{}", queue_num)
+}
+
 pub(crate) mod aggregate_store;
 pub(crate) mod helper_state_store;
+pub(crate) mod leader_agg_job_queue;
 pub(crate) mod leader_state_store;
 pub(crate) mod report_store;
 #[cfg(test)]

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -25,6 +25,7 @@ bindings = [
   { name = "DAP_REPORT_STORE", class_name = "ReportStore" },
   { name = "DAP_AGGREGATE_STORE", class_name = "AggregateStore" },
   { name = "DAP_LEADER_STATE_STORE", class_name = "LeaderStateStore" },
+  { name = "DAP_LEADER_AGG_JOB_QUEUE", class_name = "LeaderAggregationJobQueue" },
   { name = "DAP_HELPER_STATE_STORE", class_name = "HelperStateStore" },
 ]
 


### PR DESCRIPTION
Based on #58 (merge that first).
Partially addresses #25.

Change report selector for `DaphneWorkerConfig` so that instead of
scheduling work per task and batch interval, reports are processed in
order of arrival.

A new DO is implemented, `LeaderAggregationJobQueue`, which maintaines
a queue of `ReportStore` instances. Once a report arrrives to an empty
`ReportStore` instance, an "aggregation job" is added to the queue; once
the instance becomes empty, the job is removed from the queue. Jobs are
ordered by the first report's time of arrival so that the oldest data is
processed first.

Other changes:

* daphne: Remove `task_id` from `DapLeader::get_pending_collect_jobs()`
  so that scheduling work on collect jobs doesn't have to depend on a
  particular task.

* Remove a TODO that was addressed by a previous change.