### PR TITLE
daphne_worker: Define deployment types

### DIFF
--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -76,11 +76,14 @@ impl DurableObject for LeaderCollectionJobQueue {
                 // stable map from requests to URIs, which prevents us from processing the same
                 // collect request more than once.
                 let collect_req_bytes = collect_req.get_encoded();
-                let collect_id_key = Seed::get_decoded(
-                    &hex::decode(self.env.secret("DAP_COLLECT_ID_KEY")?.to_string())
-                        .map_err(int_err)?,
-                )
-                .map_err(int_err)?;
+                let collect_id_key_hex = self
+                    .env
+                    .secret("DAP_COLLECT_ID_KEY")
+                    .map_err(|e| format!("failed to load DAP_COLLECT_ID_KEY: {}", e))?
+                    .to_string();
+                let collect_id_key =
+                    Seed::get_decoded(&hex::decode(&collect_id_key_hex).map_err(int_err)?)
+                        .map_err(int_err)?;
                 let mut collect_id_bytes = [0; 32];
                 PrgAes128::seed_stream(&collect_id_key, &collect_req_bytes)
                     .fill(&mut collect_id_bytes);

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -3,10 +3,7 @@
 
 //! Daphne-Worker implements a Workers backend for Daphne.
 
-use crate::{
-    config::DaphneWorkerConfig,
-    dap::{dap_response_to_worker, worker_request_to_dap},
-};
+use crate::{config::DaphneWorkerConfig, dap::dap_response_to_worker};
 use daphne::{
     constants,
     messages::{Id, Interval},
@@ -106,8 +103,8 @@ impl DaphneWorkerRouter {
     // TODO Document endpoints that aren't defined in the DAP spec
     pub async fn handle_request(&self, req: Request, env: Env) -> Result<Response> {
         let router = Router::new().get_async("/hpke_config", |req, ctx| async move {
-            let req = worker_request_to_dap(req).await?;
             let config = DaphneWorkerConfig::from_worker_context(ctx)?;
+            let req = config.worker_request_to_dap(req).await?;
             // TODO(cjpatton) Have this method return a DapResponse.
             match config.http_get_hpke_config(&req).await {
                 Ok(req) => dap_response_to_worker(req),
@@ -119,16 +116,16 @@ impl DaphneWorkerRouter {
             "leader" => {
                 router
                     .post_async("/upload", |req, ctx| async move {
-                        let req = worker_request_to_dap(req).await?;
                         let config = DaphneWorkerConfig::from_worker_context(ctx)?;
+                        let req = config.worker_request_to_dap(req).await?;
                         match config.http_post_upload(&req).await {
                             Ok(()) => Response::empty(),
                             Err(e) => abort(e),
                         }
                     })
                     .post_async("/collect", |req, ctx| async move {
-                        let req = worker_request_to_dap(req).await?;
                         let config = DaphneWorkerConfig::from_worker_context(ctx)?;
+                        let req = config.worker_request_to_dap(req).await?;
                         match config.http_post_collect(&req).await {
                             Ok(collect_uri) => {
                                 let mut headers = Headers::new();
@@ -180,16 +177,16 @@ impl DaphneWorkerRouter {
 
             "helper" => router
                 .post_async("/aggregate", |req, ctx| async move {
-                    let req = worker_request_to_dap(req).await?;
                     let config = DaphneWorkerConfig::from_worker_context(ctx)?;
+                    let req = config.worker_request_to_dap(req).await?;
                     match config.http_post_aggregate(&req).await {
                         Ok(resp) => dap_response_to_worker(resp),
                         Err(e) => abort(e),
                     }
                 })
                 .post_async("/aggregate_share", |req, ctx| async move {
-                    let req = worker_request_to_dap(req).await?;
                     let config = DaphneWorkerConfig::from_worker_context(ctx)?;
+                    let req = config.worker_request_to_dap(req).await?;
                     match config.http_post_aggregate_share(&req).await {
                         Ok(resp) => dap_response_to_worker(resp),
                         Err(e) => abort(e),

--- a/daphne_worker_test/README.md
+++ b/daphne_worker_test/README.md
@@ -23,19 +23,19 @@ Prerequisites:
 To run the Leader, run
 
 ```
-miniflare --port=8787 --env=leader.env --binding=DAP_ENV=dev
+miniflare --port=8787 --env=leader.env --binding=DAP_DEPLOYMENT=dev
 ```
 
 To run the Helper, in a separate terminal do
 
 ```
-miniflare --port=8788 --env=helper.env --binding=DAP_ENV=dev
+miniflare --port=8788 --env=helper.env --binding=DAP_DEPLOYMENT=dev
 ```
 
 You can now `curl` the Leader or the Helper, or run the end-to-end tests via
 
 ```
-DAP_ENV=dev cargo test --features=test_e2e -- --test-threads 1
+DAP_DEPLOYMENT=dev cargo test --features=test_e2e -- --test-threads 1
 ```
 
 The `daphne_worker` crate also has integration tests for
@@ -43,6 +43,5 @@ The `daphne_worker` crate also has integration tests for
 Docker environment is running and then do
 
 ```
-DAP_ENV=dev cargo test --features=test_janus -- --test-threads 1
+DAP_DEPLOYMENT=dev cargo test --features=test_janus -- --test-threads 1
 ```
-

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -181,11 +181,12 @@ impl TestRunner {
         // aggregator URL with 127.0.0.1.
         let mut leader_url = task_config.leader_url.clone();
         let mut helper_url = task_config.helper_url.clone();
-        if let Ok(env) = std::env::var("DAP_ENV") {
+        if let Ok(env) = std::env::var("DAP_DEPLOYMENT") {
             if env == "dev" {
-                println!("DAP_ENV: Hostname override applied");
                 leader_url.set_host(Some("127.0.0.1")).unwrap();
                 helper_url.set_host(Some("127.0.0.1")).unwrap();
+            } else {
+                panic!("unrecognized value for DAP_DEPLOYMENT: '{}'", env);
             }
         };
 


### PR DESCRIPTION
Replace the `DAP_ENV` environmnet variable with `DAP_DEPLOYMENT` that
allows Daphne-Worker to be run either in a development environment or in
production.

This change also includes some refactoring that will make it easier to
add service bindings as a deployment type later on.