### PR TITLE
daphne_worker: Improve garbage collection

### DIFF
--- a/daphne_worker/src/durable/garbage_collector.rs
+++ b/daphne_worker/src/durable/garbage_collector.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{durable, int_err, now};
+use rand::prelude::*;
+use worker::*;
+
+pub(crate) const DURABLE_GARBAGE_COLLECTOR_PUT: &str = "/internal/do/garbage_collector/put";
+
+/// Durable Object (DO) for keeping track of all persistent DO storage.
+#[durable_object]
+pub struct GarbageCollector {
+    #[allow(dead_code)]
+    state: State,
+    env: Env,
+}
+
+#[durable_object]
+impl DurableObject for GarbageCollector {
+    fn new(state: State, env: Env) -> Self {
+        Self { state, env }
+    }
+
+    async fn fetch(&mut self, mut req: Request) -> Result<Response> {
+        let mut rng = thread_rng();
+        match (req.path().as_ref(), req.method()) {
+            // Schedule a durable object (DO) instance for deletion.
+            (DURABLE_GARBAGE_COLLECTOR_PUT, Method::Post) => {
+                let durable_ref: durable::DurableReference = req.json().await?;
+                match durable_ref.binding.as_ref() {
+                    durable::BINDING_DAP_REPORT_STORE
+                    | durable::BINDING_DAP_AGGREGATE_STORE
+                    | durable::BINDING_DAP_LEADER_AGG_JOB_QUEUE
+                    | durable::BINDING_DAP_LEADER_COL_JOB_QUEUE
+                    | durable::BINDING_DAP_HELPER_STATE_STORE => (),
+                    s => {
+                        return Err(int_err(format!(
+                            "GarbageCollector: unrecognized binding: {}",
+                            s
+                        )))
+                    }
+                };
+
+                // Reference handle encodes the current time and a random nonce in order to deal
+                // with collisions. This time goes first in order to ensure we can delete the
+                // oldest objects first.
+                let mut rand = [0; 16];
+                rng.fill(&mut rand);
+                let durable_handle = format!(
+                    "object/{}/time/{:020}/rand/{}",
+                    durable_ref.binding,
+                    now(),
+                    hex::encode(rand)
+                );
+                self.state
+                    .storage()
+                    .put(&durable_handle, &durable_ref)
+                    .await?;
+                console_debug!(
+                    "GarbageCollector: scheduled {} instance {} for deletion",
+                    durable_ref.binding,
+                    durable_ref.id_hex
+                );
+                Response::empty()
+            }
+
+            // Delete all DO instances.
+            //
+            // NOTE This method is likely to hit memory and/or time limits when run in a production
+            // deployment. This method is not intended for production use. If deleting all memory
+            // for a deployment is needed, then the proper way is to do a Workers migration that
+            // deletes each of the DO classes.
+            //
+            //   TODO Add a method for deleting all instances scheduled before a given time. This
+            //   will allow us to prune storage we're not likely to need anymore, e.g., for
+            //   replay protection. However, for replay protection in particular, it'll be
+            //   important to make sure the Leader rejects reports with old timestamps.
+            (durable::DURABLE_DELETE_ALL, Method::Post) => {
+                let opt = ListOptions::new().prefix("object/");
+                let iter = self.state.storage().list_with_options(opt).await?.entries();
+                let mut item = iter.next()?;
+                while !item.done() {
+                    let (_durable_handle, durable_ref): (String, durable::DurableReference) =
+                        item.value().into_serde()?;
+                    let namespace = self.env.durable_object(&durable_ref.binding)?;
+                    let stub = namespace.id_from_string(&durable_ref.id_hex)?.get_stub()?;
+                    durable_post!(stub, durable::DURABLE_DELETE_ALL, &()).await?;
+                    console_debug!(
+                        "GarbageCollector: deleted {} instance {}",
+                        durable_ref.binding,
+                        durable_ref.id_hex
+                    );
+                    item = iter.next()?;
+                }
+
+                self.state.storage().delete_all().await?;
+                Response::empty()
+            }
+
+            _ => Err(int_err(format!(
+                "GarbageCollector: unexpected request: method={:?}; path={:?}",
+                req.method(),
+                req.path()
+            ))),
+        }
+    }
+}

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -1,12 +1,52 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use serde::Deserialize;
+use daphne::messages::Id;
+use serde::{Deserialize, Serialize};
 use worker::*;
 
 pub(crate) const DURABLE_DELETE_ALL: &str = "/internal/do/delete_all";
 
+pub(crate) const BINDING_DAP_REPORT_STORE: &str = "DAP_REPORT_STORE";
+pub(crate) const BINDING_DAP_AGGREGATE_STORE: &str = "DAP_AGGREGATE_STORE";
+pub(crate) const BINDING_DAP_LEADER_AGG_JOB_QUEUE: &str = "DAP_LEADER_AGG_JOB_QUEUE";
+pub(crate) const BINDING_DAP_LEADER_COL_JOB_QUEUE: &str = "DAP_LEADER_COL_JOB_QUEUE";
+pub(crate) const BINDING_DAP_HELPER_STATE_STORE: &str = "DAP_HELPER_STATE_STORE";
+pub(crate) const BINDING_DAP_GARBAGE_COLLECTOR: &str = "DAP_GARBAGE_COLLECTOR";
+
 const ERR_NO_VALUE: &str = "No such value in storage.";
+
+macro_rules! ensure_garbage_collected {
+    ($req:expr, $object:expr, $id:expr, $binding:expr) => {{
+        if $req.path() == crate::durable::DURABLE_DELETE_ALL && $req.method() == Method::Post {
+            $object.state.storage().delete_all().await?;
+            $object.touched = false;
+            return Response::empty();
+        } else if !$object.touched {
+            let touched: bool =
+                crate::durable::state_set_if_not_exists(&$object.state, "touched", &true)
+                    .await?
+                    .unwrap_or(false);
+            if !touched {
+                let namespace = $object
+                    .env
+                    .durable_object(crate::durable::BINDING_DAP_GARBAGE_COLLECTOR)?;
+                let stub = namespace.id_from_name("garbage_collector")?.get_stub()?;
+                durable_post!(
+                    stub,
+                    crate::durable::garbage_collector::DURABLE_GARBAGE_COLLECTOR_PUT,
+                    &crate::durable::DurableReference {
+                        binding: $binding.to_string(),
+                        id_hex: $id,
+                        task_id: None,
+                    }
+                )
+                .await?;
+                $object.touched = true;
+            }
+        }
+    }};
+}
 
 pub(crate) async fn state_get_or_default<T: Default + for<'a> Deserialize<'a>>(
     state: &State,
@@ -34,11 +74,42 @@ pub(crate) async fn state_get<T: for<'a> Deserialize<'a>>(
     })
 }
 
+/// Set a key/value pair unless the key already exists. If the key exists, then return the current
+/// value. Otherwise return nothing.
+pub(crate) async fn state_set_if_not_exists<T: for<'a> Deserialize<'a> + Serialize>(
+    state: &State,
+    key: &str,
+    val: &T,
+) -> Result<Option<T>> {
+    let curr_val: Option<T> = state_get(state, key).await?;
+    if curr_val.is_some() {
+        return Ok(curr_val);
+    }
+
+    state.storage().put(key, val).await?;
+    Ok(None)
+}
+
 pub(crate) fn durable_queue_name(queue_num: usize) -> String {
     format!("/queue/{}", queue_num)
 }
 
+/// Reference to a DO instance, used by the garbage collector.
+#[derive(Deserialize, Serialize)]
+pub(crate) struct DurableReference {
+    /// The DO binding, e.g., "DAP_REPORT_STORE".
+    pub(crate) binding: String,
+
+    /// Unique ID assigned to the DO instance by the Workers runtime.
+    pub(crate) id_hex: String,
+
+    /// If applicable, the DAP task ID to which the DO instance is associated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) task_id: Option<Id>,
+}
+
 pub(crate) mod aggregate_store;
+pub(crate) mod garbage_collector;
 pub(crate) mod helper_state_store;
 pub(crate) mod leader_agg_job_queue;
 pub(crate) mod leader_col_job_queue;

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -27,6 +27,7 @@ bindings = [
   { name = "DAP_LEADER_AGG_JOB_QUEUE", class_name = "LeaderAggregationJobQueue" },
   { name = "DAP_LEADER_COL_JOB_QUEUE", class_name = "LeaderCollectionJobQueue" },
   { name = "DAP_HELPER_STATE_STORE", class_name = "HelperStateStore" },
+  { name = "DAP_GARBAGE_COLLECTOR", class_name = "GarbageCollector" },
 ]
 
 


### PR DESCRIPTION
Adds a new durable object, `GarbageCollector`, that keeps track of every
DO instance that is created. When called, it invokes .delete_all() on
each DO instance scheduled for deletion. A DO instance schedules itself
for deletion by issuing a request to the garbage collector. This occurs
only once when the instance is first touched.

Replaces the `/internal/test/reset` endpoint with a new endpoint,
`/internal/delete_all`, that invokes the garbage collector. This allows
us to perform this task without needing to specify a range of buckets.
In particular, a batch interval and task ID are no longer needed.

This endpoint is only suitable for non-production deployments.
Eventually, we will schedule a cron job that periodically prunes the
oldest DO instances. In anticipation of this need, DO instances deleted
in the order in which they were touched.