### PR TITLE
daphne_worker: Add /task endpoint

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -105,6 +105,9 @@ pub(crate) struct DaphneWorkerConfig<D> {
 
     /// Default DAP version to use if not specified by the API URL
     pub(crate) default_version: DapVersion,
+
+    /// Admin bearer token. If configured, it is used to authorize requests from the administrator.
+    pub(crate) admin_token: Option<BearerToken>,
 }
 
 impl<D> DaphneWorkerConfig<D> {
@@ -202,6 +205,14 @@ impl<D> DaphneWorkerConfig<D> {
             None
         };
 
+        let admin_token = match ctx.secret("DAP_ADMIN_BEARER_TOKEN") {
+            Ok(raw) => Some(BearerToken::from(raw.to_string())),
+            Err(err) => {
+                console_log!("DAP_ADMIN_BEARER_TOKEN not configured: {:?}", err);
+                None
+            }
+        };
+
         Ok(Self {
             ctx: Some(ctx),
             client,
@@ -217,6 +228,7 @@ impl<D> DaphneWorkerConfig<D> {
             is_leader,
             taskprov_config,
             default_version,
+            admin_token,
         })
     }
 

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -77,6 +77,7 @@ preview_id = "<ignored>" # TODO(cjpatton) Figure out how to pick this.
 # production. In particular, they will not be passed as environment variables
 # as they are here. See
 # https://developers.cloudflare.com/workers/wrangler/commands/#secret.
+DAP_ADMIN_BEARER_TOKEN = "administrator bearer token" # SECRET
 DAP_AGGREGATOR_ROLE = "helper"
 DAP_BASE_URL = "http://127.0.0.1:8788/"
 DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"


### PR DESCRIPTION
Closes #82.

Like /internal/test/add_task, but requires a bearer token. The header for the token is X-Daphne-Worker-Admin-Bearer-Token; on the server side, the token is stored in DAP_ADMIN_BEARER_TOKEN. This allows us to manually configure a task in a live deployment without exposing the internal test endpoints.