### PR TITLE
daphne_worker: Version DO instances containing DAP artifacts

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -261,6 +261,15 @@ impl From<&str> for DapVersion {
     }
 }
 
+impl AsRef<str> for DapVersion {
+    fn as_ref(&self) -> &str {
+        match self {
+            DapVersion::Draft01 => "v01",
+            _ => panic!("tried to construct string from unknown DAP version"),
+        }
+    }
+}
+
 /// Global DAP parameters common across tasks.
 //
 // NOTE: Consider whether the following parameters should be included

--- a/daphne_worker/src/config_test.rs
+++ b/daphne_worker/src/config_test.rs
@@ -104,7 +104,7 @@ fn daphne_param() {
     };
     assert_eq!(
         config.durable_report_store_name(&task_config, &task_id, &nonce),
-        "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1"
+        "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1"
     );
 
     // Try enumerating a sequence of batch names.
@@ -113,22 +113,22 @@ fn daphne_param() {
         duration: 2 * 3600,
     };
     let batch_names: Vec<String> = config
-        .iter_report_store_names(&task_id, &interval)
+        .iter_report_store_names(&task_config.version, &task_id, &interval)
         .unwrap()
         .collect();
     assert_eq!(
         batch_names,
         vec![
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/0",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/0",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/1",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/2",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/2",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/3",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/3",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/4",
-            "task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/4",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/0",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/0",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/1",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/1",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/2",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/2",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/3",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/3",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637362800/bucket/4",
+            "v01/task/f285be3caf948fcfc36b7d32181c14db95c55f04f55a2db2ee439c5879264e1f/window/1637366400/bucket/4",
         ]
     );
 }

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -5,12 +5,21 @@ use crate::{
     durable::{state_get_or_default, BINDING_DAP_AGGREGATE_STORE},
     int_err,
 };
-use daphne::DapAggregateShare;
+use daphne::{DapAggregateShare, DapVersion};
 use serde::{Deserialize, Serialize};
 use worker::*;
 
-pub(crate) fn durable_agg_store_name(task_id_hex: &str, window: u64) -> String {
-    format!("task/{}/window/{}", task_id_hex, window)
+pub(crate) fn durable_agg_store_name(
+    version: &DapVersion,
+    task_id_hex: &str,
+    window: u64,
+) -> String {
+    format!(
+        "{}/task/{}/window/{}",
+        version.as_ref(),
+        task_id_hex,
+        window
+    )
 }
 
 pub(crate) const DURABLE_AGGREGATE_STORE_GET: &str = "/internal/do/aggregate_store/get";
@@ -28,10 +37,11 @@ pub(crate) enum AggregateStoreResult {
 ///
 /// The naming conventions for instances of the [`AggregateStore`] DO is as follows:
 ///
-/// > task/<task_id>/window/<window>
+/// > <version>/task/<task_id>/window/<window>
 ///
-/// where `<task_id>` is a task ID, `<window>` is a batch window. A batch window is a UNIX
-/// timestamp (in seconds) truncated by the minimum batch duration.
+/// where <version> is the DAP version (e.g., "v01"), `<task_id>` is a task ID, `<window>` is a
+/// batch window. A batch window is a UNIX timestamp (in seconds) truncated by the minimum batch
+/// duration.
 #[durable_object]
 pub struct AggregateStore {
     #[allow(dead_code)]

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -5,11 +5,20 @@ use crate::{
     durable::{state_get, BINDING_DAP_HELPER_STATE_STORE},
     int_err,
 };
-use daphne::messages::Id;
+use daphne::{messages::Id, DapVersion};
 use worker::*;
 
-pub(crate) fn durable_helper_state_name(task_id: &Id, agg_job_id: &Id) -> String {
-    format!("task/{}/agg_job/{}", task_id.to_hex(), agg_job_id.to_hex())
+pub(crate) fn durable_helper_state_name(
+    version: &DapVersion,
+    task_id: &Id,
+    agg_job_id: &Id,
+) -> String {
+    format!(
+        "{}/task/{}/agg_job/{}",
+        version.as_ref(),
+        task_id.to_hex(),
+        agg_job_id.to_hex()
+    )
 }
 
 pub(crate) const DURABLE_HELPER_STATE_PUT: &str = "/internal/do/helper_state/put";
@@ -17,8 +26,12 @@ pub(crate) const DURABLE_HELPER_STATE_GET: &str = "/internal/do/helper_state/get
 
 /// Durable Object (DO) for storing the Helper's state for a given aggregation job.
 ///
-/// An instance of the [`LeaderStateStore`] DO is named `task/<task_id>/agg_job/<agg_job_id>`,
-/// where `<task_id>` is the task ID and `<agg_job_id>` is the aggregation job ID.
+/// An instance of the [`LeaderStateStore`] DO is named
+///
+/// > <version>/task/<task_id>/agg_job/<agg_job_id>
+///
+/// where `<version>` is the DAP version, `<task_id>` is the task ID and `<agg_job_id>` is the
+/// aggregation job ID.
 #[durable_object]
 pub struct HelperStateStore {
     #[allow(dead_code)]

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -39,7 +39,7 @@ impl AggregationJob {
 
 /// Durable Object (DO) representing an aggregation job queue.
 ///
-/// An instance of the [`LeaderAggregationJobQueue`] DO is named `/queue/<queue_num>` where
+/// An instance of the [`LeaderAggregationJobQueue`] DO is named `queue/<queue_num>` where
 /// `<queue_num>` is an integer idnentifying a specific queue.
 #[durable_object]
 pub struct LeaderAggregationJobQueue {

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -30,10 +30,11 @@ struct OrderedCollectReq {
     collect_req: CollectReq,
 }
 
+// XXX Rename instance
 /// Durable Object (DO) for storing the Leader's state for a given task.
 ///
-/// An instance of the [`LeaderCollectionJobQueue`] DO is named `queue/<queue_num>`, where `<queue_num>`
-/// is an integer representing a specific queue.
+/// An instance of the [`LeaderCollectionJobQueue`] DO is named `queue/<queue_num>`, where
+/// `<queue_num>` is an integer representing a specific queue.
 //
 // TODO spec: Consider allowing completed aggregate results to be deleted after a period of time.
 #[durable_object]


### PR DESCRIPTION
Based on #84 (merge that first).
Closes #83.

Prefixes the DO instance name with the DAP protocol version. This is
intended to allow breaking changes to the naming scheme between DAP
versions while maintaining backwards compatibility.

While at it, refactor some of the code in dap.rs behind a new method on
DaphneWorkerConfig, `try_get_task_config_for()`.