### PR TITLE
daphne_worker: Implement /internal/test/ready

### DIFF
--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -343,6 +343,10 @@ impl DaphneWorkerRouter {
                         Err(e) => abort(e.into()),
                     }
                 })
+                // Endpoints for draft-dcook-ppm-dap-interop-test-design-02
+                .post_async("/internal/test/ready", |_req, _ctx| async move {
+                    Response::from_json(&())
+                })
                 .post_async("/internal/test/add_task", |mut req, ctx| async move {
                     let config = DaphneWorkerConfig::from_worker_context(ctx)?;
                     let cmd: InternalTestAddTask = req.json().await?;

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -20,6 +20,20 @@ use test_runner::TestRunner;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "test_e2e"), ignore)]
+async fn e2e_leader_ready() {
+    let t = TestRunner::default().await;
+    t.leader_post_internal("/internal/test/ready", &()).await;
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "test_e2e"), ignore)]
+async fn e2e_helper_ready() {
+    let t = TestRunner::default().await;
+    t.helper_post_internal("/internal/test/ready", &()).await;
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "test_e2e"), ignore)]
 async fn e2e_leader_hpke_config() {
     let t = TestRunner::default().await;
     let client = t.http_client();


### PR DESCRIPTION
Partially addresses #138.
Based on #153 (merge that first).