### PR TITLE
Allow maximum batch duration to be accepted by Leader

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -242,7 +242,7 @@ pub struct ProblemDetails {
 // in the spec.
 #[derive(Deserialize, Serialize)]
 pub struct DapGlobalConfig {
-    /// Maximum window size permitted in CollectReq.
+    /// Maximum interval duration permitted in CollectReq.
     /// Prevents Collectors from requesting wide range or reports.
     pub max_batch_duration: u64,
 

--- a/daphne_worker/src/config_test.rs
+++ b/daphne_worker/src/config_test.rs
@@ -5,9 +5,9 @@ use crate::config::DaphneWorkerConfig;
 use daphne::messages::{Interval, Nonce};
 
 pub const GLOBAL_CONFIG: &str = r#"{
-    "max_batch_duration": 100,
-    "min_batch_interval_start": 432000,
-    "max_batch_interval_end": 18000
+    "max_batch_duration": 360000,
+    "min_batch_interval_start": 259200,
+    "max_batch_interval_end": 259200
 }"#;
 
 const DAP_TASK_LIST: &str = r#"{

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -43,7 +43,7 @@ use daphne::{
         ReportShare, TransitionFailure,
     },
     roles::{DapAggregator, DapAuthorizedSender, DapHelper, DapLeader},
-    DapAbort, DapAggregateShare, DapCollectJob, DapError, DapHelperState, DapOutputShare,
+    DapAggregateShare, DapCollectJob, DapError, DapGlobalConfig, DapHelperState, DapOutputShare,
     DapRequest, DapResponse, DapTaskConfig,
 };
 use prio::codec::{Decode, Encode};
@@ -134,8 +134,16 @@ impl<D> DapAggregator<BearerToken> for DaphneWorkerConfig<D> {
         self.bearer_token_authorized(req).await
     }
 
+    fn get_global_config(&self) -> &DapGlobalConfig {
+        &self.global_config
+    }
+
     fn get_task_config_for(&self, task_id: &Id) -> Option<&DapTaskConfig> {
         self.tasks.get(task_id)
+    }
+
+    fn get_current_time(&self) -> u64 {
+        now()
     }
 
     async fn is_batch_overlapping(
@@ -356,29 +364,6 @@ impl<D> DapLeader<BearerToken> for DaphneWorkerConfig<D> {
         let task_config = self
             .get_task_config_for(&collect_req.task_id)
             .ok_or_else(|| DapError::fatal(INT_ERR_UNRECOGNIZED_TASK))?;
-        let now = now();
-
-        if collect_req.batch_interval.duration / task_config.min_batch_duration
-            > self.global_config.max_batch_duration
-        {
-            return Err(DapError::Abort(DapAbort::BadRequest(
-                "batch interval too large".to_string(),
-            )));
-        }
-        if now.abs_diff(collect_req.batch_interval.start)
-            > self.global_config.min_batch_interval_start
-        {
-            return Err(DapError::Abort(DapAbort::BadRequest(
-                "batch interval too far into past".to_string(),
-            )));
-        }
-        if now.abs_diff(collect_req.batch_interval.end())
-            > self.global_config.max_batch_interval_end
-        {
-            return Err(DapError::Abort(DapAbort::BadRequest(
-                "batch interval too far into future".to_string(),
-            )));
-        }
 
         // Try to put the request into collection job queue. If the request is overlapping
         // with past requests, then abort.

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -17,7 +17,7 @@ DAP_BUCKET_KEY = 'f79c352056982bae1737e34bdac24d63'
 DAP_BUCKET_COUNT = 2
 
 # Global configurations.
-GLOBAL_CONFIG = '{"max_batch_duration": 100,"min_batch_interval_start": 432000,"max_batch_interval_end": 18000}'
+GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
 
 # A list of task IDs and their corresponding configurations. Each configuration
 # includes the VDAF algorithm and secret the verification parameter.

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -17,7 +17,7 @@ DAP_BUCKET_KEY = '61cd9685547370cfea76c2eb8d156ad9'
 DAP_BUCKET_COUNT = 2
 
 # Global configurations.
-GLOBAL_CONFIG = '{"max_batch_duration": 100,"min_batch_interval_start": 432000,"max_batch_interval_end": 18000}'
+GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
 
 # Key used to derive collect job IDs.
 DAP_COLLECT_ID_KEY = "b416a85d280591d6da14e5b75a7d6e31"

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -492,6 +492,27 @@ async fn e2e_leader_collect_abort_unknown_request() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "test_e2e"), ignore)]
+async fn e2e_leader_collect_accept_max_batch_duration() {
+    let t = TestRunner::default().await;
+    let client = t.http_client();
+    let batch_interval = Interval {
+        start: t.now - (t.now % t.min_batch_duration) - t.max_batch_duration / 2,
+        duration: t.max_batch_duration,
+    };
+
+    // Maximum allowed batch duration.
+    let collect_req = CollectReq {
+        task_id: t.task_id.clone(),
+        batch_interval,
+        agg_param: Vec::new(),
+    };
+    let _collect_uri = t
+        .leader_post_collect(&client, collect_req.get_encoded())
+        .await;
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "test_e2e"), ignore)]
 async fn e2e_leader_collect_abort_invalid_batch_interval() {
     let t = TestRunner::default().await;
     let client = t.http_client();

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -28,9 +28,9 @@ const DEFAULT_TASK: &str = "f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee43
 const JANUS_HELPER_TASK: &str = "410d5e0abd94a88b8435a192cc458cc1667da2989827584cbf8a591626d5a61f";
 
 pub const GLOBAL_CONFIG: &str = r#"{
-    "max_batch_duration": 100,
-    "min_batch_interval_start": 432000,
-    "max_batch_interval_end": 18000
+    "max_batch_duration": 360000,
+    "min_batch_interval_start": 259200,
+    "max_batch_interval_end": 259200
 }"#;
 
 // This value of this JSON string must match DAP_TASK_LIST in tests/backend/leader.env.


### PR DESCRIPTION
This PR implements a test case where the maximum batch duration set by the global config is accepted by the Leader.

The global config numbers have been set to the following:
* max_batch_duration: 360,000 sec (100 batches of 3,600 sec)
* min_batch_interval_start: 279,200 sec (72 hours)
* max_batch_interval_end: 279,200 sec (72 hours)