### PR TITLE
daphne_worker: Generalize KV caching logic

### DIFF
--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -31,7 +31,7 @@ bindings = [
 ]
 
 [[kv_namespaces]]
-  binding = "DAP_HPKE_RECEIVER_CONFIG_STORE"
+  binding = "DAP_CONFIG"
   id = "<ignored>"
   preview_id = "<ignored>"
 


### PR DESCRIPTION
Partially addresses #138.
Based on #137 (merge that first).

HPKE configs are stored in KV, however they're cached in memory so that we can avoid fetching from KV multiple times per request. In order to implement draft-dcook-ppm-dap-interop-test-design-02 we will need to store task configs in KV as well.

In preparation for this change, generalize the underlying caching so logic so that it can be reused for tasks.