### PR TITLE
Make task ID optional for HPKE config request

### DIFF
--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -85,11 +85,11 @@ pub trait HpkeDecrypter<'a> {
     /// Return type of `get_hpke_config_for()`, wraps a reference to an HPKE config.
     type WrappedHpkeConfig: AsRef<HpkeConfig>;
 
-    /// Look up the HPKE configuration to use for the given task ID.
+    /// Look up the HPKE configuration to use for the given task ID (if specified).
     async fn get_hpke_config_for(
         &'a self,
-        task_id: &Id,
-    ) -> Result<Option<Self::WrappedHpkeConfig>, DapError>;
+        task_id: Option<&Id>,
+    ) -> Result<Self::WrappedHpkeConfig, DapError>;
 
     /// Returns `true` if a ciphertext with the HPKE config ID can be consumed in the current task.
     async fn can_hpke_decrypt(&self, task_id: &Id, config_id: u8) -> Result<bool, DapError>;
@@ -263,8 +263,8 @@ impl<'a> HpkeDecrypter<'a> for HpkeReceiverConfig {
 
     async fn get_hpke_config_for(
         &'a self,
-        _task_id: &Id,
-    ) -> Result<Option<Self::WrappedHpkeConfig>, DapError> {
+        _task_id: Option<&Id>,
+    ) -> Result<Self::WrappedHpkeConfig, DapError> {
         unreachable!("not implemented");
     }
 

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -138,6 +138,10 @@ pub enum DapAbort {
     #[error("invalidBatchSize")]
     InvalidBatchSize,
 
+    /// Request with missing task ID.
+    #[error("missingTaskID")]
+    MissingTaskId,
+
     /// Replayed report. Sent in response to an upload request containing a Report that has been replayed.
     //
     // TODO spec: Define this error type.
@@ -184,6 +188,7 @@ impl DapAbort {
             | Self::InvalidBatchInterval
             | Self::InvalidProtocolVersion
             | Self::InvalidBatchSize
+            | Self::MissingTaskId
             | Self::ReplayedReport
             | Self::StaleReport
             | Self::UnauthorizedRequest

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -163,18 +163,13 @@ pub trait DapAggregator<'a, S>: HpkeDecrypter<'a> + Sized {
             if task_config.as_ref().version != req.version {
                 return Err(DapAbort::InvalidProtocolVersion);
             }
-
-            let hpke_config = self
-                .get_hpke_config_for(task_id)
-                .await?
-                .ok_or(DapAbort::UnrecognizedTask)?;
-            Ok(DapResponse {
-                media_type: Some(MEDIA_TYPE_HPKE_CONFIG),
-                payload: hpke_config.as_ref().get_encoded(),
-            })
-        } else {
-            Err(DapAbort::BadRequest("missing query parameter".into()))
         }
+
+        let hpke_config = self.get_hpke_config_for(id.as_ref()).await?;
+        Ok(DapResponse {
+            media_type: Some(MEDIA_TYPE_HPKE_CONFIG),
+            payload: hpke_config.as_ref().get_encoded(),
+        })
     }
 }
 

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -74,8 +74,8 @@ impl<'a, D> HpkeDecrypter<'a> for DaphneWorkerConfig<D> {
 
     async fn get_hpke_config_for(
         &'a self,
-        _task_id: &Id,
-    ) -> std::result::Result<Option<GuardedHpkeReceiverConfig<'a>>, DapError> {
+        _task_id: Option<&Id>,
+    ) -> std::result::Result<GuardedHpkeReceiverConfig<'a>, DapError> {
         let kv_store = self.kv("DAP_HPKE_RECEIVER_CONFIG_STORE").map_err(dap_err)?;
         let keys = kv_store
             .list()
@@ -120,7 +120,8 @@ impl<'a, D> HpkeDecrypter<'a> for DaphneWorkerConfig<D> {
         Ok(self
             .hpke_receiver_config(hpke_config_id)
             .await
-            .map_err(dap_err)?)
+            .map_err(dap_err)?
+            .ok_or_else(|| DapError::fatal("empty HPKE receiver config list"))?)
     }
 
     async fn can_hpke_decrypt(


### PR DESCRIPTION
Partially addresses #100.
Based on #127 (merge that first).

Per DAP-02, allow the task ID to be an optional query parameter for the /hpke_config endpoint.