### PR TITLE
Implement LeaderState and Collect job related methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "getrandom",
  "hex",
  "hpke 0.8.0",
+ "matchit 0.6.0",
  "prio",
  "rand",
  "reqwest",
@@ -1427,6 +1428,12 @@ name = "matchit"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
+
+[[package]]
+name = "matchit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
 
 [[package]]
 name = "md-5"
@@ -3318,7 +3325,7 @@ dependencies = [
  "futures-util",
  "http",
  "js-sys",
- "matchit",
+ "matchit 0.4.6",
  "pin-project",
  "serde",
  "serde_json",

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -37,4 +37,5 @@ reqwest = { version = "0.11.11", features = ["blocking"] } # Required for daph C
 anyhow = "1.0.58" # Required for daph CLI
 
 [dev-dependencies]
+matchit = "0.6.0"
 tokio = { version = "^1.19", features = ["macros","rt"] }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -517,7 +517,7 @@ pub struct DapResponse {
 }
 
 /// Status of a collect job.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DapCollectJob {
     Done(CollectResp),

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -397,7 +397,7 @@ impl Decode for Interval {
 /// A collect request.
 //
 // TODO Add serialization tests.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CollectReq {
     pub task_id: Id,
     pub batch_interval: Interval,
@@ -425,7 +425,7 @@ impl Decode for CollectReq {
 /// A collect response.
 //
 // TODO Add serialization tests.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CollectResp {
     pub encrypted_agg_shares: Vec<HpkeCiphertext>,
 }

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -359,12 +359,12 @@ impl<D> DapLeader<BearerToken> for DaphneWorkerConfig<D> {
     async fn get_pending_collect_jobs(
         &self,
         task_id: &Id,
-    ) -> std::result::Result<Vec<(Id, CollectReq)>, DapError> {
+    ) -> std::result::Result<HashMap<Id, Vec<CollectReq>>, DapError> {
         let leader_state_namespace = self.durable_object("DAP_LEADER_STATE_STORE")?;
         let leader_state_stub = leader_state_namespace
             .id_from_name(&durable_leader_state_name(task_id))?
             .get_stub()?;
-        let res: Vec<(Id, CollectReq)> =
+        let res: HashMap<Id, Vec<CollectReq>> =
             durable_get!(leader_state_stub, DURABLE_LEADER_STATE_GET_COLLECT_REQS)
                 .await?
                 .json()


### PR DESCRIPTION
Implements final missing pieces of #20, in particular methods used by the Leader to handle collect jobs.

This PR implements LeaderState, which stores collect jobs it received from the Collector.
Collect job related methods, `init_collect_job`, `poll_collect_job`, `get_pending_collect_jobs`, and `finish_collect_job` are also implemented.

The full e2e test is also implemented, starting from the Client submitting a report, the Leader and Helper processing it, and finally the Leader processing the collect job received from the Collector.