### PR TITLE
Trigger don't-clear-the-agg-job-queue behavior on a new variable.

### DIFF
--- a/daphne_worker/src/durable/report_store.rs
+++ b/daphne_worker/src/durable/report_store.rs
@@ -170,8 +170,16 @@ impl DurableObject for ReportStore {
                 //   processed. This way we can avoid storing "agg_job" here.
                 //
                 // In the meantime, to avoid flakyness in interop tests, supress the bug in
-                // development environments by never clearing the agg job queue.
-                if empty && self.env.var("DAP_DEPLOYMENT")?.to_string() != "dev" {
+                // development environments by never clearing the agg job queue if a workaround flag
+                // is set. Note that it is necessary to restart miniflare between test runs in order
+                // to reset the DO state.
+                if empty
+                    && self
+                        .env
+                        .var("DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION")?
+                        .to_string()
+                        == "true"
+                {
                     let agg_job: Option<AggregationJob> = state_get(&self.state, "agg_job").await?;
                     if let Some(agg_job) = agg_job {
                         // NOTE There is only one agg job queue for now. In the future, work will

--- a/daphne_worker_test/helper.env
+++ b/daphne_worker_test/helper.env
@@ -1,5 +1,6 @@
 DAP_DEPLOYMENT = "prod"
 DAP_AGGREGATOR_ROLE = "helper"
+DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the
 # Aggregator, but the Aggregator will decrypt input shares using any of them.

--- a/daphne_worker_test/leader.env
+++ b/daphne_worker_test/leader.env
@@ -1,5 +1,6 @@
 DAP_DEPLOYMENT = "prod"
 DAP_AGGREGATOR_ROLE = "leader"
+DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 
 # A list of HPKE configs. Only the first config in the list is advertised by the
 # Aggregator, but the Aggregator will decrypt input shares using any of them.


### PR DESCRIPTION
Previously, it was triggered if DAP_DEPLOYMENT was set to "dev".
However, DAP_DEPLOYMENT also controls whether various parts of the
codebase override hostnames to localhost. I think that controlling both
aspects with one variable did not capture all the use-cases:

* Local dev, based on running a miniflare process on a developer
  workstation, will want both the localhost-override & the
  don't-clear-agg-job-queue behavior.
* Container-based testing, as in the E2E tests, wants the
  don't-clear-agg-job-queue behavior but not the localhost-override.
* Production deployments want neither the localhost-override nor the
  don't-clear-agg-job-queue behavior.