### PR TITLE
Temporarly lock daphne_worker to daphne 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
  "assert_matches",
  "base64",
  "clap 3.2.20",
- "daphne",
+ "daphne 0.1.2",
  "prio",
  "reqwest",
  "serde",
@@ -527,6 +527,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "daphne"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150b45b6e1df7fcbaff121c2ac09059152e6335a81e986d89ce5c88abbcba17d"
+dependencies = [
+ "assert_matches",
+ "async-trait",
+ "base64",
+ "getrandom",
+ "hex",
+ "hpke 0.8.0",
+ "matchit 0.6.0",
+ "prio",
+ "rand",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "daphne-worker-test"
 version = "0.1.2"
 dependencies = [
@@ -534,7 +556,7 @@ dependencies = [
  "base64",
  "cfg-if 0.1.10",
  "console_error_panic_hook",
- "daphne",
+ "daphne 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "daphne_worker",
  "deadpool-postgres",
  "futures",
@@ -562,7 +584,7 @@ version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64",
- "daphne",
+ "daphne 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "getrandom",
  "hex",

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-daphne = { path = "../daphne" }
+daphne = "0.1.2" # TODO(issue #100) Use path = "../daphne" instead.
 futures = "0.3.21"
 async-trait = "0.1.56"
 base64 = "0.13.0"

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -33,7 +33,7 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 [dev-dependencies]
 assert_matches = "1.5.0"
 base64 = "0.13.0"
-daphne = { path = "../daphne" }
+daphne = "0.1.2" # TODO(issue #100) Use path = "../daphne" instead.
 hex = { version = "0.4.3", features = ["serde"] }
 lazy_static = "1.4.0"
 futures = "0.3.21"


### PR DESCRIPTION
Allows us to work on DAP-02 in daphne (issue#100) while continuing development of daphne_worker.

Build will fail until we publish daphne 0.1.2. Release plan:

- [x] Approval of PR
- [x] Publish daphne 0.1.2
- [x] Ensure CI passes
- [x] Ensure daphne_worker_test tests pass
- [x] Publish daphne_worker 0.1.2
- [ ] Merge PR
- [ ] Tag the commit with `0.1.2`
- [ ] Yank daphne and daphne_worker 0.1.1 from crates io (0.1.2 would be the first tagged version)

These steps are necessary because we will be making breaking changes for #100.