### PR TITLE
daphne_worker: Dequeue pending collect jobs properly

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -64,7 +64,7 @@ impl<D> DaphneWorkerConfig<D> {
         // aggregator URL with 127.0.0.1.
         if let Ok(env) = ctx.var("DAP_ENV") {
             if env.as_ref() == "dev" {
-                console_log!("DAP_ENV: Hostname override applied");
+                console_debug!("DAP_ENV: Hostname override applied");
                 for (_, task_config) in tasks.iter_mut() {
                     task_config.leader_url.set_host(Some("127.0.0.1")).unwrap();
                     task_config.helper_url.set_host(Some("127.0.0.1")).unwrap();

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -296,6 +296,13 @@ impl<D> DapLeader<BearerToken> for DaphneWorkerConfig<D> {
             }
         }
 
+        for (task_id, reports) in reports_per_task.iter() {
+            console_debug!(
+                "got {} reports for task {}",
+                reports.len(),
+                task_id.to_base64url()
+            );
+        }
         Ok(reports_per_task)
     }
 

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -10,7 +10,7 @@ pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_GET: &str = "/internal/do/agg_job_
 pub(crate) const DURABLE_LEADER_AGG_JOB_QUEUE_FINISH: &str = "/internal/do/agg_job_queue/finish";
 
 /// An aggregation job.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct AggregationJob {
     /// Durable object ID of the [`ReportStore`](crate::durable::ReportStore) instance with reports
     /// to be aggregated.
@@ -70,6 +70,7 @@ impl DurableObject for LeaderAggregationJobQueue {
                     item = iter.next()?;
                 }
 
+                console_debug!("agg job queue: {:?}", res);
                 // Results are in order of the oldest bucket first.
                 Response::from_json(&res)
             }

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -157,17 +157,14 @@ impl DurableObject for LeaderCollectionJobQueue {
                     ));
                 }
 
+                let mut storage = self.state.storage();
                 let pending_key = format!("pending/{}", collect_id_hex);
-                let pending: Option<OrderedCollectReq> =
-                    state_get(&self.state, &pending_key).await?;
-                if pending.is_none() {
-                    return Err(int_err("LeaderCollectionJobQueue: missing collect request"));
-                }
-
+                let delete_pending_future = storage.delete(&pending_key);
                 self.state
                     .storage()
                     .put(&processed_key, res.collect_resp)
                     .await?;
+                delete_pending_future.await?;
                 Response::empty()
             }
 

--- a/daphne_worker/src/durable/report_store.rs
+++ b/daphne_worker/src/durable/report_store.rs
@@ -127,6 +127,11 @@ impl DurableObject for ReportStore {
                     }
                 }
 
+                console_debug!(
+                    "drained {} reports from bucket {}",
+                    reports.len(),
+                    self.state.id().to_string()
+                );
                 Response::from_json(&reports)
             }
 
@@ -151,6 +156,10 @@ impl DurableObject for ReportStore {
                         rand: rng.gen(),
                     };
 
+                    console_debug!(
+                        "agg job for bucket {} has been scheduled",
+                        agg_job.report_store_id_hex
+                    );
                     let namespace = self.env.durable_object("DAP_LEADER_AGG_JOB_QUEUE")?;
                     // TODO Shard the work across multiple job queues rather than just one. (See
                     // issue #25.) For now there is jsut one job queue.

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -169,7 +169,10 @@ impl DaphneWorkerRouter {
                         let config = DaphneWorkerConfig::from_worker_context(ctx)?;
                         let agg_info: InternalAggregateInfo = req.json().await?;
                         match config.process(&agg_info).await {
-                            Ok(telem) => Response::from_json(&telem),
+                            Ok(telem) => {
+                                console_debug!("{:?}", telem);
+                                Response::from_json(&telem)
+                            }
                             Err(e) => abort(e),
                         }
                     })


### PR DESCRIPTION
After a collect job is completed, we fail to properly remove the collect
request from the job queue. This causes the /internal/process endpoint
to encounter an internal error.

POST /internal/process 500 Internal Server Error (146.19ms)
 ... [log line redacted] ...
DAP_ENV: Hostname override applied
internal error: LeaderCollectionJobQueue: tried to overwrite collect response
internal error: internalError: fatal error: worker: internalError
internalError

This change modifies the LeaderCollectJobQueue DO so that it removes the
job from the queue.

Note: This behavior was triggered by an interop test with Janus' Helper.