### PR TITLE
Add support for HPKE configurations based on P-256

### DIFF
--- a/daphne/src/hpke_test.rs
+++ b/daphne/src/hpke_test.rs
@@ -2,13 +2,28 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::hpke::HpkeReceiverConfig;
+use crate::messages::HpkeKemId;
 
 #[test]
-fn encrypt_roundtrip() {
+fn encrypt_roundtrip_x25519_hkdf_sha256() {
     let info = b"info string";
     let aad = b"associated data";
     let plaintext = b"plaintext";
-    let config = HpkeReceiverConfig::gen(23);
+    let config = HpkeReceiverConfig::gen(23, HpkeKemId::X25519HkdfSha256);
+    println!("{}", serde_json::to_string(&config).unwrap());
+    let (enc, ciphertext) = config.encrypt(info, aad, plaintext).unwrap();
+    assert_eq!(
+        config.decrypt(info, aad, &enc, &ciphertext).unwrap(),
+        plaintext
+    );
+}
+
+#[test]
+fn encrypt_roundtrip_p256_hkdf_sha256() {
+    let info = b"info string";
+    let aad = b"associated data";
+    let plaintext = b"plaintext";
+    let config = HpkeReceiverConfig::gen(23, HpkeKemId::P256HkdfSha256);
     println!("{}", serde_json::to_string(&config).unwrap());
     let (enc, ciphertext) = config.encrypt(info, aad, plaintext).unwrap();
     assert_eq!(

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 const KEM_ID_X25519_HKDF_SHA256: u16 = 0x0020;
+const KEM_ID_P256_HKDF_SHA256: u16 = 0x0010;
 const KDF_ID_HKDF_SHA256: u16 = 0x0001;
 const AEAD_ID_AES128GCM: u16 = 0x0001;
 
@@ -507,6 +508,7 @@ impl Decode for AggregateShareResp {
 /// Codepoint for KEM schemes compatible with HPKE.
 #[derive(Clone, Copy, Deserialize, Serialize, Debug, PartialEq)]
 pub enum HpkeKemId {
+    P256HkdfSha256,
     X25519HkdfSha256,
     NotImplemented(u16),
 }
@@ -514,6 +516,7 @@ pub enum HpkeKemId {
 impl From<HpkeKemId> for u16 {
     fn from(kem_id: HpkeKemId) -> Self {
         match kem_id {
+            HpkeKemId::P256HkdfSha256 => KEM_ID_P256_HKDF_SHA256,
             HpkeKemId::X25519HkdfSha256 => KEM_ID_X25519_HKDF_SHA256,
             HpkeKemId::NotImplemented(x) => x,
         }
@@ -529,6 +532,7 @@ impl Encode for HpkeKemId {
 impl Decode for HpkeKemId {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         match u16::decode(bytes)? {
+            x if x == KEM_ID_P256_HKDF_SHA256 => Ok(Self::P256HkdfSha256),
             x if x == KEM_ID_X25519_HKDF_SHA256 => Ok(Self::X25519HkdfSha256),
             x => Ok(Self::NotImplemented(x)),
         }

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -567,9 +567,12 @@ impl<'a> Test<'a> {
         let task_id = Id(rng.gen());
         let agg_job_id = Id(rng.gen());
         let vdaf_verify_key = vdaf.gen_verify_key();
-        let leader_hpke_receiver_config = HpkeReceiverConfig::gen(rng.gen());
-        let helper_hpke_receiver_config = HpkeReceiverConfig::gen(rng.gen());
-        let collector_hpke_receiver_config = HpkeReceiverConfig::gen(rng.gen());
+        let leader_hpke_receiver_config =
+            HpkeReceiverConfig::gen(rng.gen(), HpkeKemId::X25519HkdfSha256);
+        let helper_hpke_receiver_config =
+            HpkeReceiverConfig::gen(rng.gen(), HpkeKemId::X25519HkdfSha256);
+        let collector_hpke_receiver_config =
+            HpkeReceiverConfig::gen(rng.gen(), HpkeKemId::X25519HkdfSha256);
         let leader_hpke_config = leader_hpke_receiver_config.clone().config;
         let helper_hpke_config = helper_hpke_receiver_config.clone().config;
         let collector_hpke_config = collector_hpke_receiver_config.clone().config;


### PR DESCRIPTION
Closes #39

This is a temporary solution. In the future, when we have a more ergonomic HPKE library that's friendly to agility, we can generalize `HpkeConfig` and its users over the HPKE algorithms.