### PR TITLE
dapne: Refactor roles test framework

### DIFF
--- a/daphne/src/auth.rs
+++ b/daphne/src/auth.rs
@@ -38,6 +38,12 @@ impl From<String> for BearerToken {
     }
 }
 
+impl From<&str> for BearerToken {
+    fn from(token: &str) -> Self {
+        Self(token.to_string())
+    }
+}
+
 /// A source of bearer tokens used for authorizing DAP requests.
 #[async_trait(?Send)]
 pub trait BearerTokenProvider {

--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -6,7 +6,7 @@
 use crate::{
     messages::{
         decode_u16_bytes, encode_u16_bytes, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId,
-        HpkeKemId, Id,
+        HpkeKemId, Id, TransitionFailure,
     },
     DapError,
 };
@@ -279,6 +279,9 @@ impl<'a> HpkeDecrypter<'a> for HpkeReceiverConfig {
         aad: &[u8],
         ciphertext: &HpkeCiphertext,
     ) -> Result<Vec<u8>, DapError> {
+        if ciphertext.config_id != self.config.id {
+            return Err(DapError::Transition(TransitionFailure::HpkeUnknownConfigId));
+        }
         self.decrypt(info, aad, &ciphertext.enc, &ciphertext.payload)
     }
 }

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -594,7 +594,7 @@ pub type BatchSelector = Query;
 /// An aggregate-share request.
 //
 // TODO Add serialization tests.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AggregateShareReq {
     pub task_id: Id,
     pub batch_selector: BatchSelector,

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -7,34 +7,32 @@ use crate::{
         MEDIA_TYPE_AGG_CONT_REQ, MEDIA_TYPE_AGG_INIT_REQ, MEDIA_TYPE_AGG_SHARE_REQ,
         MEDIA_TYPE_COLLECT_REQ, MEDIA_TYPE_HPKE_CONFIG, MEDIA_TYPE_REPORT,
     },
-    hpke::HpkeReceiverConfig,
+    hpke::{HpkeDecrypter, HpkeReceiverConfig},
     messages::{
         AggregateContinueReq, AggregateInitializeReq, AggregateResp, AggregateShareReq,
         AggregateShareResp, BatchParameter, BatchSelector, CollectReq, CollectResp, HpkeCiphertext,
-        Id, Interval, Nonce, Query, Report, ReportMetadata, ReportShare, Transition,
-        TransitionFailure, TransitionVar,
+        HpkeKemId, Id, Interval, Query, Report, ReportShare, Time, Transition, TransitionFailure,
+        TransitionVar,
     },
-    roles::{DapAggregator, DapHelper, DapLeader},
-    testing::{
-        AggStoreState, BucketInfo, MockAggregateInfo, MockAggregator, ReportStore,
-        COLLECTOR_BEARER_TOKEN, HPKE_RECEIVER_CONFIG_LIST, LEADER_BEARER_TOKEN,
-    },
-    DapAbort, DapAggregateShare, DapCollectJob, DapLeaderTransition, DapMeasurement,
-    DapQueryConfig, DapRequest, DapTaskConfig, DapVersion, Prio3Config, VdafConfig,
+    roles::{DapAggregator, DapAuthorizedSender, DapHelper, DapLeader},
+    testing::{AggStoreState, BucketInfo, MockAggregateInfo, MockAggregator, ReportStore},
+    vdaf::VdafVerifyKey,
+    DapAbort, DapAggregateShare, DapCollectJob, DapGlobalConfig, DapLeaderTransition,
+    DapMeasurement, DapQueryConfig, DapRequest, DapTaskConfig, DapVersion, Prio3Config, VdafConfig,
 };
 use assert_matches::assert_matches;
 use matchit::Router;
 use prio::codec::{Decode, Encode};
 use rand::{thread_rng, Rng};
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     ops::DerefMut,
+    sync::{Arc, Mutex},
+    time::SystemTime,
     vec,
 };
 use url::Url;
 
-// MockAggregator's implementation of DapLeader::get_report() always returns reports for a single
-// task. This macro is used to conveniently unwrap the task ID and reports for testing purposes.
 macro_rules! get_reports {
     ($leader:expr, $selector:expr) => {{
         let reports_per_task = $leader.get_reports($selector).await.unwrap();
@@ -43,10 +41,131 @@ macro_rules! get_reports {
     }};
 }
 
-impl MockAggregator {
+struct Test {
+    now: Time,
+    leader: MockAggregator,
+    helper: MockAggregator,
+    #[allow(dead_code)] // TODO(issue #100) Remove
+    collector_hpke_receiver_config: HpkeReceiverConfig,
+    #[allow(dead_code)] // TODO(issue #100) Remove
+    collector_token: BearerToken,
+    time_interval_task_id: Id,
+    #[allow(dead_code)] // TODO(issue #100) Remove
+    fixed_size_task_id: Id,
+}
+
+impl Test {
+    fn new() -> Self {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut rng = thread_rng();
+
+        // Global config. In a real deployment, the Leader and Helper may make different choices
+        // here.
+        let global_config = DapGlobalConfig {
+            max_batch_duration: 360000,
+            min_batch_interval_start: 259200,
+            max_batch_interval_end: 259200,
+            supported_hpke_kems: vec![HpkeKemId::X25519HkdfSha256],
+        };
+
+        // Task Parameters that the Leader and Helper must agree on.
+        let vdaf_config = VdafConfig::Prio3(Prio3Config::Count);
+        let leader_url = Url::parse("https://leader.biz/v01/").unwrap();
+        let helper_url = Url::parse("http://helper.com:8788/v01/").unwrap();
+        let time_precision = 3600;
+        let version = DapVersion::Draft01;
+        let collector_hpke_receiver_config =
+            HpkeReceiverConfig::gen(rng.gen(), HpkeKemId::X25519HkdfSha256);
+
+        // Create the task list.
+        let time_interval_task_id = Id(rng.gen());
+        let fixed_size_task_id = Id(rng.gen());
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            time_interval_task_id.clone(),
+            DapTaskConfig {
+                version,
+                collector_hpke_config: collector_hpke_receiver_config.config.clone(),
+                leader_url: leader_url.clone(),
+                helper_url: helper_url.clone(),
+                time_precision,
+                query: DapQueryConfig::TimeInterval { min_batch_size: 1 },
+                vdaf: vdaf_config.clone(),
+                vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+            },
+        );
+        tasks.insert(
+            fixed_size_task_id.clone(),
+            DapTaskConfig {
+                version,
+                collector_hpke_config: collector_hpke_receiver_config.config.clone(),
+                leader_url: leader_url.clone(),
+                helper_url: helper_url.clone(),
+                time_precision,
+                query: DapQueryConfig::FixedSize {
+                    min_batch_size: 1,
+                    max_batch_size: 2,
+                },
+                vdaf: vdaf_config.clone(),
+                vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+            },
+        );
+
+        // Authorization tokens, used for all tasks.
+        let leader_token = BearerToken::from("this is a bearer token!");
+        let collector_token = BearerToken::from("This is a DIFFERENT token.");
+
+        let leader_hpke_receiver_config_list = global_config
+            .gen_hpke_receiver_config_list(rng.gen())
+            .into_iter()
+            .collect();
+        let leader = MockAggregator {
+            now,
+            global_config: global_config.clone(),
+            tasks: tasks.clone(),
+            hpke_receiver_config_list: leader_hpke_receiver_config_list,
+            leader_token: leader_token.clone(),
+            collector_token: Some(collector_token.clone()),
+            report_store: Arc::new(Mutex::new(HashMap::new())),
+            leader_state_store: Arc::new(Mutex::new(HashMap::new())),
+            helper_state_store: Arc::new(Mutex::new(HashMap::new())),
+            agg_store: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        let helper_hpke_receiver_config_list = global_config
+            .gen_hpke_receiver_config_list(rng.gen())
+            .into_iter()
+            .collect();
+        let helper = MockAggregator {
+            now,
+            global_config,
+            tasks,
+            leader_token,
+            collector_token: None,
+            hpke_receiver_config_list: helper_hpke_receiver_config_list,
+            report_store: Arc::new(Mutex::new(HashMap::new())),
+            leader_state_store: Arc::new(Mutex::new(HashMap::new())),
+            helper_state_store: Arc::new(Mutex::new(HashMap::new())),
+            agg_store: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        Self {
+            now,
+            leader,
+            helper,
+            collector_hpke_receiver_config,
+            collector_token,
+            time_interval_task_id,
+            fixed_size_task_id,
+        }
+    }
+
     fn gen_test_upload_req(&self, report: Report) -> DapRequest<BearerToken> {
-        let task_id = self.nominal_task_id();
-        let task_config = self.tasks.get(task_id).unwrap();
+        let task_id = &self.time_interval_task_id;
+        let task_config = self.leader.tasks.get(task_id).unwrap();
         let version = task_config.version.clone();
 
         DapRequest {
@@ -58,110 +177,96 @@ impl MockAggregator {
         }
     }
 
-    fn gen_test_agg_init_req(&self, report_shares: Vec<ReportShare>) -> DapRequest<BearerToken> {
+    async fn gen_test_agg_init_req(
+        &self,
+        task_id: &Id,
+        report_shares: Vec<ReportShare>,
+    ) -> DapRequest<BearerToken> {
         let mut rng = thread_rng();
-        let task_id = self.nominal_task_id();
-        let task_config = self.tasks.get(task_id).unwrap();
-        let version = task_config.version.clone();
+        let task_config = self.leader.tasks.get(task_id).unwrap();
         let batch_param = match task_config.query {
             DapQueryConfig::TimeInterval { .. } => BatchParameter::TimeInterval,
             _ => panic!("TODO(issue #100)"),
         };
 
-        DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_INIT_REQ),
-            payload: AggregateInitializeReq {
+        self.leader_authorized_req(
+            task_id,
+            task_config.version,
+            MEDIA_TYPE_AGG_INIT_REQ,
+            AggregateInitializeReq {
                 task_id: task_id.clone(),
                 agg_job_id: Id(rng.gen()),
                 agg_param: Vec::default(),
                 batch_param,
                 report_shares,
-            }
-            .get_encoded(),
-            url: task_config.helper_url.join("aggregate").unwrap(),
-            sender_auth: None,
-        }
+            },
+            task_config.helper_url.join("aggregate").unwrap(),
+        )
+        .await
     }
 
-    fn gen_test_agg_cont_req(
+    async fn gen_test_agg_cont_req(
         &self,
         agg_job_id: Id,
         transitions: Vec<Transition>,
     ) -> DapRequest<BearerToken> {
-        let task_id = self.nominal_task_id();
-        let task_config = self.tasks.get(task_id).unwrap();
-        let version = task_config.version.clone();
+        let task_id = &self.time_interval_task_id;
+        let task_config = self.leader.tasks.get(task_id).unwrap();
 
-        DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_CONT_REQ),
-            payload: AggregateContinueReq {
+        self.leader_authorized_req(
+            task_id,
+            task_config.version,
+            MEDIA_TYPE_AGG_CONT_REQ,
+            AggregateContinueReq {
                 task_id: task_id.clone(),
                 agg_job_id,
                 transitions,
-            }
-            .get_encoded(),
-            url: task_config.helper_url.join("aggregate").unwrap(),
-            sender_auth: None,
-        }
+            },
+            task_config.helper_url.join("aggregate").unwrap(),
+        )
+        .await
     }
 
-    fn gen_test_agg_share_req(
+    async fn gen_test_agg_share_req(
         &self,
         report_count: u64,
         checksum: [u8; 32],
     ) -> DapRequest<BearerToken> {
-        let task_id = self.nominal_task_id();
-        let task_config = self.tasks.get(task_id).unwrap();
-        let version = task_config.version.clone();
+        let task_id = &self.time_interval_task_id;
+        let task_config = self.leader.tasks.get(task_id).unwrap();
 
-        DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_SHARE_REQ),
-            payload: AggregateShareReq {
+        self.leader_authorized_req(
+            task_id,
+            task_config.version,
+            MEDIA_TYPE_AGG_SHARE_REQ,
+            AggregateShareReq {
                 task_id: task_id.clone(),
                 batch_selector: BatchSelector::default(),
                 agg_param: Vec::default(),
                 report_count,
                 checksum,
-            }
-            .get_encoded(),
-            url: task_config.helper_url.join("aggregate_share").unwrap(),
-            sender_auth: None,
-        }
+            },
+            task_config.helper_url.join("aggregate_share").unwrap(),
+        )
+        .await
     }
 
-    fn gen_test_collect_req(&self) -> DapRequest<BearerToken> {
-        let task_id = self.nominal_task_id();
-        let task_config = self.tasks.get(task_id).unwrap();
-        let version = task_config.version.clone();
-
-        DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-            payload: CollectReq {
-                task_id: task_id.clone(),
-                query: Query::default(),
-                agg_param: Vec::default(),
-            }
-            .get_encoded(),
-            url: task_config.leader_url.join("collect").unwrap(),
-            sender_auth: None,
-        }
-    }
-
-    fn gen_test_report(&self, task_id: &Id) -> Report {
-        // Construct HPKE receiver config List.
-        let hpke_receiver_config_list: Vec<HpkeReceiverConfig> =
-            serde_json::from_str(HPKE_RECEIVER_CONFIG_LIST)
-                .expect("failed to parse hpke_receiver_config_list");
-
+    async fn gen_test_report(&self, task_id: &Id) -> Report {
         // Construct HPKE config list.
-        let mut hpke_config_list = Vec::with_capacity(hpke_receiver_config_list.len());
-        for receiver_config in hpke_receiver_config_list {
-            hpke_config_list.push(receiver_config.config);
-        }
+        let hpke_config_list = [
+            self.leader
+                .get_hpke_config_for(Some(task_id))
+                .await
+                .unwrap()
+                .as_ref()
+                .clone(),
+            self.helper
+                .get_hpke_config_for(Some(task_id))
+                .await
+                .unwrap()
+                .as_ref()
+                .clone(),
+        ];
 
         // Construct report.
         let vdaf_config: &VdafConfig = &VdafConfig::Prio3(Prio3Config::Count);
@@ -172,18 +277,16 @@ impl MockAggregator {
         report
     }
 
-    async fn run_test_agg_job(
-        &self,
-        helper: &MockAggregator,
-        task_id: &Id,
-        task_config: &DapTaskConfig,
-    ) {
+    async fn run_agg_job(&self, task_id: &Id) -> Result<(), DapAbort> {
+        let wrapped = self.leader.get_task_config_for(task_id).await.unwrap();
+        let task_config = wrapped.as_ref().unwrap();
+
         // Leader: Store received report to ReportStore.
         let selector = &MockAggregateInfo {
             task_id: task_id.clone(),
             agg_rate: 1,
         };
-        let (task_id, reports) = get_reports!(self, selector);
+        let (task_id, reports) = get_reports!(self.leader, selector);
 
         // Leader: Consume report share.
         let mut rng = thread_rng();
@@ -191,81 +294,97 @@ impl MockAggregator {
         let transition = task_config
             .vdaf
             .produce_agg_init_req(
-                self,
+                &self.leader,
                 &task_config.vdaf_verify_key,
                 &task_id,
                 &agg_job_id,
                 reports,
             )
-            .await
-            .unwrap();
+            .await?;
         assert_matches!(transition, DapLeaderTransition::Continue(..));
         let (leader_state, agg_init_req) = transition.unwrap_continue();
 
         // Leader: Send aggregate initialization request to Helper and receive response.
         let version = task_config.version.clone();
-        let req = DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_INIT_REQ),
-            payload: agg_init_req.get_encoded(),
-            url: task_config.helper_url.join("aggregate").unwrap(),
-            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-        };
-        let res = helper.http_post_aggregate(&req).await.unwrap();
+        let req = self
+            .leader_authorized_req(
+                &task_id,
+                version,
+                MEDIA_TYPE_AGG_INIT_REQ,
+                agg_init_req,
+                task_config.helper_url.join("aggregate").unwrap(),
+            )
+            .await;
+        let res = self.helper.http_post_aggregate(&req).await?;
         let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
 
         // Leader: Produce Leader output share and prepare aggregate continue request for Helper.
-        let transition = task_config
-            .vdaf
-            .handle_agg_resp(&task_id, &agg_job_id, leader_state, agg_resp)
-            .unwrap();
+        let transition =
+            task_config
+                .vdaf
+                .handle_agg_resp(&task_id, &agg_job_id, leader_state, agg_resp)?;
         assert_matches!(transition, DapLeaderTransition::Uncommitted(..));
         let (leader_uncommitted, agg_cont_req) = transition.unwrap_uncommitted();
 
         // Leader: Send aggregate continue request to Helper and receive response.
         let version = task_config.version.clone();
-        let req = DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_CONT_REQ),
-            payload: agg_cont_req.get_encoded(),
-            url: task_config.helper_url.join("aggregate").unwrap(),
-            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-        };
-        let res = helper.http_post_aggregate(&req).await.unwrap();
-        let agg_resp = AggregateResp::get_decoded(&res.payload).unwrap();
+        let req = self
+            .leader_authorized_req(
+                &task_id,
+                version,
+                MEDIA_TYPE_AGG_CONT_REQ,
+                agg_cont_req,
+                task_config.helper_url.join("aggregate").unwrap(),
+            )
+            .await;
+        let res = self.helper.http_post_aggregate(&req).await?;
+        let agg_resp = AggregateResp::get_decoded(&res.payload)?;
 
         // Leader: Commit output shares of Leader and Helper.
         let out_shares = task_config
             .vdaf
-            .handle_final_agg_resp(leader_uncommitted, agg_resp)
-            .unwrap();
-        self.put_out_shares(&task_id, out_shares).await.unwrap();
+            .handle_final_agg_resp(leader_uncommitted, agg_resp)?;
+        self.leader.put_out_shares(&task_id, out_shares).await?;
+
+        Ok(())
     }
 
-    async fn run_test_col_job(
-        &self,
-        task_id: &Id,
-        collect_id: &Id,
-        collect_req: &CollectReq,
-        task_config: &DapTaskConfig,
-    ) {
-        // Leader: Get Leader's encrypted aggregate share.
-        let leader_agg_share = self
-            .get_agg_share(&collect_req.task_id, &collect_req.query)
-            .await
-            .unwrap();
+    async fn run_col_job(&self, task_id: &Id, query: &Query) -> Result<(), DapAbort> {
+        let wrapped = self.leader.get_task_config_for(task_id).await.unwrap();
+        let task_config = wrapped.as_ref().unwrap();
 
-        let leader_enc_agg_share = task_config
-            .vdaf
-            .produce_leader_encrypted_agg_share(
-                &task_config.collector_hpke_config,
-                &collect_req.task_id,
-                &collect_req.query,
-                &leader_agg_share,
+        // Collector->Leader: HTTP POST /collect
+        let req = self
+            .collector_authorized_req(
+                task_config.version,
+                MEDIA_TYPE_COLLECT_REQ,
+                CollectReq {
+                    task_id: task_id.clone(),
+                    query: query.clone(),
+                    agg_param: Vec::default(),
+                },
+                task_config.helper_url.join("collect").unwrap(),
             )
-            .unwrap();
+            .await;
 
-        // Leader: Prepare AggregateShareReq.
+        // Handle request.
+        self.leader.http_post_collect(&req).await?;
+        let resp = self.leader.get_pending_collect_jobs().await?;
+        let (collect_id, collect_req) = &resp[0];
+
+        // Leader: Handle collect job. First, fetch the aggregate share.
+        let leader_agg_share = self
+            .leader
+            .get_agg_share(&collect_req.task_id, &collect_req.query)
+            .await?;
+        let leader_enc_agg_share = task_config.vdaf.produce_leader_encrypted_agg_share(
+            &task_config.collector_hpke_config,
+            &collect_req.task_id,
+            &collect_req.query,
+            &leader_agg_share,
+        )?;
+
+        // Leader->Helper: HTTP POST /aggregate_share
         let agg_share_req = AggregateShareReq {
             task_id: collect_req.task_id.clone(),
             batch_selector: collect_req.query.clone(),
@@ -273,59 +392,105 @@ impl MockAggregator {
             report_count: leader_agg_share.report_count,
             checksum: leader_agg_share.checksum,
         };
+        let req = self
+            .leader_authorized_req(
+                &task_id,
+                task_config.version,
+                MEDIA_TYPE_AGG_SHARE_REQ,
+                agg_share_req.clone(),
+                task_config.helper_url.join("aggregate_share").unwrap(),
+            )
+            .await;
 
-        // Leader: Send AggregateShareReq to Helper and receive AggregateShareResp.
-        let version = task_config.version.clone();
-        let req = DapRequest {
-            version,
-            media_type: Some(MEDIA_TYPE_AGG_SHARE_REQ),
-            payload: agg_share_req.get_encoded(),
-            url: task_config.helper_url.join("aggregate_share").unwrap(),
-            sender_auth: Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string())),
-        };
-        let res = self.http_post_aggregate_share(&req).await.unwrap();
+        // Helper: Handle request.
+        let res = self.helper.http_post_aggregate_share(&req).await?;
         let agg_share_resp = AggregateShareResp::get_decoded(&res.payload).unwrap();
-        let helper_enc_agg_share = agg_share_resp.encrypted_agg_share;
 
-        // Leader: Complete the collect job by storing CollectResp in LeaderStore.processed.
+        // Leader: Complete the collect job.
         let collect_resp = CollectResp {
             report_count: leader_agg_share.report_count,
-            encrypted_agg_shares: vec![leader_enc_agg_share, helper_enc_agg_share],
+            encrypted_agg_shares: vec![leader_enc_agg_share, agg_share_resp.encrypted_agg_share],
         };
+        self.leader
+            .finish_collect_job(task_id, collect_id, &collect_resp)
+            .await?;
+        self.leader
+            .mark_collected(task_id, &agg_share_req.batch_selector)
+            .await?;
 
-        self.finish_collect_job(task_id, collect_id, &collect_resp)
-            .await
-            .unwrap();
+        // Collector: Poll the collect job.
+        let collect_job = self.leader.poll_collect_job(&task_id, &collect_id).await?;
+        assert_matches!(collect_job, DapCollectJob::Done(..));
 
-        // Leader: Mark the reports as collected.
-        self.mark_collected(task_id, &agg_share_req.batch_selector)
-            .await
-            .unwrap();
+        Ok(())
+    }
+
+    async fn leader_authorized_req<M: Encode>(
+        &self,
+        task_id: &Id,
+        version: DapVersion,
+        media_type: &'static str,
+        msg: M,
+        url: Url,
+    ) -> DapRequest<BearerToken> {
+        let payload = msg.get_encoded();
+        let sender_auth = Some(
+            self.leader
+                .authorize(task_id, media_type, &payload)
+                .await
+                .unwrap(),
+        );
+        DapRequest {
+            version,
+            media_type: Some(media_type),
+            payload,
+            url,
+            sender_auth,
+        }
+    }
+
+    async fn collector_authorized_req<M: Encode>(
+        &self,
+        version: DapVersion,
+        media_type: &'static str,
+        msg: M,
+        url: Url,
+    ) -> DapRequest<BearerToken> {
+        DapRequest {
+            version,
+            media_type: Some(media_type),
+            payload: msg.get_encoded(),
+            url,
+            sender_auth: Some(self.collector_token.clone()),
+        }
     }
 }
 
 #[tokio::test]
 async fn http_post_aggregate_init_unauthorized_request() {
-    let helper = MockAggregator::new();
-    let mut req = helper.gen_test_agg_init_req(Vec::default());
+    let t = Test::new();
+    let mut req = t
+        .gen_test_agg_init_req(&t.time_interval_task_id, Vec::default())
+        .await;
+    req.sender_auth = None;
 
     // Expect failure due to missing bearer token.
     assert_matches!(
-        helper.http_post_aggregate(&req).await,
+        t.helper.http_post_aggregate(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 
     // Expect failure due to incorrect bearer token.
     req.sender_auth = Some(BearerToken::from("incorrect auth token!".to_string()));
     assert_matches!(
-        helper.http_post_aggregate(&req).await,
+        t.helper.http_post_aggregate(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 }
 
 #[tokio::test]
 async fn http_get_hpke_config_unrecognized_task() {
-    let aggregator = MockAggregator::new();
+    let t = Test::new();
     let mut rng = thread_rng();
     let task_id = Id(rng.gen());
     let req = DapRequest {
@@ -341,14 +506,14 @@ async fn http_get_hpke_config_unrecognized_task() {
     };
 
     assert_matches!(
-        aggregator.http_get_hpke_config(&req).await,
+        t.leader.http_get_hpke_config(&req).await,
         Err(DapAbort::UnrecognizedTask)
     );
 }
 
 #[tokio::test]
 async fn http_get_hpke_config_missing_task_id() {
-    let aggregator = MockAggregator::new();
+    let t = Test::new();
     let req = DapRequest {
         version: DapVersion::Draft01,
         media_type: Some(MEDIA_TYPE_HPKE_CONFIG),
@@ -361,92 +526,106 @@ async fn http_get_hpke_config_missing_task_id() {
     // that Daphne-Workder does not implement this behavior. Instead it returns the HPKE config
     // used for all tasks.
     assert_matches!(
-        aggregator.http_get_hpke_config(&req).await,
+        t.leader.http_get_hpke_config(&req).await,
         Err(DapAbort::MissingTaskId)
     );
 }
 
 #[tokio::test]
 async fn http_post_aggregate_cont_unauthorized_request() {
-    let helper = MockAggregator::new();
+    let t = Test::new();
     let mut rng = thread_rng();
-    let mut req = helper.gen_test_agg_cont_req(Id(rng.gen()), Vec::default());
+    let mut req = t.gen_test_agg_cont_req(Id(rng.gen()), Vec::default()).await;
+    req.sender_auth = None;
 
     // Expect failure due to missing bearer token.
     assert_matches!(
-        helper.http_post_aggregate(&req).await,
+        t.helper.http_post_aggregate(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 
     // Expect failure due to incorrect bearer token.
     req.sender_auth = Some(BearerToken::from("incorrect auth token!".to_string()));
     assert_matches!(
-        helper.http_post_aggregate(&req).await,
+        t.helper.http_post_aggregate(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 }
 
 #[tokio::test]
 async fn http_post_aggregate_share_unauthorized_request() {
-    let helper = MockAggregator::new();
-    let mut req = helper.gen_test_agg_share_req(0, [0; 32]);
+    let t = Test::new();
+    let mut req = t.gen_test_agg_share_req(0, [0; 32]).await;
+    req.sender_auth = None;
 
     // Expect failure due to missing bearer token.
     assert_matches!(
-        helper.http_post_aggregate_share(&req).await,
+        t.helper.http_post_aggregate_share(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 
     // Expect failure due to incorrect bearer token.
     req.sender_auth = Some(BearerToken::from("incorrect auth token!".to_string()));
     assert_matches!(
-        helper.http_post_aggregate_share(&req).await,
+        t.helper.http_post_aggregate_share(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 }
 
 #[tokio::test]
 async fn http_post_collect_unauthorized_request() {
-    let leader = MockAggregator::new();
-    let mut req = leader.gen_test_collect_req();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
+    let mut req = DapRequest {
+        version: task_config.version,
+        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
+        payload: CollectReq {
+            task_id: task_id.clone(),
+            query: Query::default(),
+            agg_param: Vec::default(),
+        }
+        .get_encoded(),
+        url: task_config.leader_url.join("collect").unwrap(),
+        sender_auth: None, // Unauthorized request.
+    };
 
     // Expect failure due to missing bearer token.
     assert_matches!(
-        leader.http_post_collect(&req).await,
+        t.leader.http_post_collect(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 
     // Expect failure due to incorrect bearer token.
     req.sender_auth = Some(BearerToken::from("incorrect auth token!".to_string()));
     assert_matches!(
-        leader.http_post_collect(&req).await,
+        t.leader.http_post_collect(&req).await,
         Err(DapAbort::UnauthorizedRequest)
     );
 }
 
 #[tokio::test]
 async fn http_post_aggregate_failure_hpke_decrypt_error() {
-    let helper = MockAggregator::new();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+
+    let report = t.gen_test_report(task_id).await;
+    let (metadata, public_share, mut encrypted_input_share) = (
+        report.metadata,
+        report.public_share,
+        report.encrypted_input_shares[1].clone(),
+    );
+    encrypted_input_share.payload[0] ^= 0xff; // Cause decryption to fail
     let report_shares = vec![ReportShare {
-        metadata: ReportMetadata {
-            time: helper.now,
-            nonce: Nonce([1; 16]),
-            extensions: Vec::default(),
-        },
-        public_share: b"public share".to_vec(),
-        encrypted_input_share: HpkeCiphertext {
-            config_id: 23,
-            enc: b"invalid encapsulated key".to_vec(),
-            payload: b"invalid ciphertext".to_vec(),
-        },
+        metadata,
+        public_share,
+        encrypted_input_share,
     }];
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-    let mut req = helper.gen_test_agg_init_req(report_shares);
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_init_req(task_id, report_shares).await;
 
     // Get AggregateResp and then extract the transition data from inside.
     let agg_resp =
-        AggregateResp::get_decoded(&helper.http_post_aggregate(&req).await.unwrap().payload)
+        AggregateResp::get_decoded(&t.helper.http_post_aggregate(&req).await.unwrap().payload)
             .unwrap();
     let transition = &agg_resp.transitions[0];
 
@@ -459,24 +638,21 @@ async fn http_post_aggregate_failure_hpke_decrypt_error() {
 
 #[tokio::test]
 async fn http_post_aggregate_transition_continue() {
-    let helper = MockAggregator::new();
-    let task_id = helper.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let report = helper.gen_test_report(task_id);
+    let report = t.gen_test_report(task_id).await;
     let report_shares = vec![ReportShare {
         metadata: report.metadata.clone(),
         public_share: report.public_share,
         // 1st share is for Leader and the rest is for Helpers (note that there is only 1 helper).
         encrypted_input_share: report.encrypted_input_shares[1].clone(),
     }];
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-
-    let mut req = helper.gen_test_agg_init_req(report_shares);
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_init_req(task_id, report_shares).await;
 
     // Get AggregateResp and then extract the transition data from inside.
     let agg_resp =
-        AggregateResp::get_decoded(&helper.http_post_aggregate(&req).await.unwrap().payload)
+        AggregateResp::get_decoded(&t.helper.http_post_aggregate(&req).await.unwrap().payload)
             .unwrap();
     let transition = &agg_resp.transitions[0];
 
@@ -486,24 +662,21 @@ async fn http_post_aggregate_transition_continue() {
 
 #[tokio::test]
 async fn http_post_aggregate_failure_report_replayed() {
-    let helper = MockAggregator::new();
-    let task_id = helper.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let report = helper.gen_test_report(task_id);
+    let report = t.gen_test_report(task_id).await;
     let report_shares = vec![ReportShare {
         metadata: report.metadata.clone(),
         public_share: report.public_share,
         // 1st share is for Leader and the rest is for Helpers (note that there is only 1 helper).
         encrypted_input_share: report.encrypted_input_shares[1].clone(),
     }];
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-
-    let mut req = helper.gen_test_agg_init_req(report_shares);
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_init_req(task_id, report_shares).await;
 
     // The following scope is to ensure that the report_store lock is released before http_post_aggregate is called.
     {
-        let mut report_store_mutex_guard = helper.report_store.lock().expect("lock() failed");
+        let mut report_store_mutex_guard = t.helper.report_store.lock().expect("lock() failed");
         let report_store = report_store_mutex_guard.deref_mut();
         let mut processed = HashSet::new();
         processed.insert(report.metadata.nonce.clone());
@@ -518,7 +691,7 @@ async fn http_post_aggregate_failure_report_replayed() {
 
     // Get AggregateResp and then extract the transition data from inside.
     let agg_resp =
-        AggregateResp::get_decoded(&helper.http_post_aggregate(&req).await.unwrap().payload)
+        AggregateResp::get_decoded(&t.helper.http_post_aggregate(&req).await.unwrap().payload)
             .unwrap();
     let transition = &agg_resp.transitions[0];
 
@@ -531,25 +704,22 @@ async fn http_post_aggregate_failure_report_replayed() {
 
 #[tokio::test]
 async fn http_post_aggregate_failure_batch_collected() {
-    let helper = MockAggregator::new();
-    let task_id = helper.nominal_task_id();
-    let task_config = helper.tasks.get(task_id).unwrap();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.helper.tasks.get(task_id).unwrap();
 
-    let report = helper.gen_test_report(task_id);
+    let report = t.gen_test_report(task_id).await;
     let report_shares = vec![ReportShare {
         metadata: report.metadata.clone(),
         public_share: report.public_share,
         // 1st share is for Leader and the rest is for Helpers (note that there is only 1 helper).
         encrypted_input_share: report.encrypted_input_shares[1].clone(),
     }];
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-
-    let mut req = helper.gen_test_agg_init_req(report_shares);
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_init_req(task_id, report_shares).await;
 
     // This is to ensure that the lock is released before we call http_post_aggregate.
     {
-        let mut agg_store_mutex_guard = helper.agg_store.lock().expect("lock() failed");
+        let mut agg_store_mutex_guard = t.helper.agg_store.lock().expect("lock() failed");
         let agg_store = agg_store_mutex_guard.deref_mut();
         let bucket_info = BucketInfo::new(task_config, task_id, report.metadata.time);
         let agg_store_state = AggStoreState {
@@ -561,7 +731,7 @@ async fn http_post_aggregate_failure_batch_collected() {
 
     // Get AggregateResp and then extract the transition data from inside.
     let agg_resp =
-        AggregateResp::get_decoded(&helper.http_post_aggregate(&req).await.unwrap().payload)
+        AggregateResp::get_decoded(&t.helper.http_post_aggregate(&req).await.unwrap().payload)
             .unwrap();
     let transition = &agg_resp.transitions[0];
 
@@ -574,26 +744,23 @@ async fn http_post_aggregate_failure_batch_collected() {
 
 #[tokio::test]
 async fn http_post_aggregate_abort_helper_state_overwritten() {
-    let helper = MockAggregator::new();
-    let task_id = helper.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let report = helper.gen_test_report(task_id);
+    let report = t.gen_test_report(task_id).await;
     let report_shares = vec![ReportShare {
         metadata: report.metadata.clone(),
         public_share: report.public_share,
         // 1st share is for Leader and the rest is for Helpers (note that there is only 1 helper).
         encrypted_input_share: report.encrypted_input_shares[1].clone(),
     }];
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-
-    let mut req = helper.gen_test_agg_init_req(report_shares);
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_init_req(task_id, report_shares).await;
 
     // Send aggregate request.
-    let _ = helper.http_post_aggregate(&req).await;
+    let _ = t.helper.http_post_aggregate(&req).await;
 
     // Send another aggregate request.
-    let err = helper.http_post_aggregate(&req).await.unwrap_err();
+    let err = t.helper.http_post_aggregate(&req).await.unwrap_err();
 
     // Expect failure due to overwriting existing helper state.
     assert_matches!(err, DapAbort::BadRequest(e) =>
@@ -603,16 +770,12 @@ async fn http_post_aggregate_abort_helper_state_overwritten() {
 
 #[tokio::test]
 async fn http_post_aggregate_fail_send_cont_req() {
+    let t = Test::new();
     let mut rng = thread_rng();
-    let helper = MockAggregator::new();
-    let leader = MockAggregator::new();
-    let sender_auth = Some(BearerToken::from(LEADER_BEARER_TOKEN.to_string()));
-
-    let mut req = leader.gen_test_agg_cont_req(Id(rng.gen()), Vec::default());
-    req.sender_auth = sender_auth;
+    let req = t.gen_test_agg_cont_req(Id(rng.gen()), Vec::default()).await;
 
     // Send aggregate continue request to helper.
-    let err = helper.http_post_aggregate(&req).await.unwrap_err();
+    let err = t.helper.http_post_aggregate(&req).await.unwrap_err();
 
     // Expect failure due to sending continue request before initialization request.
     assert_matches!(err, DapAbort::UnrecognizedAggregationJob);
@@ -620,34 +783,34 @@ async fn http_post_aggregate_fail_send_cont_req() {
 
 #[tokio::test]
 async fn http_post_upload_fail_send_invalid_report() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
     // Construct a report payload with an invalid task ID.
-    let mut report_empty_task_id = leader.gen_test_report(task_id);
+    let mut report_empty_task_id = t.gen_test_report(task_id).await;
     report_empty_task_id.task_id = Id([0; 32]);
-    let req = leader.gen_test_upload_req(report_empty_task_id);
+    let req = t.gen_test_upload_req(report_empty_task_id);
 
     // Expect failure due to invalid task ID in report.
     assert_matches!(
-        leader.http_post_upload(&req).await,
+        t.leader.http_post_upload(&req).await,
         Err(DapAbort::UnrecognizedTask)
     );
 
     // Construct an invalid report payload that only has one input share.
-    let mut report_one_input_share = leader.gen_test_report(task_id);
+    let mut report_one_input_share = t.gen_test_report(task_id).await;
     report_one_input_share.encrypted_input_shares =
         vec![report_one_input_share.encrypted_input_shares[0].clone()];
-    let req = leader.gen_test_upload_req(report_one_input_share);
+    let req = t.gen_test_upload_req(report_one_input_share);
 
     // Expect failure due to incorrect number of input shares
     assert_matches!(
-        leader.http_post_upload(&req).await,
+        t.leader.http_post_upload(&req).await,
         Err(DapAbort::UnrecognizedMessage)
     );
 
     // Construct an invalid report payload that has an incorrect order of input shares.
-    let mut report_incorrect_share_order = leader.gen_test_report(task_id);
+    let mut report_incorrect_share_order = t.gen_test_report(task_id).await;
     report_incorrect_share_order.encrypted_input_shares = vec![
         HpkeCiphertext {
             config_id: 1,
@@ -661,25 +824,25 @@ async fn http_post_upload_fail_send_invalid_report() {
         },
     ];
 
-    let req = leader.gen_test_upload_req(report_incorrect_share_order);
+    let req = t.gen_test_upload_req(report_incorrect_share_order);
 
     // Expect failure due to incorrect number of input shares
     assert_matches!(
-        leader.http_post_upload(&req).await,
+        t.leader.http_post_upload(&req).await,
         Err(DapAbort::UnrecognizedHpkeConfig)
     );
 }
 
 #[tokio::test]
 async fn get_reports_empty_response() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let report = leader.gen_test_report(task_id);
-    let req = leader.gen_test_upload_req(report.clone());
+    let report = t.gen_test_report(task_id).await;
+    let req = t.gen_test_upload_req(report.clone());
 
     // Upload report.
-    leader
+    t.leader
         .http_post_upload(&req)
         .await
         .expect("upload failed unexpectedly");
@@ -691,45 +854,45 @@ async fn get_reports_empty_response() {
         task_id: task_id.clone(),
         agg_rate: 1,
     };
-    let (returned_task_id, reports) = get_reports!(leader, selector);
+    let (returned_task_id, reports) = get_reports!(t.leader, selector);
     assert_eq!(reports.len(), 1);
     assert_eq!(&returned_task_id, task_id);
 
     // Try to get another report. This should not return an error, but simply
     // an empty vector, as we drained the ReportStore above. The task ID
     // associated to the report should be the same one we requested.
-    let (returned_task_id, reports) = get_reports!(leader, selector);
+    let (returned_task_id, reports) = get_reports!(t.leader, selector);
     assert_eq!(reports.len(), 0);
     assert_eq!(&returned_task_id, task_id);
 }
 
 #[tokio::test]
 async fn poll_collect_job_test_results() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: task_config.query_for_current_batch_window(leader.now),
-        agg_param: Vec::default(),
-    };
     let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+    let req = t
+        .collector_authorized_req(
+            version,
+            MEDIA_TYPE_COLLECT_REQ,
+            CollectReq {
+                task_id: task_id.clone(),
+                query: task_config.query_for_current_batch_window(t.now),
+                agg_param: Vec::default(),
+            },
+            task_config.helper_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    leader.http_post_collect(&req).await.unwrap();
+    t.leader.http_post_collect(&req).await.unwrap();
 
     // Expect DapCollectJob::Unknown due to invalid collect ID.
     assert_eq!(
-        leader
+        t.leader
             .poll_collect_job(task_id, &Id::default())
             .await
             .unwrap(),
@@ -737,7 +900,7 @@ async fn poll_collect_job_test_results() {
     );
 
     // Leader: Get pending collect job to obtain collect_id
-    let resp = leader.get_pending_collect_jobs().await.unwrap();
+    let resp = t.leader.get_pending_collect_jobs().await.unwrap();
     let (collect_id, _collect_req) = &resp[0];
     let collect_resp = CollectResp {
         report_count: 0,
@@ -746,109 +909,112 @@ async fn poll_collect_job_test_results() {
 
     // Expect DapCollectJob::Pending due to pending collect job.
     assert_eq!(
-        leader.poll_collect_job(task_id, &collect_id).await.unwrap(),
+        t.leader
+            .poll_collect_job(task_id, &collect_id)
+            .await
+            .unwrap(),
         DapCollectJob::Pending
     );
 
     // Leader: Complete the collect job by storing CollectResp in LeaderStore.processed.
-    leader
+    t.leader
         .finish_collect_job(&task_id, &collect_id, &collect_resp)
         .await
         .unwrap();
 
     // Expect DapCollectJob::Done due to processed collect job.
     assert_matches!(
-        leader.poll_collect_job(task_id, &collect_id).await.unwrap(),
+        t.leader
+            .poll_collect_job(task_id, &collect_id)
+            .await
+            .unwrap(),
         DapCollectJob::Done(..)
     );
 }
 
 #[tokio::test]
 async fn http_post_collect_fail_invalid_batch_interval() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
-    let now = leader.now;
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq with a very large batch interval.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: Query::TimeInterval {
-            batch_interval: Interval {
-                start: now - (now % task_config.time_precision),
-                duration: leader.global_config.max_batch_duration + task_config.time_precision,
+    let req = t
+        .collector_authorized_req(
+            task_config.version,
+            MEDIA_TYPE_COLLECT_REQ,
+            CollectReq {
+                task_id: task_id.clone(),
+                query: Query::TimeInterval {
+                    batch_interval: Interval {
+                        start: t.now - (t.now % task_config.time_precision),
+                        duration: t.leader.global_config.max_batch_duration
+                            + task_config.time_precision,
+                    },
+                },
+                agg_param: Vec::default(),
             },
-        },
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+            task_config.helper_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    let err = leader.http_post_collect(&req).await.unwrap_err();
+    let err = t.leader.http_post_collect(&req).await.unwrap_err();
 
     // Fails because the requested batch interval is too large.
     assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too large".to_string()));
 
     // Collector: Create a CollectReq with a batch interval in the past.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: Query::TimeInterval {
-            batch_interval: Interval {
-                start: now
-                    - (now % task_config.time_precision)
-                    - leader.global_config.min_batch_interval_start
-                    - task_config.time_precision,
-                duration: task_config.time_precision * 2,
+    let req = t
+        .collector_authorized_req(
+            task_config.version,
+            MEDIA_TYPE_COLLECT_REQ,
+            CollectReq {
+                task_id: task_id.clone(),
+                query: Query::TimeInterval {
+                    batch_interval: Interval {
+                        start: t.now
+                            - (t.now % task_config.time_precision)
+                            - t.leader.global_config.min_batch_interval_start
+                            - task_config.time_precision,
+                        duration: task_config.time_precision * 2,
+                    },
+                },
+                agg_param: Vec::default(),
             },
-        },
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+            task_config.helper_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    let err = leader.http_post_collect(&req).await.unwrap_err();
+    let err = t.leader.http_post_collect(&req).await.unwrap_err();
 
     // Fails because the requested batch interval is too far into the past.
     assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too far into past".to_string()));
 
     // Collector: Create a CollectReq with a batch interval in the future.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: Query::TimeInterval {
-            batch_interval: Interval {
-                start: now - (now % task_config.time_precision)
-                    + leader.global_config.max_batch_interval_end
-                    - task_config.time_precision,
-                duration: task_config.time_precision * 2,
+    let req = t
+        .collector_authorized_req(
+            task_config.version,
+            MEDIA_TYPE_COLLECT_REQ,
+            CollectReq {
+                task_id: task_id.clone(),
+                query: Query::TimeInterval {
+                    batch_interval: Interval {
+                        start: t.now - (t.now % task_config.time_precision)
+                            + t.leader.global_config.max_batch_interval_end
+                            - task_config.time_precision,
+                        duration: task_config.time_precision * 2,
+                    },
+                },
+                agg_param: Vec::default(),
             },
-        },
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+            task_config.leader_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    let err = leader.http_post_collect(&req).await.unwrap_err();
+    let err = t.leader.http_post_collect(&req).await.unwrap_err();
 
     // Fails because the requested batch interval is too far into the future.
     assert_matches!(err, DapAbort::BadRequest(s) => assert_eq!(s, "batch interval too far into future".to_string()));
@@ -856,128 +1022,89 @@ async fn http_post_collect_fail_invalid_batch_interval() {
 
 #[tokio::test]
 async fn http_post_collect_succeed_max_batch_interval() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
-    let now = leader.now;
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq with a very large batch interval.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: Query::TimeInterval {
-            batch_interval: Interval {
-                start: now
-                    - (now % task_config.time_precision)
-                    - leader.global_config.max_batch_duration / 2,
-                duration: leader.global_config.max_batch_duration,
+    let req = t
+        .collector_authorized_req(
+            task_config.version,
+            MEDIA_TYPE_COLLECT_REQ,
+            CollectReq {
+                task_id: task_id.clone(),
+                query: Query::TimeInterval {
+                    batch_interval: Interval {
+                        start: t.now
+                            - (t.now % task_config.time_precision)
+                            - t.leader.global_config.max_batch_duration / 2,
+                        duration: t.leader.global_config.max_batch_duration,
+                    },
+                },
+                agg_param: Vec::default(),
             },
-        },
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+            task_config.leader_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    let _collect_uri = leader.http_post_collect(&req).await.unwrap();
+    let _collect_uri = t.leader.http_post_collect(&req).await.unwrap();
 }
 
 // Send a collect request with an overlapping batch interval.
 #[tokio::test]
 async fn http_post_collect_fail_overlapping_batch_interval() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
-    let helper = MockAggregator::new();
-    let now = leader.now;
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Create a report.
-    let report = leader.gen_test_report(task_id);
-    let req = leader.gen_test_upload_req(report.clone());
+    let report = t.gen_test_report(task_id).await;
+    let req = t.gen_test_upload_req(report.clone());
 
     // Client: Send upload request to Leader.
-    leader.http_post_upload(&req).await.unwrap();
+    t.leader.http_post_upload(&req).await.unwrap();
 
     // Leader: Run aggregation job.
-    leader.run_test_agg_job(&helper, task_id, task_config).await;
+    t.run_agg_job(task_id).await.unwrap();
 
-    // Collector: Create first CollectReq.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: task_config.query_for_current_batch_window(now),
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+    // Run first collect job (expect success).
+    let query = task_config.query_for_current_batch_window(t.now);
+    t.run_col_job(task_id, &query).await.unwrap();
 
-    // Leader: Handle the CollectReq received from Collector.
-    let _url = leader.http_post_collect(&req).await.unwrap();
-    let resp = leader.get_pending_collect_jobs().await.unwrap();
-    let (collect_id, collect_req) = &resp[0];
-
-    // Leader: Run collect job.
-    leader
-        .run_test_col_job(task_id, collect_id, collect_req, task_config)
-        .await;
-
-    // Collector: Create second CollectReq.
-    let collector_collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: task_config.query_for_current_batch_window(now),
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
-
-    // Leader: Handle the CollectReq received from Collector.
-    // Fails due to batch interval overlapping.
-    let err = leader.http_post_collect(&req).await.unwrap_err();
-    assert_matches!(err, DapAbort::BatchOverlap);
+    // run a second collect job (expect failure due to overlapping batch).
+    assert_matches!(
+        t.run_col_job(task_id, &query).await.unwrap_err(),
+        DapAbort::BatchOverlap
+    );
 }
 
 // Test a successful collect request submission.
 // This checks that the Leader reponds with the collect ID with the ID associated to the request.
 #[tokio::test]
 async fn http_post_collect_success() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Collector: Create a CollectReq.
     let collector_collect_req = CollectReq {
         task_id: task_id.clone(),
-        query: task_config.query_for_current_batch_window(leader.now),
+        query: task_config.query_for_current_batch_window(t.now),
         agg_param: Vec::default(),
     };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collector_collect_req.get_encoded(),
-        url: task_config.leader_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
+    let req = t
+        .collector_authorized_req(
+            task_config.version,
+            MEDIA_TYPE_COLLECT_REQ,
+            collector_collect_req.clone(),
+            task_config.leader_url.join("collect").unwrap(),
+        )
+        .await;
 
     // Leader: Handle the CollectReq received from Collector.
-    let url = leader.http_post_collect(&req).await.unwrap();
-    let resp = leader.get_pending_collect_jobs().await.unwrap();
+    let url = t.leader.http_post_collect(&req).await.unwrap();
+    let resp = t.leader.get_pending_collect_jobs().await.unwrap();
     let (leader_collect_id, leader_collect_req) = &resp[0];
 
     // Check that the CollectReq sent by Collector is the same that is received by Leader.
@@ -1001,83 +1128,56 @@ async fn http_post_collect_success() {
 // Test HTTP POST requests with a wrong DAP version.
 #[tokio::test]
 async fn http_post_fail_wrong_dap_version() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
+    let task_config = t.leader.tasks.get(task_id).unwrap();
 
     // Send a request with the wrong DAP version.
-    let report = leader.gen_test_report(task_id);
-    let mut req = leader.gen_test_upload_req(report);
+    let report = t.gen_test_report(task_id).await;
+    let mut req = t.gen_test_upload_req(report);
     req.version = DapVersion::Unknown;
     req.url = task_config.leader_url.join("upload").unwrap();
 
-    let err = leader.http_post_upload(&req).await.unwrap_err();
+    let err = t.leader.http_post_upload(&req).await.unwrap_err();
     assert_matches!(err, DapAbort::InvalidProtocolVersion);
 }
 
 // Test the upload sub-protocol.
 #[tokio::test]
 async fn successful_http_post_upload() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let report = leader.gen_test_report(task_id);
-    let req = leader.gen_test_upload_req(report);
+    let report = t.gen_test_report(task_id).await;
+    let req = t.gen_test_upload_req(report);
 
-    leader
+    t.leader
         .http_post_upload(&req)
         .await
         .expect("upload failed unexpectedly");
 }
 
 // Test the end-to-end protocol.
-// TODO(nakatsuka-y) Implement the rest of the e2e functionality.
 #[tokio::test]
 async fn e2e() {
-    let leader = MockAggregator::new();
-    let task_id = leader.nominal_task_id();
-    let task_config = leader.tasks.get(task_id).unwrap();
+    let t = Test::new();
+    let task_id = &t.time_interval_task_id;
 
-    let helper = MockAggregator::new();
-
-    let report = leader.gen_test_report(task_id);
-    let req = leader.gen_test_upload_req(report.clone());
+    let report = t.gen_test_report(task_id).await;
+    let req = t.gen_test_upload_req(report);
 
     // Client: Send upload request to Leader.
-    leader.http_post_upload(&req).await.unwrap();
+    t.leader.http_post_upload(&req).await.unwrap();
 
     // Leader: Run aggregation job.
-    leader.run_test_agg_job(&helper, task_id, task_config).await;
+    t.run_agg_job(task_id).await.unwrap();
 
-    // Collector: Create a CollectReq.
-    let collect_req = CollectReq {
-        task_id: task_id.clone(),
-        query: task_config.query_for_current_batch_window(leader.now),
-        agg_param: Vec::default(),
-    };
-    let version = task_config.version.clone();
-    let req = DapRequest {
-        version,
-        media_type: Some(MEDIA_TYPE_COLLECT_REQ),
-        payload: collect_req.get_encoded(),
-        url: task_config.helper_url.join("collect").unwrap(),
-        sender_auth: Some(BearerToken::from(COLLECTOR_BEARER_TOKEN.to_string())),
-    };
-
-    // Leader: Handle the CollectReq received from Collector.
-    leader.http_post_collect(&req).await.unwrap();
-    let resp = leader.get_pending_collect_jobs().await.unwrap();
-    let (collect_id, collect_req) = &resp[0];
-
-    // Leader: Run collect job.
-    leader
-        .run_test_col_job(task_id, collect_id, collect_req, task_config)
-        .await;
-
-    // Leader: Respond to poll request from Collector.
-    let collect_job = leader
-        .poll_collect_job(&task_id, &collect_id)
-        .await
-        .unwrap();
-    assert_matches!(collect_job, DapCollectJob::Done(..))
+    // Collector: Create collection job and poll result.
+    let query = t
+        .leader
+        .tasks
+        .get(task_id)
+        .unwrap()
+        .query_for_current_batch_window(t.now);
+    t.run_col_job(task_id, &query).await.unwrap();
 }


### PR DESCRIPTION
Partially addresses #100.
Based on #129 (merge that first).

In preparation for adding support for "fixed_size" queries, refactor the test framework in roles_test.rs to make it easier to define per-test task configurations. The main limitation of the current test code is that the task list is hard-coded. By generating it at runtime we can more easily define a set tasks that we want our code to cover.

This change also addresses another important limitation. All code used to simulate interactions between the various parties is implemented on `MockAggregator`. This makes testing quite awkward, particularly when the parties need to share artifacts from dynamically generated tasks. To address this, a struct `Test` is defined which stores all of the artifacts associated with a logical "deployment".