### PR TITLE
Update Dockerfile, fix tests in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ The `daphne` crate relies on unit tests. The `daphne_worker` crate relies mostly
 on integration tests implemented in `daphne_worker_test`. See the README in that
 directory for instructions on running Daphne-Worker locally.
 
-> NOTE Integration tests can be run via docker-compose, but this is not working
-> at the moment.
+Integration tests can be run via docker-compose.
 
 ```
 docker-compose up --build --abort-on-container-exit --exit-code-from test

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -68,6 +68,8 @@ pub(crate) struct DaphneWorkerConfig<D> {
     tasks: Arc<RwLock<HashMap<Id, DapTaskConfig>>>,
 
     /// Deployment type. This controls certain behavior overrides relevant to specific deployments.
+    #[allow(unused)]
+    // No overrides have been defined yet, but this will be used in the future.
     pub(crate) deployment: DaphneWorkerDeployment,
 
     /// Sharding key, used to compute the ReportsPending or ReportsProcessed shard to map a report
@@ -124,7 +126,6 @@ impl<D> DaphneWorkerConfig<D> {
 
         let deployment = if let Ok(deployment) = ctx.var("DAP_DEPLOYMENT") {
             match deployment.to_string().as_str() {
-                "dev" => DaphneWorkerDeployment::Dev,
                 "prod" => DaphneWorkerDeployment::Prod,
                 s => {
                     return Err(Error::RustError(format!(
@@ -617,10 +618,6 @@ impl AsRef<DapTaskConfig> for GuardedDapTaskConfig<'_> {
 /// communication.
 #[derive(Debug, Default)]
 pub(crate) enum DaphneWorkerDeployment {
-    /// Daphne-Worker is running in a local development environment. In this setting, the hostname
-    /// of the Leader and Helper URLs are overwritten with localhost.
-    Dev,
-
     /// Daphne-Worker is running in a production environment. No behavior overrides are applied.
     #[default]
     Prod,

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     config::{
-        DaphneWorkerConfig, DaphneWorkerDeployment, GuardedBearerToken, GuardedDapTaskConfig,
-        GuardedHpkeReceiverConfig, KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG,
+        DaphneWorkerConfig, GuardedBearerToken, GuardedDapTaskConfig, GuardedHpkeReceiverConfig,
+        KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG,
     },
     dap_err,
     durable::{
@@ -660,17 +660,7 @@ where
             .await
             .map_err(dap_err)?;
 
-        let mut url = task_config.as_ref().leader_url.clone();
-        if matches!(self.deployment, DaphneWorkerDeployment::Dev) {
-            // When running in a local development environment, override the hostname of the Leader
-            // with localhost.
-            url.set_host(Some("127.0.0.1")).map_err(|e| {
-                DapError::Fatal(format!(
-                    "failed to overwrite hostname for request URL: {}",
-                    e
-                ))
-            })?;
-        }
+        let url = task_config.as_ref().leader_url.clone();
 
         let collect_uri = url
             .join(&format!(
@@ -752,18 +742,7 @@ where
         &self,
         req: DapRequest<BearerToken>,
     ) -> std::result::Result<DapResponse, DapError> {
-        let (payload, mut url) = (req.payload, req.url);
-
-        // When running in a local development environment, override the hostname of the Helper
-        // with localhost.
-        if matches!(self.deployment, DaphneWorkerDeployment::Dev) {
-            url.set_host(Some("127.0.0.1")).map_err(|e| {
-                DapError::Fatal(format!(
-                    "failed to overwrite hostname for request URL: {}",
-                    e
-                ))
-            })?;
-        }
+        let (payload, url) = (req.payload, req.url);
 
         let mut headers = reqwest_wasm::header::HeaderMap::new();
         if let Some(content_type) = req.media_type {

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -148,7 +148,7 @@
 //! | `DAP_AGGREGATOR_ROLE` | `String` | no | Aggregator role, either "leader" or "helper". |
 //! | `DAP_COLLECT_ID_KEY` | `String` | yes | Hex-encoded key used to derive the collection job ID from the collect request |
 //! | `DAP_GLOBAL_CONFIG` | [`DapGlobalConfig`](daphne::DapGlobalConfig) | no | DAP global config. |
-//! | `DAP_DEPLOYMENT` | `String` | no | Deployment type, either "prod" or "dev". |
+//! | `DAP_DEPLOYMENT` | `String` | no | Deployment type, only "prod" for now. |
 //! | `DAP_REPORT_SHARD_COUNT` | `u64` | no | Number of report shards per storage epoch. |
 //! | `DAP_REPORT_SHARD_KEY` | `String` | yes | Hex-encoded key used to hash a report into one of the report shards. |
 use crate::{config::DaphneWorkerConfig, dap::dap_response_to_worker};

--- a/daphne_worker_test/docker/miniflare.Dockerfile
+++ b/daphne_worker_test/docker/miniflare.Dockerfile
@@ -1,27 +1,27 @@
 FROM rust:1.63-alpine AS builder
 WORKDIR /tmp/dap_test
 RUN apk add --update npm bash g++ openssl-dev
-RUN npm install -g n && \
+RUN npm install -g n wasm-pack && \
     n 18.4.0
-RUN npm install -g \
-        @cloudflare/wrangler \
-        wasm-pack \
-        miniflare@2.5.1
+RUN npm install -g wrangler@2.1.13
+
+# Pre-install worker-build and Rust's wasm32 target to speed up our custom build command
+RUN cargo install --git https://github.com/cloudflare/workers-rs
+RUN rustup target add wasm32-unknown-unknown
+
 COPY Cargo.toml Cargo.lock ./
 COPY daphne_worker_test ./daphne_worker_test
 COPY daphne_worker ./daphne_worker
 COPY daphne ./daphne
 WORKDIR /tmp/dap_test/daphne_worker_test
-RUN wrangler build
+RUN wrangler publish --dry-run
 
 FROM alpine:3.16
 RUN apk add --update npm bash
 RUN npm install -g n && \
     n 18.4.0
-RUN npm install -g miniflare@2.5.1
-COPY daphne_worker_test/leader.env /leader.env
-COPY daphne_worker_test/helper.env /helper.env
+RUN npm install -g miniflare@2.11.0
 COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
 COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
 # `-B ""` to skip build command.
-ENTRYPOINT ["miniflare", "-B", ""]
+ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", ""]

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -67,8 +67,8 @@ impl TestRunner {
 
         // When running in a local development environment, override the hostname of each
         // aggregator URL with 127.0.0.1.
-        let mut leader_url = Url::parse("http://127.0.0.1:8787/v02/").unwrap();
-        let mut helper_url = Url::parse("http://127.0.0.1:8788/v02/").unwrap();
+        let mut leader_url = Url::parse("http://leader:8787/v02/").unwrap();
+        let mut helper_url = Url::parse("http://helper:8788/v02/").unwrap();
         if let Ok(env) = std::env::var("DAP_DEPLOYMENT") {
             if env == "dev" {
                 leader_url.set_host(Some("127.0.0.1")).unwrap();

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -1,3 +1,4 @@
+name = "daphne_worker_test"
 main = "build/worker/shim.mjs"
 compatibility_date = "2022-10-14"
 
@@ -19,7 +20,6 @@ fallthrough = false
 # production. In particular, they will not be passed as environment variables
 # as they are here. See
 # https://developers.cloudflare.com/workers/wrangler/commands/#secret.
-DAP_DEPLOYMENT = "dev"
 DAP_AGGREGATOR_ROLE = "leader"
 DAP_BASE_URL = "http://127.0.0.1:8787/v02/"
 DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
@@ -63,7 +63,6 @@ preview_id = "<ignored>" # TODO(cjpatton) Figure out how to pick this.
 # production. In particular, they will not be passed as environment variables
 # as they are here. See
 # https://developers.cloudflare.com/workers/wrangler/commands/#secret.
-DAP_DEPLOYMENT = "dev"
 DAP_AGGREGATOR_ROLE = "helper"
 DAP_BASE_URL = "http://127.0.0.1:8788/v02/"
 DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       context: .
       dockerfile: daphne_worker_test/docker/miniflare.Dockerfile
     command:
-      - "--env=leader.env"
+      - "--wrangler-env=leader"
       - "--port=8787"
       - "--global-random"
   helper:
@@ -27,7 +27,7 @@ services:
       context: .
       dockerfile: daphne_worker_test/docker/miniflare.Dockerfile
     command:
-      - "--env=helper.env"
+      - "--wrangler-env=helper"
       - "--port=8788"
       - "--global-random"
   test:


### PR DESCRIPTION
This updates the Dockerfile to accommodate the upgrade to Wrangler v2, and fixes the hostnames used in tests in a few places. I fixed the tests by deleting a few things that were overwriting URL hosts with `127.0.0.1`. As part of this, I deleted the last use of `DAP_DEPLOYMENT` in the aggregator. Now, `DAP_DEPLOYMENT` is only used as a plain environment variable in the host-targeted side of end-to-end tests.

I checked that the main test suite passes and the end-to-end test suite passes when run either locally or in docker-compose.