### PR TITLE
Implement `CollectReq` boundary check

### DIFF
--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -19,13 +19,13 @@ use crate::{
         HPKE_RECEIVER_CONFIG_LIST, LEADER_BEARER_TOKEN,
     },
     DapAbort, DapCollectJob, DapError, DapLeaderTransition, DapMeasurement, DapRequest,
-    Prio3Config, VdafConfig,
+    DapTaskConfig, Prio3Config, VdafConfig,
 };
 use assert_matches::assert_matches;
 use matchit::Router;
 use prio::codec::{Decode, Encode};
 use rand::{thread_rng, Rng};
-use std::{ops::DerefMut, vec};
+use std::{ops::DerefMut, time::SystemTime, vec};
 
 // MockAggregator's implementation of DapLeader::get_report() always returns reports for a single
 // task. This macro is used to conveniently unwrap the task ID and reports for testing purposes.
@@ -144,16 +144,140 @@ impl MockAggregator {
 
         // Construct report.
         let vdaf_config: &VdafConfig = &VdafConfig::Prio3(Prio3Config::Count);
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         let report = vdaf_config
-            .produce_report(
-                &hpke_config_list,
-                1637361337,
-                task_id,
-                DapMeasurement::U64(1),
-            )
+            .produce_report(&hpke_config_list, now, task_id, DapMeasurement::U64(1))
             .unwrap();
 
         report
+    }
+
+    async fn run_test_agg_job(
+        &self,
+        helper: &MockAggregator,
+        now: u64,
+        task_id: &Id,
+        task_config: &DapTaskConfig,
+    ) {
+        // Leader: Store received report to ReportStore.
+        let selector = &MockAggregateInfo {
+            task_id: task_id.clone(),
+            batch_info: Some(task_config.current_batch_window(now)),
+            agg_rate: 1,
+        };
+        let (task_id, reports) = get_reports!(self, selector);
+
+        // Leader: Consume report share.
+        let mut rng = thread_rng();
+        let agg_job_id = Id(rng.gen());
+        let transition = task_config
+            .vdaf
+            .produce_agg_init_req(
+                self,
+                &task_config.vdaf_verify_key,
+                &task_id,
+                &agg_job_id,
+                reports,
+            )
+            .unwrap();
+        assert_matches!(transition, DapLeaderTransition::Continue(..));
+        let (leader_state, agg_init_req) = transition.unwrap_continue();
+
+        // Leader: Send aggregate initialization request to Helper and receive response.
+        let req = DapRequest {
+            media_type: Some(MEDIA_TYPE_AGG_INIT_REQ),
+            payload: agg_init_req.get_encoded(),
+            url: task_config.helper_url.join("/aggregate").unwrap(),
+            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
+        };
+        let res = helper.http_post_aggregate(&req).await.unwrap();
+        let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
+
+        // Leader: Produce Leader output share and prepare aggregate continue request for Helper.
+        let transition = task_config
+            .vdaf
+            .handle_agg_resp(&task_id, &agg_job_id, leader_state, agg_resp)
+            .unwrap();
+        assert_matches!(transition, DapLeaderTransition::Uncommitted(..));
+        let (leader_uncommitted, agg_cont_req) = transition.unwrap_uncommitted();
+
+        // Leader: Send aggregate continue request to Helper and receive response.
+        let req = DapRequest {
+            media_type: Some(MEDIA_TYPE_AGG_CONT_REQ),
+            payload: agg_cont_req.get_encoded(),
+            url: task_config.helper_url.join("/aggregate").unwrap(),
+            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
+        };
+        let res = helper.http_post_aggregate(&req).await.unwrap();
+        let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
+
+        // Leader: Commit output shares of Leader and Helper.
+        let out_shares = task_config
+            .vdaf
+            .handle_final_agg_resp(leader_uncommitted, agg_resp)
+            .unwrap();
+        self.put_out_shares(&task_id, out_shares).await.unwrap();
+    }
+
+    async fn run_test_col_job(
+        &self,
+        task_id: &Id,
+        collect_id: &Id,
+        collect_req: &CollectReq,
+        task_config: &DapTaskConfig,
+    ) {
+        // Leader: Get Leader's encrypted aggregate share.
+        let leader_agg_share = self
+            .get_agg_share(&collect_req.task_id, &collect_req.batch_interval)
+            .await
+            .unwrap();
+
+        let leader_enc_agg_share = task_config
+            .vdaf
+            .produce_leader_encrypted_agg_share(
+                &task_config.collector_hpke_config,
+                &collect_req.task_id,
+                &collect_req.batch_interval,
+                &leader_agg_share,
+            )
+            .unwrap();
+
+        // Leader: Prepare AggregateShareReq.
+        let agg_share_req = AggregateShareReq {
+            task_id: collect_req.task_id.clone(),
+            batch_interval: collect_req.batch_interval.clone(),
+            agg_param: collect_req.agg_param.clone(),
+            report_count: leader_agg_share.report_count,
+            checksum: leader_agg_share.checksum,
+        };
+
+        // Leader: Send AggregateShareReq to Helper and receive AggregateShareResp.
+        let req = DapRequest {
+            media_type: Some(MEDIA_TYPE_AGG_SHARE_REQ),
+            payload: agg_share_req.get_encoded(),
+            url: task_config.helper_url.join("/aggregate_share").unwrap(),
+            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
+        };
+        let res = self.http_post_aggregate_share(&req).await.unwrap();
+        let agg_share_resp = AggregateShareResp::get_decoded(&res.payload).unwrap();
+        let helper_enc_agg_share = agg_share_resp.encrypted_agg_share;
+
+        // Leader: Complete the collect job by storing CollectResp in LeaderStore.processed.
+        let collect_resp = CollectResp {
+            encrypted_agg_shares: vec![leader_enc_agg_share, helper_enc_agg_share],
+        };
+
+        self.finish_collect_job(task_id, collect_id, &collect_resp)
+            .await
+            .unwrap();
+
+        // Leader: Mark the reports as collected.
+        self.mark_collected(task_id, &agg_share_req.batch_interval)
+            .await
+            .unwrap();
     }
 }
 
@@ -237,9 +361,13 @@ async fn http_post_collect_unauthorized_request() {
 #[tokio::test]
 async fn http_post_aggregate_failure_hpke_decrypt_error() {
     let helper = MockAggregator::new();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
     let report_shares = vec![ReportShare {
         nonce: Nonce {
-            time: 1637361337,
+            time: now,
             rand: [1; 16],
         },
         extensions: Vec::default(),
@@ -477,7 +605,7 @@ async fn get_reports_empty_response() {
         .expect("upload failed unexpectedly");
 
     // Get report.
-    let now = report.nonce.time - 200000000;
+    let now = report.nonce.time - task_config.min_batch_duration - 1;
     let selector = &MockAggregateInfo {
         task_id: task_id.clone(),
         batch_info: Some(task_config.current_batch_window(now)),
@@ -489,7 +617,7 @@ async fn get_reports_empty_response() {
     assert_eq!(reports.len(), 0);
 
     // Attempt to get reports from the future.
-    let now = report.nonce.time + 200000000;
+    let now = report.nonce.time + task_config.min_batch_duration + 1;
     let selector = &MockAggregateInfo {
         task_id: task_id.clone(),
         batch_info: Some(task_config.current_batch_window(now)),
@@ -506,7 +634,10 @@ async fn poll_collect_job_test_results() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
     let task_config = leader.get_task_config_for(task_id).unwrap();
-    let now = 1637361337;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
 
     // Collector: Create a CollectReq.
     let collector_collect_req = CollectReq {
@@ -559,16 +690,157 @@ async fn poll_collect_job_test_results() {
     );
 }
 
+#[tokio::test]
+async fn http_post_collect_fail_invalid_batch_interval() {
+    let leader = MockAggregator::new();
+    let task_id = leader.nominal_task_id();
+    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    // Collector: Create a CollectReq with a very large batch interval.
+    let collector_collect_req = CollectReq {
+        task_id: task_id.clone(),
+        batch_interval: Interval {
+            start: now - (now % task_config.min_batch_duration),
+            duration: task_config.min_batch_duration
+                * (leader.global_config.max_batch_duration + 1),
+        },
+        agg_param: Vec::default(),
+    };
+    let req = DapRequest {
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: collector_collect_req.get_encoded(),
+        url: task_config.helper_url.join("/collect").unwrap(),
+        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
+    };
+
+    // Leader: Handle the CollectReq received from Collector.
+    let err = leader.http_post_collect(&req).await.unwrap_err();
+
+    // Fails because the requested batch interval is too large.
+    assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too large".to_string()));
+
+    // Collector: Create a CollectReq with a batch interval in the past.
+    let collector_collect_req = CollectReq {
+        task_id: task_id.clone(),
+        batch_interval: task_config
+            .current_batch_window(now - leader.global_config.min_batch_interval_start),
+        agg_param: Vec::default(),
+    };
+    let req = DapRequest {
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: collector_collect_req.get_encoded(),
+        url: task_config.helper_url.join("/collect").unwrap(),
+        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
+    };
+
+    // Leader: Handle the CollectReq received from Collector.
+    let err = leader.http_post_collect(&req).await.unwrap_err();
+
+    // Fails because the requested batch interval is too far into the past.
+    assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too far into past".to_string()));
+
+    // Collector: Create a CollectReq with a batch interval in the future.
+    let collector_collect_req = CollectReq {
+        task_id: task_id.clone(),
+        batch_interval: task_config
+            .current_batch_window(now + leader.global_config.max_batch_interval_end),
+        agg_param: Vec::default(),
+    };
+    let req = DapRequest {
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: collector_collect_req.get_encoded(),
+        url: task_config.helper_url.join("/collect").unwrap(),
+        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
+    };
+
+    // Leader: Handle the CollectReq received from Collector.
+    let err = leader.http_post_collect(&req).await.unwrap_err();
+
+    // Fails because the requested batch interval is too far into the future.
+    assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too far into future".to_string()));
+}
+
+// Send a collect request with an overlapping batch interval.
+#[tokio::test]
+async fn http_post_collect_fail_overlapping_batch_interval() {
+    let leader = MockAggregator::new();
+    let task_id = leader.nominal_task_id();
+    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let helper = MockAggregator::new();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    // Create a report.
+    let report = leader.gen_test_report(task_id);
+    let req = leader.gen_test_upload_req(report.clone());
+
+    // Client: Send upload request to Leader.
+    leader.http_post_upload(&req).await.unwrap();
+
+    // Leader: Run aggregation job.
+    leader
+        .run_test_agg_job(&helper, now, task_id, task_config)
+        .await;
+
+    // Collector: Create first CollectReq.
+    let collector_collect_req = CollectReq {
+        task_id: task_id.clone(),
+        batch_interval: task_config.current_batch_window(now),
+        agg_param: Vec::default(),
+    };
+    let req = DapRequest {
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: collector_collect_req.get_encoded(),
+        url: task_config.helper_url.join("/collect").unwrap(),
+        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
+    };
+
+    // Leader: Handle the CollectReq received from Collector.
+    let _url = leader.http_post_collect(&req).await.unwrap();
+    let resp = leader.get_pending_collect_jobs().await.unwrap();
+    let (collect_id, collect_req) = &resp[0];
+
+    // Leader: Run collect job.
+    leader
+        .run_test_col_job(task_id, collect_id, collect_req, task_config)
+        .await;
+
+    // Collector: Create second CollectReq.
+    let collector_collect_req = CollectReq {
+        task_id: task_id.clone(),
+        batch_interval: task_config.current_batch_window(now),
+        agg_param: Vec::default(),
+    };
+    let req = DapRequest {
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: collector_collect_req.get_encoded(),
+        url: task_config.helper_url.join("/collect").unwrap(),
+        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
+    };
+
+    // Leader: Handle the CollectReq received from Collector.
+    // Fails due to batch interval overlapping.
+    let err = leader.http_post_collect(&req).await.unwrap_err();
+    assert_matches!(err, DapAbort::BatchOverlap);
+}
+
 // Test a successful collect request submission.
 // This checks that the Leader reponds with the collect ID with the ID associated to the request.
-//
-// TODO(nakatsuka-y) Implement a test case when a Leader rejects a collect request.
 #[tokio::test]
 async fn http_post_collect_success() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
     let task_config = leader.get_task_config_for(task_id).unwrap();
-    let now = 1637361337;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
 
     // Collector: Create a CollectReq.
     let collector_collect_req = CollectReq {
@@ -628,6 +900,10 @@ async fn e2e() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
     let task_config = leader.get_task_config_for(task_id).unwrap();
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
 
     let helper = MockAggregator::new();
 
@@ -637,66 +913,10 @@ async fn e2e() {
     // Client: Send upload request to Leader.
     leader.http_post_upload(&req).await.unwrap();
 
-    // Leader: Store received report to ReportStore.
-    let now = 1637361337;
-    let selector = &MockAggregateInfo {
-        task_id: task_id.clone(),
-        batch_info: Some(task_config.current_batch_window(now)),
-        agg_rate: 1,
-    };
-    let (task_id, reports) = get_reports!(leader, selector);
-    assert_eq!(report, reports[0]);
-
-    // Leader: Consume report share.
-    let mut rng = thread_rng();
-    let agg_job_id = Id(rng.gen());
-    let transition = task_config
-        .vdaf
-        .produce_agg_init_req(
-            &leader,
-            &task_config.vdaf_verify_key,
-            &task_id,
-            &agg_job_id,
-            reports,
-        )
-        .unwrap();
-    assert_matches!(transition, DapLeaderTransition::Continue(..));
-    let (leader_state, agg_init_req) = transition.unwrap_continue();
-
-    // Leader: Send aggregate initialization request to Helper and receive response.
-    let req = DapRequest {
-        media_type: Some(MEDIA_TYPE_AGG_INIT_REQ),
-        payload: agg_init_req.get_encoded(),
-        url: task_config.helper_url.join("/aggregate").unwrap(),
-        sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-    };
-    let res = helper.http_post_aggregate(&req).await.unwrap();
-    let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
-
-    // Leader: Produce Leader output share and prepare aggregate continue request for Helper.
-    let transition = task_config
-        .vdaf
-        .handle_agg_resp(&task_id, &agg_job_id, leader_state, agg_resp)
-        .unwrap();
-    assert_matches!(transition, DapLeaderTransition::Uncommitted(..));
-    let (leader_uncommitted, agg_cont_req) = transition.unwrap_uncommitted();
-
-    // Leader: Send aggregate continue request to Helper and receive response.
-    let req = DapRequest {
-        media_type: Some(MEDIA_TYPE_AGG_CONT_REQ),
-        payload: agg_cont_req.get_encoded(),
-        url: task_config.helper_url.join("/aggregate").unwrap(),
-        sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-    };
-    let res = helper.http_post_aggregate(&req).await.unwrap();
-    let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
-
-    // Leader: Commit output shares of Leader and Helper.
-    let out_shares = task_config
-        .vdaf
-        .handle_final_agg_resp(leader_uncommitted, agg_resp)
-        .unwrap();
-    leader.put_out_shares(&task_id, out_shares).await.unwrap();
+    // Leader: Run aggregation job.
+    leader
+        .run_test_agg_job(&helper, now, task_id, task_config)
+        .await;
 
     // Collector: Create a CollectReq.
     let collect_req = CollectReq {
@@ -716,57 +936,10 @@ async fn e2e() {
     let resp = leader.get_pending_collect_jobs().await.unwrap();
     let (collect_id, collect_req) = &resp[0];
 
-    // Leader: Get Leader's encrypted aggregate share.
-    let leader_agg_share = leader
-        .get_agg_share(&collect_req.task_id, &collect_req.batch_interval)
-        .await
-        .unwrap();
-
-    let leader_enc_agg_share = task_config
-        .vdaf
-        .produce_leader_encrypted_agg_share(
-            &task_config.collector_hpke_config,
-            &collect_req.task_id,
-            &collect_req.batch_interval,
-            &leader_agg_share,
-        )
-        .unwrap();
-
-    // Leader: Prepare AggregateShareReq.
-    let agg_share_req = AggregateShareReq {
-        task_id: collect_req.task_id.clone(),
-        batch_interval: collect_req.batch_interval.clone(),
-        agg_param: collect_req.agg_param.clone(),
-        report_count: leader_agg_share.report_count,
-        checksum: leader_agg_share.checksum,
-    };
-
-    // Leader: Send AggregateShareReq to Helper and receive AggregateShareResp.
-    let req = DapRequest {
-        media_type: Some(MEDIA_TYPE_AGG_SHARE_REQ),
-        payload: agg_share_req.get_encoded(),
-        url: task_config.helper_url.join("/aggregate_share").unwrap(),
-        sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-    };
-    let res = leader.http_post_aggregate_share(&req).await.unwrap();
-    let agg_share_resp = AggregateShareResp::get_decoded(&res.payload).unwrap();
-    let helper_enc_agg_share = agg_share_resp.encrypted_agg_share;
-
-    // Leader: Complete the collect job by storing CollectResp in LeaderStore.processed.
-    let collect_resp = CollectResp {
-        encrypted_agg_shares: vec![leader_enc_agg_share, helper_enc_agg_share],
-    };
-
+    // Leader: Run collect job.
     leader
-        .finish_collect_job(&task_id, &collect_id, &collect_resp)
-        .await
-        .unwrap();
-
-    // Leader: Mark the reports as collected.
-    leader
-        .mark_collected(&task_id, &agg_share_req.batch_interval)
-        .await
-        .unwrap();
+        .run_test_col_job(task_id, collect_id, collect_req, task_config)
+        .await;
 
     // Leader: Respond to poll request from Collector.
     let collect_job = leader

--- a/daphne_worker/src/config_test.rs
+++ b/daphne_worker/src/config_test.rs
@@ -4,6 +4,12 @@
 use crate::config::DaphneWorkerConfig;
 use daphne::messages::{Interval, Nonce};
 
+pub const GLOBAL_CONFIG: &str = r#"{
+    "max_batch_duration": 100,
+    "min_batch_interval_start": 432000,
+    "max_batch_interval_end": 18000
+}"#;
+
 const DAP_TASK_LIST: &str = r#"{
   "f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f": {
     "leader_url": "https://leader.biz/leadver/v1/",
@@ -58,6 +64,7 @@ fn daphne_param() {
     let now = 1637364244;
     let bucket_count = 5;
     let config: DaphneWorkerConfig<String> = DaphneWorkerConfig::from_test_config(
+        GLOBAL_CONFIG,
         DAP_TASK_LIST,
         DAP_HPKE_RECEIVER_CONFIG_LIST,
         DAP_BUCKET_KEY,

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -16,6 +16,9 @@ DAP_BUCKET_KEY = 'f79c352056982bae1737e34bdac24d63'
 # Number of buckets.
 DAP_BUCKET_COUNT = 2
 
+# Global configurations.
+GLOBAL_CONFIG = '{"max_batch_duration": 100,"min_batch_interval_start": 432000,"max_batch_interval_end": 18000}'
+
 # A list of task IDs and their corresponding configurations. Each configuration
 # includes the VDAF algorithm and secret the verification parameter.
 DAP_TASK_LIST = '{"f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f":{"leader_url":"http://leader:8787","helper_url":"http://helper:8788","collector_hpke_config":{"id":23,"kem_id":"X25519HkdfSha256","kdf_id":"HkdfSha256","aead_id":"Aes128Gcm","public_key":"ec6427a49c8e9245307cc757dbdcf5d287c7a74075141af9fa566c293a52ee7c"},"min_batch_duration":3600,"min_batch_size":10,"vdaf":{"prio3":{"sum":{"bits":10}}},"vdaf_verify_key":"1fd8d30dc0e0b7ac81f0050fcab0782d"}}'

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -16,6 +16,9 @@ DAP_BUCKET_KEY = '61cd9685547370cfea76c2eb8d156ad9'
 # Number of buckets.
 DAP_BUCKET_COUNT = 2
 
+# Global configurations.
+GLOBAL_CONFIG = '{"max_batch_duration": 100,"min_batch_interval_start": 432000,"max_batch_interval_end": 18000}'
+
 # Key used to derive collect job IDs.
 DAP_COLLECT_ID_KEY = "b416a85d280591d6da14e5b75a7d6e31"
 


### PR DESCRIPTION
This PR implements a mechanism to handle `CollectReq` properly (#45).

A malicious Collector may request aggregation results over overlapping intervals.
This will  allow the malicious Collector to obtain aggregation results that are in batches smaller than `min_batch_interval`.

The Leader holds a binary tree for each Collector (distinguished via bearer token) per task.
The nodes in the binary tree hold the Interval requested by the Collector for this task in the past.
When the Leader receives a CollectReq from a Collector, it searches the binary tree for an overlapping node and if so, will reject the request.
If the new CollectReq does not overlap with the past intervals, then the Leader stores the new Interval into the tree and proceed to store the collect Id and request.

Unit test cases for the binary tree is written.
Another test case where the Collector tries to send a collect request with an overlapping interval is also implemented.