### PR TITLE
Unblock DO requests in `roles.rs`

### DIFF
--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -95,7 +95,7 @@ pub(crate) struct MockAggregator {
     pub(crate) global_config: DapGlobalConfig,
     tasks: HashMap<Id, DapTaskConfig>,
     hpke_receiver_config_list: Vec<HpkeReceiverConfig>,
-    report_store: Arc<Mutex<HashMap<Id, ReportStore>>>,
+    pub(crate) report_store: Arc<Mutex<HashMap<Id, ReportStore>>>,
     leader_state_store: Arc<Mutex<HashMap<Id, LeaderState>>>,
     helper_state_store: Arc<Mutex<HashMap<HelperStateInfo, DapHelperState>>>,
     pub(crate) agg_store: Arc<Mutex<HashMap<BucketInfo, AggStoreState>>>,
@@ -718,7 +718,7 @@ impl BucketInfo {
 /// Stores the reports received from Clients.
 pub(crate) struct ReportStore {
     pub(crate) pending: VecDeque<Report>,
-    processed: HashSet<Nonce>,
+    pub(crate) processed: HashSet<Nonce>,
 }
 
 impl ReportStore {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -35,10 +35,7 @@ use prio::{
 };
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryInto,
-};
+use std::{collections::HashSet, convert::TryInto};
 
 const CTX_INPUT_SHARE: &[u8] = b"dap-01 input share";
 const CTX_AGG_SHARE: &[u8] = b"dap-01 aggregate share";
@@ -386,7 +383,6 @@ impl VdafConfig {
         decrypter: &D,
         verify_key: &VdafVerifyKey,
         agg_init_req: &AggregateInitializeReq,
-        early_rejects: &HashMap<Nonce, TransitionFailure>,
     ) -> Result<DapHelperTransition<AggregateResp>, DapAbort>
     where
         D: HpkeDecrypter,
@@ -400,14 +396,6 @@ impl VdafConfig {
                 return Err(DapAbort::UnrecognizedMessage);
             }
             processed.insert(report_share.nonce.clone());
-
-            if let Some(failure) = early_rejects.get(&report_share.nonce) {
-                transitions.push(Transition {
-                    nonce: report_share.nonce.clone(),
-                    var: TransitionVar::Failed(*failure),
-                });
-                continue;
-            }
 
             let var = match self.consume_report_share(
                 decrypter,

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -217,45 +217,6 @@ fn agg_resp_fail_hpke_decrypt_err() {
 }
 
 #[test]
-fn agg_resp_fail_report_replayed() {
-    let mut t = Test::new(TEST_VDAF);
-    let reports = t.produce_reports(vec![DapMeasurement::U64(1)]);
-
-    // Simulate the leader replaying a report.
-    t.early_rejects
-        .insert(reports[0].nonce.clone(), TransitionFailure::ReportReplayed);
-
-    let (_, agg_req) = t.produce_agg_init_req(reports).unwrap_continue();
-    let (_, agg_resp) = t.handle_agg_init_req(agg_req).unwrap_continue();
-
-    assert_eq!(agg_resp.transitions.len(), 1);
-    assert_matches!(
-        agg_resp.transitions[0].var,
-        TransitionVar::Failed(TransitionFailure::ReportReplayed)
-    );
-}
-
-#[test]
-fn agg_resp_fail_batch_collected() {
-    let mut t = Test::new(TEST_VDAF);
-    let reports = t.produce_reports(vec![DapMeasurement::U64(1)]);
-
-    // Simulate the leader requesting aggregation of a report for a batch that has already been
-    // collected.
-    t.early_rejects
-        .insert(reports[0].nonce.clone(), TransitionFailure::BatchCollected);
-
-    let (_, agg_req) = t.produce_agg_init_req(reports).unwrap_continue();
-    let (_, agg_resp) = t.handle_agg_init_req(agg_req).unwrap_continue();
-
-    assert_eq!(agg_resp.transitions.len(), 1);
-    assert_matches!(
-        agg_resp.transitions[0].var,
-        TransitionVar::Failed(TransitionFailure::BatchCollected)
-    );
-}
-
-#[test]
 fn agg_resp_abort_transition_out_of_order() {
     let mut t = Test::new(TEST_VDAF);
     let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
@@ -635,7 +596,6 @@ impl<'a> Test<'a> {
                 &self.helper_hpke_receiver_config,
                 &self.vdaf_verify_key,
                 &agg_init_req,
-                &self.early_rejects,
             )
             .unwrap();
 


### PR DESCRIPTION
Closes #93.

This PR allows the Helper to submit DO requests while doing other things concurrently.

`http_post_aggregate` in `roles.rs` has been changed so that `mark_aggregated` is processed while `get_helper_state` is called.