### PR TITLE
Allow rwlock-guarded data to be passed by reference

### DIFF
--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -81,9 +81,15 @@ impl HpkeConfig {
 
 /// HPKE decrypter functionality.
 #[async_trait(?Send)]
-pub trait HpkeDecrypter {
+pub trait HpkeDecrypter<'a> {
+    /// Return type of `get_hpke_config_for()`, wraps a reference to an HPKE config.
+    type WrappedHpkeConfig: AsRef<HpkeConfig>;
+
     /// Look up the HPKE configuration to use for the given task ID.
-    async fn get_hpke_config_for(&self, task_id: &Id) -> Result<Option<HpkeConfig>, DapError>;
+    async fn get_hpke_config_for(
+        &'a self,
+        task_id: &Id,
+    ) -> Result<Option<Self::WrappedHpkeConfig>, DapError>;
 
     /// Returns `true` if a ciphertext with the HPKE config ID can be consumed in the current task.
     async fn can_hpke_decrypt(&self, task_id: &Id, config_id: u8) -> Result<bool, DapError>;
@@ -252,8 +258,13 @@ impl HpkeReceiverConfig {
 }
 
 #[async_trait(?Send)]
-impl HpkeDecrypter for HpkeReceiverConfig {
-    async fn get_hpke_config_for(&self, _task_id: &Id) -> Result<Option<HpkeConfig>, DapError> {
+impl<'a> HpkeDecrypter<'a> for HpkeReceiverConfig {
+    type WrappedHpkeConfig = HpkeConfig;
+
+    async fn get_hpke_config_for(
+        &'a self,
+        _task_id: &Id,
+    ) -> Result<Option<Self::WrappedHpkeConfig>, DapError> {
         unreachable!("not implemented");
     }
 

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -325,6 +325,12 @@ impl DapTaskConfig {
     }
 }
 
+impl AsRef<DapTaskConfig> for DapTaskConfig {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 struct ShadowDapTaskConfig {
     version: DapVersion,

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -616,6 +616,12 @@ pub struct HpkeConfig {
     pub(crate) public_key: Vec<u8>,
 }
 
+impl AsRef<HpkeConfig> for HpkeConfig {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl Encode for HpkeConfig {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.id.encode(bytes);

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -44,7 +44,7 @@ macro_rules! get_reports {
 impl MockAggregator {
     fn gen_test_upload_req(&self, report: Report) -> DapRequest<BearerToken> {
         let task_id = self.nominal_task_id();
-        let task_config = self.get_task_config_for(task_id).unwrap();
+        let task_config = self.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -59,7 +59,7 @@ impl MockAggregator {
     fn gen_test_agg_init_req(&self, report_shares: Vec<ReportShare>) -> DapRequest<BearerToken> {
         let mut rng = thread_rng();
         let task_id = self.nominal_task_id();
-        let task_config = self.get_task_config_for(task_id).unwrap();
+        let task_config = self.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -83,7 +83,7 @@ impl MockAggregator {
         transitions: Vec<Transition>,
     ) -> DapRequest<BearerToken> {
         let task_id = self.nominal_task_id();
-        let task_config = self.get_task_config_for(task_id).unwrap();
+        let task_config = self.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -106,7 +106,7 @@ impl MockAggregator {
         checksum: [u8; 32],
     ) -> DapRequest<BearerToken> {
         let task_id = self.nominal_task_id();
-        let task_config = self.get_task_config_for(task_id).unwrap();
+        let task_config = self.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -127,7 +127,7 @@ impl MockAggregator {
 
     fn gen_test_collect_req(&self) -> DapRequest<BearerToken> {
         let task_id = self.nominal_task_id();
-        let task_config = self.get_task_config_for(task_id).unwrap();
+        let task_config = self.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -481,7 +481,7 @@ async fn http_post_aggregate_failure_report_replayed() {
 async fn http_post_aggregate_failure_batch_collected() {
     let helper = MockAggregator::new();
     let task_id = helper.nominal_task_id();
-    let task_config = helper.get_task_config_for(task_id).unwrap();
+    let task_config = helper.tasks.get(task_id).unwrap();
 
     let report = helper.gen_test_report(task_id);
     let report_shares = vec![ReportShare {
@@ -655,7 +655,7 @@ async fn get_reports_empty_response() {
 async fn poll_collect_job_test_results() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq.
     let collector_collect_req = CollectReq {
@@ -714,7 +714,7 @@ async fn poll_collect_job_test_results() {
 async fn http_post_collect_fail_invalid_batch_interval() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
     let now = leader.now;
 
     // Collector: Create a CollectReq with a very large batch interval.
@@ -799,7 +799,7 @@ async fn http_post_collect_fail_invalid_batch_interval() {
 async fn http_post_collect_succeed_max_batch_interval() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
     let now = leader.now;
 
     // Collector: Create a CollectReq with a very large batch interval.
@@ -831,7 +831,7 @@ async fn http_post_collect_succeed_max_batch_interval() {
 async fn http_post_collect_fail_overlapping_batch_interval() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
     let helper = MockAggregator::new();
     let now = leader.now;
 
@@ -897,7 +897,7 @@ async fn http_post_collect_fail_overlapping_batch_interval() {
 async fn http_post_collect_success() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq.
     let collector_collect_req = CollectReq {
@@ -942,7 +942,7 @@ async fn http_post_collect_success() {
 async fn http_post_fail_wrong_dap_version() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
 
     // Send a request with the wrong DAP version.
     let report = leader.gen_test_report(task_id);
@@ -975,7 +975,7 @@ async fn successful_http_post_upload() {
 async fn e2e() {
     let leader = MockAggregator::new();
     let task_id = leader.nominal_task_id();
-    let task_config = leader.get_task_config_for(task_id).unwrap();
+    let task_config = leader.tasks.get(task_id).unwrap();
 
     let helper = MockAggregator::new();
 

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -213,7 +213,7 @@ impl VdafConfig {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn consume_report_share(
         &self,
-        decrypter: &impl HpkeDecrypter,
+        decrypter: &impl HpkeDecrypter<'_>,
         is_leader: bool,
         verify_key: &VdafVerifyKey,
         task_id: &Id,
@@ -285,7 +285,7 @@ impl VdafConfig {
     /// * `reports` is the set of reports uploaded by Clients.
     pub(crate) async fn produce_agg_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter,
+        decrypter: &impl HpkeDecrypter<'_>,
         verify_key: &VdafVerifyKey,
         task_id: &Id,
         agg_job_id: &Id,
@@ -384,7 +384,7 @@ impl VdafConfig {
     /// is the transition failure the Helper is to transmit.
     pub(crate) async fn handle_agg_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter,
+        decrypter: &impl HpkeDecrypter<'_>,
         verify_key: &VdafVerifyKey,
         agg_init_req: &AggregateInitializeReq,
     ) -> Result<DapHelperTransition<AggregateResp>, DapAbort> {
@@ -734,7 +734,7 @@ impl VdafConfig {
     // TODO spec: Allow the collector to have multiple HPKE public keys (the way Aggregators do).
     pub async fn consume_encrypted_agg_shares(
         &self,
-        decrypter: &impl HpkeDecrypter,
+        decrypter: &impl HpkeDecrypter<'_>,
         task_id: &Id,
         batch_interval: &Interval,
         encrypted_agg_shares: Vec<HpkeCiphertext>,

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -213,6 +213,8 @@ impl<D> DapAuthorizedSender<BearerToken> for DaphneWorkerConfig<D> {
 
 #[async_trait(?Send)]
 impl<'a, D> DapAggregator<'a, BearerToken> for DaphneWorkerConfig<D> {
+    type WrappedDapTaskConfig = &'a DapTaskConfig;
+
     async fn authorized(
         &self,
         req: &DapRequest<BearerToken>,
@@ -224,8 +226,11 @@ impl<'a, D> DapAggregator<'a, BearerToken> for DaphneWorkerConfig<D> {
         &self.global_config
     }
 
-    fn get_task_config_for(&self, task_id: &Id) -> Option<&DapTaskConfig> {
-        self.tasks.get(task_id)
+    async fn get_task_config_for(
+        &'a self,
+        task_id: &Id,
+    ) -> std::result::Result<Option<&'a DapTaskConfig>, DapError> {
+        Ok(self.tasks.get(task_id))
     }
 
     fn get_current_time(&self) -> u64 {


### PR DESCRIPTION
Partially addresses issue #82. There are two commits in this PR (review them separately):

1. Allow `HpkeDecrypter::get_hpke_config_for` to handle mutex guard.

Change the return type of `HpkeDecrypter::get_hpke_config_for` to
`HpkeDecryptor::WrappedHpkeConfig: AsRef<HpkeConfig>`. This allows
Daphne-Worker to return a reference to an HPKE config protected by a
mutex.

For `DaphneWorkerConfig`, the return type is
`GuardedHpkeReceiverConfig<'a>`, which is required to live as long as
the mutex guard for the underlying data structure (a map from config IDs
to configs). The compiler does not know whether this object lives as
long as `DaphneWorkerConfig`, so it is necessary to add a lifetime to
the `HpkeDecrypter` trait.

Because `get_hpke_config_for()` is called at most once per HTTP request,
and because the HPKE config needs to be fetched from KV for each
request, this change does not save any overhead. (It doesn't add any
either.) However, since plan to move the DAP task configs to KV as part
of issue#82, this pattern will need to be replicated for
`DapAggregator::get_task_config_for()` as well.

2. Make `DapAggregator::get_task_config_for()` async.

Allows us to use KV to back task storage from behind a mutex, which will be
needed for issue#84. Copying each time we need to fetch a task config would
be very expensive.
