### PR TITLE
daphne: Rename insufficientBatchSize -> invalidBatchSize

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -133,9 +133,10 @@ pub enum DapAbort {
     #[error("invalidProtocolVersion")]
     InvalidProtocolVersion,
 
-    /// Insufficient batch size. Sent in response to a CollectReq or AggregateShareReq.
-    #[error("insufficientBatchSize")]
-    InsufficientBatchSize,
+    /// Invalid batch size (either too small or too large). Sent in response to a CollectReq or
+    /// AggregateShareReq.
+    #[error("invalidBatchSize")]
+    InvalidBatchSize,
 
     /// Replayed report. Sent in response to an upload request containing a Report that has been replayed.
     //
@@ -182,7 +183,7 @@ impl DapAbort {
             | Self::BatchOverlap
             | Self::InvalidBatchInterval
             | Self::InvalidProtocolVersion
-            | Self::InsufficientBatchSize
+            | Self::InvalidBatchSize
             | Self::ReplayedReport
             | Self::StaleReport
             | Self::UnauthorizedRequest

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -745,7 +745,7 @@ pub trait DapHelper<'a, S>: DapAggregator<'a, S> {
 
         // Check that the minimum batch size is met.
         if agg_share.report_count < task_config.min_batch_size {
-            return Err(DapAbort::InsufficientBatchSize);
+            return Err(DapAbort::InvalidBatchSize);
         }
 
         // Mark each aggregated report as collected.


### PR DESCRIPTION
Partially addresses #100.
Based on #126 (merge that first).

Just rename one of the error types to match DAP-02.