### PR TITLE
`daphne_worker`: Clean up durable objects interface

### DIFF
--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -71,10 +71,10 @@ impl DurableObject for AggregateStore {
                 let agg_share_delta = req.json().await?;
                 agg_share.merge(agg_share_delta).map_err(int_err)?;
                 self.state.storage().put("agg_share", agg_share).await?;
-                Response::from_json(&String::new())
+                Response::from_json(&())
             }
 
-            (DURABLE_AGGREGATE_STORE_GET, Method::Post) => {
+            (DURABLE_AGGREGATE_STORE_GET, Method::Get) => {
                 // NOTE: The following logic is correct for `max_batch_lifetime = 1`, but
                 // requires changes when we allow batch lifetime longer than 1.
                 let agg_share: DapAggregateShare =
@@ -89,7 +89,7 @@ impl DurableObject for AggregateStore {
 
             (DURABLE_AGGREGATE_STORE_MARK_COLLECTED, Method::Post) => {
                 self.state.storage().put("collected", true).await?;
-                Response::from_json(&String::new())
+                Response::from_json(&())
             }
 
             _ => Err(int_err(format!(

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -69,7 +69,7 @@ impl DurableObject for HelperStateStore {
                     .storage()
                     .put("helper_state", helper_state)
                     .await?;
-                Response::empty()
+                Response::from_json(&())
             }
 
             (DURABLE_HELPER_STATE_GET, Method::Post) => {

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -74,7 +74,7 @@ impl DurableObject for LeaderAggregationJobQueue {
                     "LeaderAggregationJobQueue: bucket {} has been scheduled",
                     agg_job.report_store_id_hex
                 );
-                Response::from_json(&String::new())
+                Response::from_json(&())
             }
 
             (DURABLE_LEADER_AGG_JOB_QUEUE_GET, Method::Post) => {
@@ -98,7 +98,7 @@ impl DurableObject for LeaderAggregationJobQueue {
             (DURABLE_LEADER_AGG_JOB_QUEUE_FINISH, Method::Post) => {
                 let agg_job: AggregationJob = req.json().await?;
                 self.state.storage().delete(&agg_job.bucket_key()).await?;
-                Response::from_json(&String::new())
+                Response::from_json(&())
             }
 
             _ => Err(int_err(format!(

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -30,7 +30,6 @@ struct OrderedCollectReq {
     collect_req: CollectReq,
 }
 
-// XXX Rename instance
 /// Durable Object (DO) for storing the Leader's state for a given task.
 ///
 /// An instance of the [`LeaderCollectionJobQueue`] DO is named `queue/<queue_num>`, where
@@ -162,7 +161,7 @@ impl DurableObject for LeaderCollectionJobQueue {
                     .put(&processed_key, collect_resp)
                     .await?;
                 delete_pending_future.await?;
-                Response::from_json(&String::new())
+                Response::from_json(&())
             }
 
             // Retrieve a completed CollectResp.

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -16,32 +16,113 @@ pub(crate) const BINDING_DAP_GARBAGE_COLLECTOR: &str = "DAP_GARBAGE_COLLECTOR";
 
 const ERR_NO_VALUE: &str = "No such value in storage.";
 
+/// Used to send HTTP requests to a durable object (DO) instance.
+pub(crate) struct DurableConnector<'a> {
+    env: &'a Env,
+}
+
+impl<'a> DurableConnector<'a> {
+    pub(crate) fn new(env: &'a Env) -> Self {
+        DurableConnector { env }
+    }
+
+    /// Send a GET request with the given path to the DO instance with the given binding and name.
+    /// The response is expected to be a JSON object.
+    pub(crate) async fn get<O: for<'b> Deserialize<'b>>(
+        &self,
+        durable_binding: &str,
+        durable_path: &'static str,
+        durable_name: String,
+    ) -> Result<O> {
+        let namespace = self.env.durable_object(durable_binding)?;
+        let stub = namespace.id_from_name(&durable_name)?.get_stub()?;
+        durable_request(stub, durable_path, Method::Get, None::<()>).await
+    }
+
+    /// Send a POST request with the given path to the DO instance with the given binding and name.
+    /// The body of the request is a JSON object. The response is expected to be a JSON object.
+    pub(crate) async fn post<I: Serialize, O: for<'b> Deserialize<'b>>(
+        &self,
+        durable_binding: &str,
+        durable_path: &'static str,
+        durable_name: String,
+        data: I,
+    ) -> Result<O> {
+        let namespace = self.env.durable_object(durable_binding)?;
+        let stub = namespace.id_from_name(&durable_name)?.get_stub()?;
+        durable_request(stub, durable_path, Method::Post, Some(data)).await
+    }
+
+    /// Send a POST request with the given path to the DO instance with the given binding and hex
+    /// identifier. The body of the request is a JSON object. The response is expected to be a JSON
+    /// object.
+    pub(crate) async fn post_by_id_hex<I: Serialize, O: for<'b> Deserialize<'b>>(
+        &self,
+        durable_binding: &str,
+        durable_path: &'static str,
+        durable_id_hex: String,
+        data: I,
+    ) -> Result<O> {
+        let namespace = self.env.durable_object(durable_binding)?;
+        let stub = namespace.id_from_string(&durable_id_hex)?.get_stub()?;
+        durable_request(stub, durable_path, Method::Post, Some(data)).await
+    }
+}
+
+async fn durable_request<I: Serialize, O: for<'a> Deserialize<'a>>(
+    durable_stub: Stub,
+    durable_path: &'static str,
+    method: Method,
+    data: Option<I>,
+) -> Result<O> {
+    let req = match (&method, data) {
+        (Method::Post, Some(data)) => Request::new_with_init(
+            &format!("https://fake-host{}", durable_path),
+            RequestInit::new().with_method(Method::Post).with_body(Some(
+                wasm_bindgen::JsValue::from_str(&serde_json::to_string(&data)?),
+            )),
+        )?,
+        (Method::Get, None) => Request::new_with_init(
+            &format!("https://fake-host{}", durable_path),
+            RequestInit::new().with_method(Method::Get),
+        )?,
+        _ => {
+            return Err(Error::RustError(format!(
+                "durable_request: Unrecognized method: {:?}",
+                method
+            )));
+        }
+    };
+
+    let mut resp = durable_stub.fetch_with_request(req).await?;
+    resp.json().await
+}
+
 macro_rules! ensure_garbage_collected {
     ($req:expr, $object:expr, $id:expr, $binding:expr) => {{
         if $req.path() == crate::durable::DURABLE_DELETE_ALL && $req.method() == Method::Post {
             $object.state.storage().delete_all().await?;
             $object.touched = false;
-            return Response::empty();
+            return Response::from_json(&());
         } else if !$object.touched {
             let touched: bool =
                 crate::durable::state_set_if_not_exists(&$object.state, "touched", &true)
                     .await?
                     .unwrap_or(false);
             if !touched {
-                let namespace = $object
-                    .env
-                    .durable_object(crate::durable::BINDING_DAP_GARBAGE_COLLECTOR)?;
-                let stub = namespace.id_from_name("garbage_collector")?.get_stub()?;
-                durable_post!(
-                    stub,
-                    crate::durable::garbage_collector::DURABLE_GARBAGE_COLLECTOR_PUT,
-                    &crate::durable::DurableReference {
-                        binding: $binding.to_string(),
-                        id_hex: $id,
-                        task_id: None,
-                    }
-                )
-                .await?;
+                let durable = crate::durable::DurableConnector::new(&$object.env);
+                durable
+                    .post(
+                        crate::durable::BINDING_DAP_GARBAGE_COLLECTOR,
+                        crate::durable::garbage_collector::DURABLE_GARBAGE_COLLECTOR_PUT,
+                        "garbage_collector".to_string(),
+                        &crate::durable::DurableReference {
+                            binding: $binding.to_string(),
+                            id_hex: $id,
+                            task_id: None,
+                        },
+                    )
+                    .await?;
                 $object.touched = true;
             }
         }

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -24,39 +24,6 @@ pub struct InternalAggregateInfo {
     pub max_reports: u64,
 }
 
-macro_rules! durable_get {
-    (
-            $stub:expr,
-            $path:expr
-    ) => {{
-        let req = Request::new_with_init(
-            &format!("https://fake-host{}", $path),
-            RequestInit::new().with_method(Method::Get),
-        )?;
-
-        $stub.fetch_with_request(req)
-    }};
-}
-
-macro_rules! durable_post {
-    (
-        $stub:expr,
-        $path:expr,
-        $serializable:expr
-    ) => {{
-        use wasm_bindgen::JsValue;
-        let req = Request::new_with_init(
-            &format!("https://fake-host{}", $path),
-            RequestInit::new().with_method(Method::Post).with_body(Some(
-                // TODO Figure out how to send raw bytes to DOs rather than a JSON blob.
-                JsValue::from_str(&serde_json::to_string($serializable)?),
-            )),
-        )?;
-
-        $stub.fetch_with_request(req)
-    }};
-}
-
 macro_rules! parse_id {
     (
         $option_str:expr


### PR DESCRIPTION
Replace the `durable_post!` and `durable_get!` macros with a new object,
`DurableConnector`, used to send HTTP requests to durable objects.

The methods on this object, `get()`, `post()`, and `post_by_id_hex()`,
are designed to operate on JSON objects. This entails the following
minor functional changes:

* Fetching the value of an `AggregateStore` is now a GET.
* Whenever a DO wants to return an empty response, either via
  `Response::empty()` or `Response::from_json(&String::new())`, it now
  returns NULL object, via `Response::from_json(&())`.