### PR TITLE
daphne_worker: Helper: Coalesce requests to ReportStore

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -78,6 +78,12 @@ impl From<worker::Error> for DapError {
     }
 }
 
+impl From<hex::FromHexError> for DapError {
+    fn from(e: hex::FromHexError) -> Self {
+        Self::Fatal(format!("from hex: {}", e))
+    }
+}
+
 impl From<CodecError> for DapError {
     fn from(e: CodecError) -> Self {
         Self::Fatal(format!("codec: {}", e))

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -214,7 +214,11 @@ impl DaphneWorkerRouter {
             router
         };
 
-        router.run(req, env).await
+        let start = Date::now().as_millis();
+        let resp = router.run(req, env).await?;
+        let end = Date::now().as_millis();
+        console_log!("request completed in {}ms", end - start);
+        Ok(resp)
     }
 }
 


### PR DESCRIPTION
Based on #85 (merge that first).

The Helper makes requests to ReportStore when deciding to reject
reports early. This change coalesces requests to each ReportStore
instance, thereby removing a performance bottleneck.

While at it, this change also adds timing information to logs:
* How long each request from Leader to Helper takes (round trip)
* How long it takes an Aggregator to answer a request