### PR TITLE
taskprov: Merge DpMechanism into DpConfig

### DIFF
--- a/daphne/src/messages/mod_test.rs
+++ b/daphne/src/messages/mod_test.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::messages::taskprov::{
-    DpConfig, DpMechanism, QueryConfig, QueryConfigVar, TaskConfig, UrlBytes, VdafConfig,
-    VdafTypeVar,
+    DpConfig, QueryConfig, QueryConfigVar, TaskConfig, UrlBytes, VdafConfig, VdafTypeVar,
 };
 use crate::messages::{
     AggregateContinueReq, AggregateInitializeReq, AggregateResp, Extension, HpkeAeadId,
@@ -186,9 +185,7 @@ fn read_vdaf_config() {
     assert_eq!(
         vdaf_config,
         VdafConfig {
-            dp_config: DpConfig {
-                mechanism: DpMechanism::None
-            },
+            dp_config: DpConfig::None,
             var: VdafTypeVar::Prio3Aes128Histogram { buckets: buckets },
         }
     );
@@ -224,9 +221,7 @@ fn read_task_config_taskprov_draft01() {
             },
             task_expiration: 0x6352f9a5,
             vdaf_config: VdafConfig {
-                dp_config: DpConfig {
-                    mechanism: DpMechanism::None
-                },
+                dp_config: DpConfig::None,
                 var: VdafTypeVar::Prio3Aes128Histogram { buckets: buckets },
             },
         }

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -24,7 +24,6 @@ const VDAF_TYPE_PRIO3_AES128_HISTOGRAM: u32 = 0x00000002;
 const VDAF_TYPE_POPLAR1_AES128: u32 = 0x00001000; // The gap from the previous constant is intentional
 
 // Differential privacy mechanism types.
-const DP_MECHANISM_RESERVED: u8 = 0x00;
 const DP_MECHANISM_NONE: u8 = 0x01;
 
 /// A VDAF type.
@@ -115,56 +114,33 @@ impl From<VdafTypeVar> for VdafType {
 }
 
 /// A differential privacy mechanism.
-#[derive(Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq)]
-pub enum DpMechanism {
-    Reserved,
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+pub enum DpConfig {
     None,
-    NotImplemented(u8),
 }
 
-impl From<DpMechanism> for u8 {
-    fn from(dp_mech: DpMechanism) -> Self {
-        match dp_mech {
-            DpMechanism::Reserved => DP_MECHANISM_RESERVED,
-            DpMechanism::None => DP_MECHANISM_NONE,
-            DpMechanism::NotImplemented(x) => x,
+impl From<DpConfig> for u8 {
+    fn from(dp_config: DpConfig) -> Self {
+        match dp_config {
+            DpConfig::None => DP_MECHANISM_NONE,
         }
     }
-}
-
-impl Encode for DpMechanism {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        u8::from(*self).encode(bytes);
-    }
-}
-
-impl Decode for DpMechanism {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        match u8::decode(bytes)? {
-            x if x == DP_MECHANISM_RESERVED => Ok(Self::Reserved),
-            x if x == DP_MECHANISM_NONE => Ok(Self::None),
-            _ => Err(CodecError::UnexpectedValue),
-        }
-    }
-}
-
-/// A differential privacy configuration.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct DpConfig {
-    pub mechanism: DpMechanism,
 }
 
 impl Encode for DpConfig {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.mechanism.encode(bytes);
+        match self {
+            Self::None => DP_MECHANISM_NONE.encode(bytes),
+        }
     }
 }
 
 impl Decode for DpConfig {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        Ok(Self {
-            mechanism: DpMechanism::decode(bytes)?,
-        })
+        match u8::decode(bytes)? {
+            DP_MECHANISM_NONE => Ok(Self::None),
+            _ => Err(CodecError::UnexpectedValue),
+        }
     }
 }
 

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -9,8 +9,7 @@ use daphne::{
     constants,
     messages::{
         taskprov::{
-            DpConfig, DpMechanism, QueryConfig, QueryConfigVar, TaskConfig, UrlBytes, VdafConfig,
-            VdafTypeVar,
+            DpConfig, QueryConfig, QueryConfigVar, TaskConfig, UrlBytes, VdafConfig, VdafTypeVar,
         },
         BatchSelector, CollectReq, CollectResp, Extension, HpkeCiphertext, Id, Interval, Query,
         Report, ReportId, ReportMetadata,
@@ -306,9 +305,7 @@ async fn e2e_leader_upload() {
         },
         task_expiration: t.now + 86400,
         vdaf_config: VdafConfig {
-            dp_config: DpConfig {
-                mechanism: DpMechanism::None,
-            },
+            dp_config: DpConfig::None,
             var: VdafTypeVar::Prio3Aes128Count,
         },
     };
@@ -412,9 +409,7 @@ async fn e2e_leader_upload() {
         },
         task_expiration: t.now + 86400,
         vdaf_config: VdafConfig {
-            dp_config: DpConfig {
-                mechanism: DpMechanism::None,
-            },
+            dp_config: DpConfig::None,
             var: VdafTypeVar::Prio3Aes128Count,
         },
     };
@@ -1135,9 +1130,7 @@ async fn e2e_leader_collect_taskprov_ok() {
         },
         task_expiration: t.now + 86400 * 14,
         vdaf_config: VdafConfig {
-            dp_config: DpConfig {
-                mechanism: DpMechanism::None,
-            },
+            dp_config: DpConfig::None,
             var: VdafTypeVar::Prio3Aes128Sum { bit_length: 10 },
         },
     };


### PR DESCRIPTION
Adding a new DP mechanism currently requires changing code in three places: Adding a new DP_MECHANISM_* const, a new DpMechanims variant, and whatever parameters are needed for DpConfig (currenntly no variants of this structure are implemented). This change refactors serialization of the DpConfig to make this a bit easeier.