### PR TITLE
taskprov: Simplify verify key derivation slightly.

### DIFF
--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -27,7 +27,7 @@ const VDAF_TYPE_POPLAR1_AES128: u32 = 0x00001000; // The gap from the previous c
 const DP_MECHANISM_NONE: u8 = 0x01;
 
 /// A VDAF type.
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum VdafType {
     Prio3Aes128Count,

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -78,11 +78,11 @@ pub(crate) fn expand_prk_into_verify_key(
     vdaf_type: VdafType,
 ) -> VdafVerifyKey {
     let info = [task_id.as_ref()];
+    // This expand(), and the associated fill() below can only fail if the length is wrong,
+    // and it won't be, so we unwrap().
+    let okm = prk.expand(&info, vdaf_type).unwrap();
     match &vdaf_type {
         VdafType::Prio3Aes128Count | VdafType::Prio3Aes128Sum | VdafType::Prio3Aes128Histogram => {
-            // This expand(), and the associated fill() below can only fail if the length is wrong,
-            // and it won't be, so we unwrap().
-            let okm = prk.expand(&info, vdaf_type.clone()).unwrap();
             let mut bytes = [0u8; 16];
             okm.fill(&mut bytes[..]).unwrap();
             VdafVerifyKey::Prio3(bytes)
@@ -175,7 +175,9 @@ impl From<VdafTypeVar> for VdafConfig {
             VdafTypeVar::Prio3Aes128Sum { bit_length } => VdafConfig::Prio3(Prio3Config::Sum {
                 bits: bit_length.into(),
             }),
-            _ => panic!("poplar1 is not implemented"),
+            VdafTypeVar::Poplar1Aes128 { .. } | VdafTypeVar::NotImplemented(..) => {
+                unreachable!("VDAF not implemented")
+            }
         }
     }
 }


### PR DESCRIPTION
Move up computation of `okm` in the verify key derivation to preceed the match statement. The OKM computation is identical for each of the branches, so this will avoid having to de-duplicate when we add new variants.

While at it, derive `Copy` for `VdafVerifyKey` to get rid of the clone there.