### PR TITLE
/internal/test/add_task: Return status in response

### DIFF
--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -359,7 +359,9 @@ impl DaphneWorkerRouter {
                     let config = DaphneWorkerConfig::from_worker_context(ctx)?;
                     let cmd: InternalTestAddTask = req.json().await?;
                     config.internal_add_task(cmd).await?;
-                    Response::from_json(&())
+                    Response::from_json(&serde_json::json!({
+                        "status": "success",
+                    }))
                 })
         } else {
             router

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -58,7 +58,11 @@ async fn e2e_leader_endpoint_for_task() {
             }),
         )
         .await;
-    assert_eq!(res.status, "success");
+    assert_eq!(
+        res.status, "success",
+        "response status: {}, error: {:?}",
+        res.status, res.error
+    );
     assert_eq!(res.endpoint.unwrap(), "/v02/");
 }
 
@@ -75,7 +79,11 @@ async fn e2e_helper_endpoint_for_task() {
             }),
         )
         .await;
-    assert_eq!(res.status, "success");
+    assert_eq!(
+        res.status, "success",
+        "response status: {}, error: {:?}",
+        res.status, res.error
+    );
     assert_eq!(res.endpoint.unwrap(), "/v02/");
 }
 

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -28,6 +28,13 @@ const MIN_BATCH_SIZE: u64 = 10;
 const MAX_BATCH_SIZE: u64 = 12;
 const TIME_PRECISION: Duration = 3600; // seconds
 
+#[derive(Deserialize)]
+struct InternalTestAddTaskResult {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
 #[allow(dead_code)]
 pub struct TestRunner {
     pub global_config: DapGlobalConfig,
@@ -162,8 +169,14 @@ impl TestRunner {
             "collector_hpke_config": collector_hpke_config_base64url.clone(),
             "task_expiration": t.task_config.expiration,
         });
-        t.leader_post_internal::<_, ()>("/internal/test/add_task", &leader_add_task_cmd)
+        let res: InternalTestAddTaskResult = t
+            .leader_post_internal("/internal/test/add_task", &leader_add_task_cmd)
             .await;
+        assert_eq!(
+            res.status, "success",
+            "response status: {}, error: {:?}",
+            res.status, res.error
+        );
 
         // Configure the Helper with the task.
         let helper_add_task_cmd = json!({
@@ -181,8 +194,14 @@ impl TestRunner {
             "collector_hpke_config": collector_hpke_config_base64url.clone(),
             "task_expiration": t.task_config.expiration,
         });
-        t.helper_post_internal::<_, ()>("/internal/test/add_task", &helper_add_task_cmd)
+        let res: InternalTestAddTaskResult = t
+            .helper_post_internal("/internal/test/add_task", &helper_add_task_cmd)
             .await;
+        assert_eq!(
+            res.status, "success",
+            "response status: {}, error: {:?}",
+            res.status, res.error
+        );
 
         t
     }


### PR DESCRIPTION
This returns a success status in the response object returned from the `/internal/test/add_task` handler, and fleshes out uses of response objects in the end-to-end tests. (see [Table 8](https://divergentdave.github.io/draft-dcook-ppm-dap-interop-test-design/draft-dcook-ppm-dap-interop-test-design.html#table-8))