### PR TITLE
daphne_worker: Use hex encoding of task ID for DO instance names

### DIFF
--- a/daphne_worker/src/config_test.rs
+++ b/daphne_worker/src/config_test.rs
@@ -81,7 +81,7 @@ fn daphne_param() {
     };
     assert_eq!(
         config.durable_report_store_name(&task_config, &task_id, &nonce),
-        "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/1"
+        "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1"
     );
 
     // Try enumerating a sequence of batch names.
@@ -96,16 +96,16 @@ fn daphne_param() {
     assert_eq!(
         batch_names,
         vec![
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/0",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/0",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/1",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/1",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/2",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/2",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/3",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/3",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637362800/bucket/4",
-            "/task/8oW-PK-Uj8_Da30yGBwU25XFXwT1Wi2y7kOcWHkmTh8/window/1637366400/bucket/4",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/0",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/0",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/1",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/2",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/2",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/3",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/3",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/4",
+            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/4",
         ]
     );
 }

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -150,13 +150,12 @@ impl<D> DapAggregator<BearerToken> for DaphneWorkerConfig<D> {
         // Check whether the request overlaps with previous requests. This is done by
         // checking the AggregateStore and seeing whether it requests for aggregate
         // shares that have already been marked collected.
-        let task_id_base64url = task_id.to_base64url();
         let namespace = self.durable_object("DAP_AGGREGATE_STORE")?;
         for window in (batch_interval.start..batch_interval.end())
             .step_by(task_config.min_batch_duration.try_into().unwrap())
         {
             let stub = namespace
-                .id_from_name(&durable_agg_store_name(&task_id_base64url, window))?
+                .id_from_name(&durable_agg_store_name(&task_id.to_hex(), window))?
                 .get_stub()?;
 
             // TODO Don't block on DO requests (issue multiple requests simultaneously).
@@ -185,14 +184,13 @@ impl<D> DapAggregator<BearerToken> for DaphneWorkerConfig<D> {
             .ok_or_else(|| DapError::fatal(INT_ERR_UNRECOGNIZED_TASK))?;
 
         let namespace = self.durable_object(BINDING_DAP_AGGREGATE_STORE)?;
-        let task_id_base64url = task_id.to_base64url();
 
         let agg_shares =
             DapAggregateShare::batches_from_out_shares(out_shares, task_config.min_batch_duration)?;
 
         for (window, agg_share) in agg_shares.into_iter() {
             let stub = namespace
-                .id_from_name(&durable_agg_store_name(&task_id_base64url, window))?
+                .id_from_name(&durable_agg_store_name(&task_id.to_hex(), window))?
                 .get_stub()?;
 
             // TODO Don't block on DO requests (issue multiple requests simultaneously).
@@ -212,13 +210,12 @@ impl<D> DapAggregator<BearerToken> for DaphneWorkerConfig<D> {
             .ok_or_else(|| DapError::fatal(INT_ERR_UNRECOGNIZED_TASK))?;
 
         let namespace = self.durable_object(BINDING_DAP_AGGREGATE_STORE)?;
-        let task_id_base64url = task_id.to_base64url();
         let mut agg_share = DapAggregateShare::default();
         for window in (batch_interval.start..batch_interval.end())
             .step_by(task_config.min_batch_duration.try_into().unwrap())
         {
             let stub = namespace
-                .id_from_name(&durable_agg_store_name(&task_id_base64url, window))?
+                .id_from_name(&durable_agg_store_name(&task_id.to_hex(), window))?
                 .get_stub()?;
 
             // TODO Don't block on DO requests (issue multiple requests simultaneously).
@@ -259,7 +256,7 @@ impl<D> DapAggregator<BearerToken> for DaphneWorkerConfig<D> {
             .step_by(task_config.min_batch_duration.try_into().unwrap())
         {
             let stub = namespace
-                .id_from_name(&durable_agg_store_name(&task_id.to_base64url(), window))?
+                .id_from_name(&durable_agg_store_name(&task_id.to_hex(), window))?
                 .get_stub()?;
 
             // TODO Don't block on DO requests (issue multiple requests simultaneously).

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -9,8 +9,8 @@ use daphne::DapAggregateShare;
 use serde::{Deserialize, Serialize};
 use worker::*;
 
-pub(crate) fn durable_agg_store_name(task_id_base64url: &str, window: u64) -> String {
-    format!("/task/{}/window/{}", task_id_base64url, window)
+pub(crate) fn durable_agg_store_name(task_id_hex: &str, window: u64) -> String {
+    format!("task/{}/window/{}", task_id_hex, window)
 }
 
 pub(crate) const DURABLE_AGGREGATE_STORE_GET: &str = "/internal/do/aggregate_store/get";
@@ -28,7 +28,7 @@ pub(crate) enum AggregateStoreResult {
 ///
 /// The naming conventions for instances of the [`AggregateStore`] DO is as follows:
 ///
-/// > /task/<task_id>/window/<window>
+/// > task/<task_id>/window/<window>
 ///
 /// where `<task_id>` is a task ID, `<window>` is a batch window. A batch window is a UNIX
 /// timestamp (in seconds) truncated by the minimum batch duration.

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -9,11 +9,7 @@ use daphne::messages::Id;
 use worker::*;
 
 pub(crate) fn durable_helper_state_name(task_id: &Id, agg_job_id: &Id) -> String {
-    format!(
-        "/task/{}/agg_job/{}",
-        task_id.to_base64url(),
-        agg_job_id.to_base64url()
-    )
+    format!("task/{}/agg_job/{}", task_id.to_hex(), agg_job_id.to_hex())
 }
 
 pub(crate) const DURABLE_HELPER_STATE_PUT: &str = "/internal/do/helper_state/put";
@@ -21,7 +17,7 @@ pub(crate) const DURABLE_HELPER_STATE_GET: &str = "/internal/do/helper_state/get
 
 /// Durable Object (DO) for storing the Helper's state for a given aggregation job.
 ///
-/// An instance of the [`LeaderStateStore`] DO is named `/task/<task_id>/agg_job/<agg_job_id>`,
+/// An instance of the [`LeaderStateStore`] DO is named `task/<task_id>/agg_job/<agg_job_id>`,
 /// where `<task_id>` is the task ID and `<agg_job_id>` is the aggregation job ID.
 #[durable_object]
 pub struct HelperStateStore {

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -32,7 +32,7 @@ struct OrderedCollectReq {
 
 /// Durable Object (DO) for storing the Leader's state for a given task.
 ///
-/// An instance of the [`LeaderCollectionJobQueue`] DO is named `/queue/<queue_num>`, where `<queue_num>`
+/// An instance of the [`LeaderCollectionJobQueue`] DO is named `queue/<queue_num>`, where `<queue_num>`
 /// is an integer representing a specific queue.
 //
 // TODO spec: Consider allowing completed aggregate results to be deleted after a period of time.

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -91,7 +91,7 @@ pub(crate) async fn state_set_if_not_exists<T: for<'a> Deserialize<'a> + Seriali
 }
 
 pub(crate) fn durable_queue_name(queue_num: usize) -> String {
-    format!("/queue/{}", queue_num)
+    format!("queue/{}", queue_num)
 }
 
 /// Reference to a DO instance, used by the garbage collector.

--- a/daphne_worker/src/durable/report_store.rs
+++ b/daphne_worker/src/durable/report_store.rs
@@ -17,15 +17,8 @@ use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use worker::*;
 
-pub(crate) fn durable_report_store_name(
-    task_id_base64url: &str,
-    window: u64,
-    bucket: u64,
-) -> String {
-    format!(
-        "/task/{}/window/{}/bucket/{}",
-        task_id_base64url, window, bucket
-    )
+pub(crate) fn durable_report_store_name(task_id_hex: &str, window: u64, bucket: u64) -> String {
+    format!("task/{}/window/{}/bucket/{}", task_id_hex, window, bucket)
 }
 
 pub(crate) const DURABLE_REPORT_STORE_GET_PENDING: &str = "/internal/do/report_store/get_pending";


### PR DESCRIPTION
Based on #70 (merge that first).

This makes the encoding consistent across the entire backend. Reserve
the base64url encoding for the wire.