### PR TITLE
`daphne`: Remove `worker` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "worker",
 ]
 
 [[package]]

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -26,7 +26,6 @@ assert_matches = "1.5.0"
 async-trait = "0.1.56"
 base64 = "0.13.0"
 getrandom = { version = "0.2", features = ["js"] } # Required for prio
-worker = "0.0.10"
 serde_json = "1.0.82"
 prio = { version = "=0.8.2", features = ["prio2"] }
 hpke = { version = "0.8.0", features = ["std", "serde_impls"] }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -74,12 +74,6 @@ impl From<serde_json::Error> for DapError {
     }
 }
 
-impl From<worker::Error> for DapError {
-    fn from(e: worker::Error) -> Self {
-        Self::Fatal(format!("worker: {}", e))
-    }
-}
-
 impl From<hex::FromHexError> for DapError {
     fn from(e: hex::FromHexError) -> Self {
         Self::Fatal(format!("from hex: {}", e))

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -6,6 +6,7 @@
 //! Daphne-Worker configuration.
 
 use crate::{
+    dap_err,
     durable::{
         report_store::durable_report_store_name, DurableConnector, BINDING_DAP_GARBAGE_COLLECTOR,
         DURABLE_DELETE_ALL,
@@ -286,7 +287,8 @@ impl<D> DaphneWorkerConfig<D> {
                 "garbage_collector".to_string(),
                 &(),
             )
-            .await?;
+            .await
+            .map_err(dap_err)?;
         Ok(())
     }
 

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -198,6 +198,17 @@ pub(crate) fn int_err<S: ToString>(s: S) -> Error {
     Error::RustError("internalError".to_string())
 }
 
+/// Convert a [`worker::Error`] into a [`daphne::DapError`].
+///
+/// NOTE Alternatively, we could implement `From<worker::Error>` for `daphne::DapError` in the
+/// `daphne` crate. This requires synchronizing the version of the `worker` crate used here and by
+/// `daphne`. However, The `worker` crate is still under active development, and we often need
+/// changes that are on the main branch but not yet released. Thus, synchronizing this dependency
+/// between both crates is not currently feasible.
+pub(crate) fn dap_err(e: Error) -> DapError {
+    DapError::Fatal(format!("worker: {}", e))
+}
+
 fn abort(e: DapAbort) -> Result<Response> {
     match &e {
         DapAbort::Internal(..) => {


### PR DESCRIPTION
Based on #102 (merge that first).

Remove `From<worker::Error` for `DapError`, thereby eliminating the
`worker` dependency from `daphne` altogether. Instead, implement
conversion explicitly in the `daphne_worker` crate.

This results in more verbose code, but the upside is that we no longer
need to synchronize the version of `worker` to use across the crates.
This is useful while workers-rs is under active development.