### PR TITLE
Prepare `MockAggregator` for fixed-size query tasks

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -404,10 +404,10 @@ pub struct DapTaskConfig {
     pub(crate) collector_hpke_config: HpkeConfig,
 }
 
-#[cfg(test)]
 impl DapTaskConfig {
     /// Convert at timestamp `now` into an [`Interval`] that contains it. The timestamp is the
     /// numbre of seconds since the beginning of UNIX time.
+    #[cfg(test)]
     pub fn query_for_current_batch_window(&self, now: u64) -> crate::messages::Query {
         let start = now - (now % self.time_precision);
         crate::messages::Query::TimeInterval {
@@ -416,6 +416,10 @@ impl DapTaskConfig {
                 duration: self.time_precision,
             },
         }
+    }
+
+    pub(crate) fn truncate_time(&self, time: Time) -> Time {
+        time - (time % self.time_precision)
     }
 }
 

--- a/daphne/src/messages.rs
+++ b/daphne/src/messages.rs
@@ -430,7 +430,7 @@ impl Decode for AggregateResp {
 }
 
 /// A batch interval.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[allow(missing_docs)]
 pub struct Interval {
     pub start: Time,
@@ -461,7 +461,7 @@ impl Decode for Interval {
 }
 
 /// A query issued by the Collector in a collect request.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Query {
     TimeInterval { batch_interval: Interval },


### PR DESCRIPTION
Partially addresses #100.
Based on #131 (merge that first).

Extend `MockAggregator`'s data stores so that data can be bucketed by batch ID and not just by batch window. Along the way, simplify some of the mutex code.