### PR TITLE
daphne_worker: Helper Don't garbage collect HelperStateStore

### DIFF
--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -44,7 +44,6 @@ pub(crate) enum AggregateStoreResult {
 /// duration.
 #[durable_object]
 pub struct AggregateStore {
-    #[allow(dead_code)]
     state: State,
     env: Env,
     touched: bool,

--- a/daphne_worker/src/durable/garbage_collector.rs
+++ b/daphne_worker/src/durable/garbage_collector.rs
@@ -10,7 +10,6 @@ pub(crate) const DURABLE_GARBAGE_COLLECTOR_PUT: &str = "/internal/do/garbage_col
 /// Durable Object (DO) for keeping track of all persistent DO storage.
 #[durable_object]
 pub struct GarbageCollector {
-    #[allow(dead_code)]
     state: State,
     env: Env,
 }

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -43,7 +43,6 @@ impl AggregationJob {
 /// `<queue_num>` is an integer idnentifying a specific queue.
 #[durable_object]
 pub struct LeaderAggregationJobQueue {
-    #[allow(dead_code)]
     state: State,
     env: Env,
     touched: bool,

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -39,7 +39,6 @@ struct OrderedCollectReq {
 // TODO spec: Consider allowing completed aggregate results to be deleted after a period of time.
 #[durable_object]
 pub struct LeaderCollectionJobQueue {
-    #[allow(dead_code)]
     state: State,
     env: Env,
     touched: bool,

--- a/daphne_worker/src/durable/report_store.rs
+++ b/daphne_worker/src/durable/report_store.rs
@@ -58,7 +58,6 @@ pub(crate) enum ReportStoreResult {
 /// from the task ID and nonce of the report itself.
 #[durable_object]
 pub struct ReportStore {
-    #[allow(dead_code)]
     state: State,
     env: Env,
     touched: bool,

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -238,6 +238,7 @@ fn abort(e: DapAbort) -> Result<Response> {
             Err(Error::RustError("internalError".to_string()))
         }
         _ => {
+            console_warn!("request aborted: {}", e.to_string());
             let mut headers = Headers::new();
             headers.set("Content-Type", "application/problem+json")?;
             Ok(Response::from_json(&e.to_problem_details())?


### PR DESCRIPTION
Removes garbage collection of instances of the HelperStateStore. If the
Leader abandons an aggregation job before the last request, this will
result in an instance of this DO being left in storage indefinitely.