### PR TITLE
Unblock DO requests in Daphne Workers

### DIFF
--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -71,7 +71,7 @@ impl DurableObject for AggregateStore {
                 let agg_share_delta = req.json().await?;
                 agg_share.merge(agg_share_delta).map_err(int_err)?;
                 self.state.storage().put("agg_share", agg_share).await?;
-                Response::empty()
+                Response::from_json(&String::new())
             }
 
             (DURABLE_AGGREGATE_STORE_GET, Method::Post) => {
@@ -89,7 +89,7 @@ impl DurableObject for AggregateStore {
 
             (DURABLE_AGGREGATE_STORE_MARK_COLLECTED, Method::Post) => {
                 self.state.storage().put("collected", true).await?;
-                Response::empty()
+                Response::from_json(&String::new())
             }
 
             _ => Err(int_err(format!(

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -74,7 +74,7 @@ impl DurableObject for LeaderAggregationJobQueue {
                     "LeaderAggregationJobQueue: bucket {} has been scheduled",
                     agg_job.report_store_id_hex
                 );
-                Response::empty()
+                Response::from_json(&String::new())
             }
 
             (DURABLE_LEADER_AGG_JOB_QUEUE_GET, Method::Post) => {
@@ -98,7 +98,7 @@ impl DurableObject for LeaderAggregationJobQueue {
             (DURABLE_LEADER_AGG_JOB_QUEUE_FINISH, Method::Post) => {
                 let agg_job: AggregationJob = req.json().await?;
                 self.state.storage().delete(&agg_job.bucket_key()).await?;
-                Response::empty()
+                Response::from_json(&String::new())
             }
 
             _ => Err(int_err(format!(

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -162,7 +162,7 @@ impl DurableObject for LeaderCollectionJobQueue {
                     .put(&processed_key, collect_resp)
                     .await?;
                 delete_pending_future.await?;
-                Response::empty()
+                Response::from_json(&String::new())
             }
 
             // Retrieve a completed CollectResp.


### PR DESCRIPTION
Previously we were defining and computing the `stub` within the `for` loop that iterates over the necessary variables.
`durable_post` was called within this loop while taking in the `stub` as an argument.
The aim of this change is to send concurrent DO requests within this loop by removing `await` from the `durable_post` within the `for` loop.
However, if we try to remove `await` from `durable_post`, we cannot compile to code because the defined `stub` goes out of scope even though `durable_post` is still using it.

The new changes precompute the `stub` and put it into an array where we can reference it when calling `durable_post`.