### PR TITLE
Remove `From<DpConfig>` for `u8`

### DIFF
--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -119,14 +119,6 @@ pub enum DpConfig {
     None,
 }
 
-impl From<DpConfig> for u8 {
-    fn from(dp_config: DpConfig) -> Self {
-        match dp_config {
-            DpConfig::None => DP_MECHANISM_NONE,
-        }
-    }
-}
-
 impl Encode for DpConfig {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match self {


### PR DESCRIPTION
We don't use this anywhere.