### PR TITLE
Release 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "daphne"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "daphne-worker-test"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "base64",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "daphne_worker"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Daphne
 
 Daphne is a Rust implementation of the Distributed Aggregation Protocol
-([DAP](https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap)) standard. DAP is
+([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard. DAP is
 under active development in the PPM working group of the IETF.
+
+Daphne currently implements draft-ietf-ppm-dap-01.
 
 This software is intended to support experimental DAP deployments and is not yet
 suitable for use in production. Daphne will evolve along with the DAP draft:
@@ -10,7 +12,7 @@ Backwards compatibility with previous drafts won't be guaranteed until the draft
 itself begins to stabilize. API-breaking changes between releases should also be
 expected.
 
-This repository contains three crates:
+The [repository](https://github.com/cloudflare/daphne) contains three crates:
 
 * `daphne` (aka "Daphne") -- Implementation of the core DAP protocol logic for
   Clients, Aggregators, and Collectors. This crate does not provide the
@@ -31,17 +33,23 @@ This repository contains three crates:
 ## Testing
 
 The `daphne` crate relies on unit tests. The `daphne_worker` crate relies mostly
-on integration tests implemented in `daphne_worker_test`. Integration tests can
-be run via docker-compose:
+on integration tests implemented in `daphne_worker_test`. See the README in that
+directory for instructions on running Daphne-Worker locally.
+
+> NOTE Integration tests can be run via docker-compose, but this is not working
+> at the moment.
 
 ```
 docker-compose up --build --abort-on-container-exit --exit-code-from test
 ```
 
-See the README in that directory for instructions on running Daphne-Worker
-locally.
+
 
 ## Acknowledgements
+
+Thanks to Yoshimichi Nakatsuka who contributed signficantly to Daphne during his
+internship at Cloudflare Research. Thanks to Brandon Pitman for testing,
+reporting bugs, and sending patches.
 
 The name "Daphne" is credited to Cloudflare Research interns Tim Alberdingk
 Thijm and James Larisch, who came up with the name independently.

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "daphne"
 description = "Implementation of the DAP specification"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! This crate implements the core protocol logic for the Distributed Aggregation Protocol
-//! ([DAP](https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap)) standard under development in the
+//! ([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard under development in the
 //! PPM working group of the IETF. See [`VdafConfig`] for a listing of supported
 //! [VDAFs](https://github.com/cfrg/draft-irtf-cfrg-vdaf).
+//!
+//! Daphne implements draft-ietf-ppm-dap-01.
 //!
 //! Daphne does not provide the complete, end-to-end functionality of any party in the protocol.
 //! Instead, it defines traits for the functionalities that a concrete instantiation of the
@@ -16,15 +18,15 @@
 //! * The collect sub-protocol has not yet been fully implemented. In particular, Daphne Aggreators
 //! do not check properly if batch intervals overlap across collect requests. Note that this
 //! feature is privacy-critical and implementation is planned. See
-//! https://github.com/cloudflare/daphne/issues/45 for details.
+//! <https://github.com/cloudflare/daphne/issues/45> for details.
 //!
 //! * Daphne is not compatible with DAP tasks whose maximum batch lifetime is longer than one.
 //!
 //! * Aborts are not handled precisely as specified. In particular, some fields in the "Problem
 //! Details" document are omitted.
 //!
-//! * Daphne does not implement a complete DAP Client. However, a method is provided on
-//! [`VdafConfig`](crate::VdafConfig) for producing reports.
+//! * Daphne does not implement a complete DAP Client or Collector. However, methods are provided
+//! on [`VdafConfig`](crate::VdafConfig) for producing reports and consuming aggregate results.
 
 use crate::{
     messages::{CollectResp, HpkeConfig, Interval, Nonce, TransitionFailure},

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "daphne_worker"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",
@@ -14,7 +14,7 @@ license = "BSD-3-Clause"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-daphne = { path = "../daphne" }
+daphne = { version = "0.1.0", path = "../daphne" } # draft-ietf-ppm-dap-01
 futures = "0.3.21"
 async-trait = "0.1.56"
 base64 = "0.13.0"

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "daphne-worker-test"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -217,10 +217,6 @@ async fn e2e_internal_leader_process() {
 }
 
 // Test that all reports eventually get drained at minimum aggregation rate.
-//
-// BUG(issue#73) We're temporarily not removing completed agg jobs from the queue. This this test
-// to flake due to a call to /internal/process handling an empty bucket.
-#[ignore]
 #[tokio::test]
 #[cfg_attr(not(feature = "test_e2e"), ignore)]
 async fn e2e_leader_process_min_agg_rate() {


### PR DESCRIPTION
Update each crate version to "0.1.0". In addition:

* Have daphne_worker use daphne = "0.1.0". This allows us to continue
  development for deployed DAP-01 endpoints while unblocking work on
  DAP-02 support for daphne.

* Clean up documentation a bit

* Re-enable an integration test.

* Add acknowledgements

Once merged I will publish the daphne and daphne_worker crates.