### PR TITLE
/internal/test/endpoint_for_task: Relative URL

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -413,7 +413,7 @@ impl<D> DaphneWorkerConfig<D> {
 
         Response::from_json(&serde_json::json!({
             "status": "success",
-            "endpoint": self.base_url,
+            "endpoint": self.base_url.path(),
         }))
     }
 

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -59,7 +59,7 @@ async fn e2e_leader_endpoint_for_task() {
         )
         .await;
     assert_eq!(res.status, "success");
-    assert_eq!(res.endpoint.unwrap(), "http://127.0.0.1:8787/v02/");
+    assert_eq!(res.endpoint.unwrap(), "/v02/");
 }
 
 #[tokio::test]
@@ -76,7 +76,7 @@ async fn e2e_helper_endpoint_for_task() {
         )
         .await;
     assert_eq!(res.status, "success");
-    assert_eq!(res.endpoint.unwrap(), "http://127.0.0.1:8788/v02/");
+    assert_eq!(res.endpoint.unwrap(), "/v02/");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Currently, the `/internal/test/endpoint_for_task` returns the URL passed in via the variable binding `DAP_BASE_URL`. This PR changes it to instead return the path component of that URL. In the context of a container-based interop test, any hostname chosen at build time will be wrong, plus we will want to use a different port number for this than Daphne's end-to-end tests.

[Relative URLs in the response are supported](https://divergentdave.github.io/draft-dcook-ppm-dap-interop-test-design/draft-dcook-ppm-dap-interop-test-design.html#name-internal-test-endpoint_for_), and are the easiest way forward; the alternative is to parse the hostname out of the request, and build an absolute URL using that and port 8080.