### PR TITLE
Fix & shrink Miniflare-based test container.

### DIFF
--- a/daphne_worker_test/docker/miniflare.Dockerfile
+++ b/daphne_worker_test/docker/miniflare.Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --update npm bash
 RUN npm install -g n && \
     n 18.4.0
 RUN npm install -g miniflare@2.5.1
+COPY daphne_worker_test/leader.env /leader.env
+COPY daphne_worker_test/helper.env /helper.env
 COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
 COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
 # `-B ""` to skip build command.

--- a/daphne_worker_test/docker/miniflare.Dockerfile
+++ b/daphne_worker_test/docker/miniflare.Dockerfile
@@ -1,26 +1,25 @@
-FROM rust:1.61-bullseye
-
+FROM rust:1.63-alpine AS builder
 WORKDIR /tmp/dap_test
-
-RUN apt-get update && \
-    apt-get install -y nodejs npm
-
+RUN apk add --update npm bash g++ openssl-dev
 RUN npm install -g n && \
     n 18.4.0
-
 RUN npm install -g \
         @cloudflare/wrangler \
         wasm-pack \
         miniflare@2.5.1
-
 COPY Cargo.toml Cargo.lock ./
 COPY daphne_worker_test ./daphne_worker_test
 COPY daphne_worker ./daphne_worker
 COPY daphne ./daphne
-
-ENV PATH="${PATH}:/root/.cargo/bin"
-
 WORKDIR /tmp/dap_test/daphne_worker_test
 RUN wrangler build
 
-ENTRYPOINT ["miniflare"]
+FROM alpine:3.16
+RUN apk add --update npm bash
+RUN npm install -g n && \
+    n 18.4.0
+RUN npm install -g miniflare@2.5.1
+COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
+COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
+# `-B ""` to skip build command.
+ENTRYPOINT ["miniflare", "-B", ""]

--- a/daphne_worker_test/docker/runtests.Dockerfile
+++ b/daphne_worker_test/docker/runtests.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.61-bullseye
+FROM rust:1.63-bullseye
 
 WORKDIR /tmp/dap_test
 
@@ -16,7 +16,7 @@ COPY daphne ./daphne
 COPY daphne_worker_test/docker/test.sh /
 RUN chmod +x /test.sh
 
-RUN cargo build
+RUN cargo test --no-run --features=test_e2e -p daphne-worker-test
 
 ENV PATH="${PATH}:/root/.cargo/bin"
 CMD ["/test.sh"]

--- a/daphne_worker_test/docker/test.sh
+++ b/daphne_worker_test/docker/test.sh
@@ -6,7 +6,7 @@
 set -e
 
 echo "Running tests."
-env RUST_BACKTRACE=1 cargo test --features=test_e2e -- --nocapture --test-threads 1
+env RUST_BACKTRACE=1 cargo test --features=test_e2e -p daphne-worker-test -- --nocapture --test-threads 1
 
 echo "Running clippy."
 cargo clippy -- -Dwarnings

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -1,3 +1,4 @@
+DAP_DEPLOYMENT = "prod"
 DAP_AGGREGATOR_ROLE = "helper"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -1,3 +1,4 @@
+DAP_DEPLOYMENT = "prod"
 DAP_AGGREGATOR_ROLE = "leader"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -6,9 +6,7 @@ compatibility_date = "2022-01-20"
 
 
 [build]
-# TODO Revert this temporary fix once
-# https://github.com/cloudflare/workers-rs/issues/204 is closed.
-command = "cargo install -q --git https://github.com/cloudflare/workers-rs --branch zeb/esbuild && worker-build"
+command = "cargo install -q --git https://github.com/cloudflare/workers-rs && worker-build"
 
 [build.upload]
 dir    = "build/worker"


### PR DESCRIPTION
This container had stopped building successfully (I think the Daphne
codebase started using a Rust feature that wasn't stabilized until after
1.61; bumping to 1.63 was all that was needed to get a successful
build.)

While I was at it, I also split the container build into a "build"
portion and an "output" portion & switched to alpine-based base images
-- this shrunk the output image from 3.32GB to 390MB.

Also go back to building Daphne using the mainline version of workers-rs,
as the referenced issue has been fixed.