### PR TITLE
/internal/test/add_task: Make "bits" a string

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -427,7 +427,10 @@ impl<D> DaphneWorkerConfig<D> {
         // VDAF config.
         let vdaf = match (cmd.vdaf.typ.as_ref(), cmd.vdaf.bits) {
             ("Prio3Aes128Count", None) => VdafConfig::Prio3(Prio3Config::Count),
-            ("Prio3Aes128Sum", Some(bits)) => VdafConfig::Prio3(Prio3Config::Sum { bits }),
+            ("Prio3Aes128Sum", Some(bits)) => {
+                let bits = bits.parse().map_err(int_err)?;
+                VdafConfig::Prio3(Prio3Config::Sum { bits })
+            }
             _ => return Err(int_err("command failed: unrecognized VDAF")),
         };
 

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -426,7 +426,7 @@ pub(crate) struct InternalTestVdaf {
     #[serde(rename = "type")]
     typ: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    bits: Option<u32>,
+    bits: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -129,7 +129,10 @@ impl TestRunner {
 
         let vdaf = json!({
             "type": "Prio3Aes128Sum",
-            "bits": assert_matches!(t.task_config.vdaf, VdafConfig::Prio3(Prio3Config::Sum{ bits }) => bits),
+            "bits": assert_matches!(
+                t.task_config.vdaf,
+                VdafConfig::Prio3(Prio3Config::Sum{ bits }) => format!("{bits}")
+            ),
         });
 
         let (query_type, max_batch_size) = match t.task_config.query {


### PR DESCRIPTION
This updates `/internal/test/add_task` to take a string at the path `.vdaf.bits` inside the request body. See [Table 1](https://divergentdave.github.io/draft-dcook-ppm-dap-interop-test-design/draft-dcook-ppm-dap-interop-test-design.html#table-1) for reference.