### PR TITLE
Fix "type" field in Problem Details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "daphne"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -513,39 +513,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "daphne"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac1aa6245bfed062236968613dc2d4895a40e8c6f6670fa4cb0dc2bddf84cd0"
-dependencies = [
- "anyhow",
- "assert_matches",
- "async-trait",
- "base64",
- "clap 3.2.19",
- "getrandom",
- "hex",
- "hpke 0.8.0",
- "matchit 0.6.0",
- "prio",
- "rand",
- "reqwest",
- "ring",
- "serde",
- "serde_json",
- "thiserror",
- "url",
-]
-
-[[package]]
 name = "daphne-worker-test"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_matches",
  "base64",
  "cfg-if 0.1.10",
  "console_error_panic_hook",
- "daphne 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "daphne",
  "daphne_worker",
  "deadpool-postgres",
  "futures",
@@ -569,11 +544,11 @@ dependencies = [
 
 [[package]]
 name = "daphne_worker"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64",
- "daphne 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "daphne",
  "futures",
  "getrandom",
  "hex",

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "daphne"
 description = "Implementation of the DAP specification"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -194,7 +194,7 @@ impl DapAbort {
         };
 
         ProblemDetails {
-            typ,
+            typ: format!("urn:ietf:params:ppm:dap:error:{}", typ),
             taskid: None,   // TODO interop: Implement as specified.
             instance: None, // TODO interop: Implement as specified.
             detail,

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "daphne_worker"
 description = "Workers backend for Daphne"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",
@@ -18,7 +18,7 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-daphne = "0.1.1"
+daphne = { path = "../daphne" }
 futures = "0.3.21"
 async-trait = "0.1.56"
 base64 = "0.13.0"

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "daphne-worker-test"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   "Christopher Patton <cpatton@cloudflare.com>",
   "Armando Faz Hernandez <armfazh@cloudflare.com>",
@@ -33,7 +33,7 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 [dev-dependencies]
 assert_matches = "1.5.0"
 base64 = "0.13.0"
-daphne = "0.1.1"
+daphne = { path = "../daphne" }
 hex = { version = "0.4.3", features = ["serde"] }
 lazy_static = "1.4.0"
 futures = "0.3.21"

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -361,7 +361,10 @@ impl TestRunner {
 
         let problem_details: serde_json::Value = resp.json().await.unwrap();
         let got = problem_details.as_object().unwrap().get("type").unwrap();
-        assert_eq!(got, expected_err_type);
+        assert_eq!(
+            got,
+            &format!("urn:ietf:params:ppm:dap:error:{}", expected_err_type)
+        );
     }
 
     pub async fn leader_post_collect(&self, client: &reqwest::Client, data: Vec<u8>) -> Url {


### PR DESCRIPTION
Closes #110.

The spec calls for this field to be URI and to be prefixed by
"urn:ietf:params:ppm:dap:error:". This change corrects this.

While at it, bump crate versions in preparation for releasing a new
version.