### PR TITLE
daphne: Check for query mismatch

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -113,6 +113,10 @@ pub enum DapAbort {
     #[error("badRequest")]
     BadRequest(String),
 
+    /// Invalid batch. Sent in response to a CollectReq or AggregateShareReq.
+    #[error("batchInvalid")]
+    BatchInvalid,
+
     /// Batch mismatch. Sent in response to an AggregateShareReq.
     #[error("batchMismatch")]
     BatchMismatch,
@@ -126,10 +130,6 @@ pub enum DapAbort {
     #[error("internalError: {0}")]
     Internal(#[source] Box<dyn std::error::Error + 'static + Send + Sync>),
 
-    /// Invalid batch interval. Sent in response to a CollectReq or AggregateShareReq.
-    #[error("invalidBatchInterval")]
-    InvalidBatchInterval,
-
     /// Invalid DAP version. Sent in response to requests for an unsupported (or unknown) DAP version.
     #[error("invalidProtocolVersion")]
     InvalidProtocolVersion,
@@ -142,6 +142,10 @@ pub enum DapAbort {
     /// Request with missing task ID.
     #[error("missingTaskID")]
     MissingTaskId,
+
+    /// Query mismatch. Sent in response to a CollectReq or AggregateShareReq.
+    #[error("queryMismatch")]
+    QueryMismatch,
 
     /// Replayed report. Sent in response to an upload request containing a Report that has been replayed.
     //
@@ -184,11 +188,12 @@ impl DapAbort {
     /// request was targeted and `task_id` is the associated TaskID.
     pub fn to_problem_details(&self) -> ProblemDetails {
         let (typ, detail) = match self {
-            Self::BatchMismatch
+            Self::BatchInvalid
+            | Self::BatchMismatch
             | Self::BatchOverlap
-            | Self::InvalidBatchInterval
             | Self::InvalidProtocolVersion
             | Self::InvalidBatchSize
+            | Self::QueryMismatch
             | Self::MissingTaskId
             | Self::ReplayedReport
             | Self::StaleReport

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -3,7 +3,6 @@
 
 //! Messages in the DAP protocol.
 
-use crate::DapTaskConfig;
 use prio::codec::{
     decode_u16_items, decode_u32_items, encode_u16_items, encode_u32_items, CodecError, Decode,
     Encode,
@@ -442,17 +441,6 @@ impl Interval {
     /// Return the end of the interval, i.e., `self.start + self.duration`.
     pub fn end(&self) -> Time {
         self.start + self.duration
-    }
-
-    /// Check that the batch interval is valid for the given task configuration.
-    pub fn is_valid_for(&self, task_config: &DapTaskConfig) -> bool {
-        if self.start % task_config.time_precision != 0
-            || self.duration % task_config.time_precision != 0
-            || self.duration < task_config.time_precision
-        {
-            return false;
-        }
-        true
     }
 }
 

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -582,7 +582,7 @@ async fn e2e_leader_collect_abort_invalid_batch_interval() {
         constants::MEDIA_TYPE_COLLECT_REQ,
         collect_req.get_encoded(),
         400,
-        "invalidBatchInterval",
+        "batchInvalid",
     )
     .await;
 
@@ -604,7 +604,7 @@ async fn e2e_leader_collect_abort_invalid_batch_interval() {
         constants::MEDIA_TYPE_COLLECT_REQ,
         collect_req.get_encoded(),
         400,
-        "invalidBatchInterval",
+        "batchInvalid",
     )
     .await;
 }


### PR DESCRIPTION
Partially addresses #100.
Based on #130 (merge that first).

Ensure all requests that encode a query type assert that the correct query type is indicated. Along the way, refactor the batch validation logic so that the Leader and Helper use more of the same code.

In addition, rename "invalidBatchInterval" to "batchInvalid".