### PR TITLE
daphne_worker: Update variable name for global config

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -59,9 +59,10 @@ pub(crate) struct DaphneWorkerConfig<D> {
 impl<D> DaphneWorkerConfig<D> {
     /// Fetch DAP parameters from environment variables.
     pub(crate) fn from_worker_context(ctx: RouteContext<D>) -> Result<Self> {
-        let global_config: DapGlobalConfig =
-            serde_json::from_str(ctx.secret("GLOBAL_CONFIG")?.to_string().as_ref())
-                .map_err(|e| Error::RustError(format!("Failed to parse GLOBAL_CONFIG: {}", e)))?;
+        let global_config: DapGlobalConfig = serde_json::from_str(
+            ctx.var("DAP_GLOBAL_CONFIG")?.to_string().as_ref(),
+        )
+        .map_err(|e| Error::RustError(format!("Failed to parse DAP_GLOBAL_CONFIG: {}", e)))?;
 
         let tasks: HashMap<Id, DapTaskConfig> =
             serde_json::from_str(ctx.secret("DAP_TASK_LIST")?.to_string().as_ref())

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -17,7 +17,7 @@ DAP_BUCKET_KEY = 'f79c352056982bae1737e34bdac24d63'
 DAP_BUCKET_COUNT = 2
 
 # Global configurations.
-GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
+DAP_GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
 
 # A list of task IDs and their corresponding configurations. Each configuration
 # includes the VDAF algorithm and secret the verification parameter.

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -17,7 +17,7 @@ DAP_BUCKET_KEY = '61cd9685547370cfea76c2eb8d156ad9'
 DAP_BUCKET_COUNT = 2
 
 # Global configurations.
-GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
+DAP_GLOBAL_CONFIG = '{"max_batch_duration": 360000,"min_batch_interval_start": 259200,"max_batch_interval_end": 259200}'
 
 # Key used to derive collect job IDs.
 DAP_COLLECT_ID_KEY = "b416a85d280591d6da14e5b75a7d6e31"


### PR DESCRIPTION
Change `GLOBAL_CONFIG` to `DAP_GLOBAL_CONFIG` in order to align with
other environment variables. While at it, don't make this variable
secret.