### PR TITLE
Time-based GC.

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -312,30 +312,15 @@ impl AsRef<str> for DapVersion {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct DapGlobalConfig {
     /// The report storage epoch duration. This value is used to control the period of time for
-    /// which an Aggregator guarantees storage of reports and/or report metadata:
+    /// which an Aggregator guarantees storage of reports and/or report metadata.
     ///
-    /// 1. Once an epoch has elapsed, all reports and metadata corresponding to the epoch may be
-    ///    deleted in order to reduce storage costs. In addition, all reports for this epoch will
-    ///    be rejected.
-    /// 2. Reports pertaining to epochs that have not yet begun may be rejected.
-    ///
-    /// Let `now` be the current time truncated by the report storage epoch duration. All epochs
-    /// preceeding the previous are subject to deletion; for all epochs following the next, reports
-    /// will be rejected:
-    ///
-    /// ```text
-    ///     now-2 <- reports rejected, data subject to deletion
-    ///     now-1 <- start of previous epoch
-    ///     now   <- start of current epoch
-    ///     now+1 <- start of next epoch
-    ///     now+2 <- reports rejected
-    /// ```
-    ///
-    /// Thus, storage is only guaranteed for the previous epoch, the current epoch, and the next
-    /// epoch.
-    //
-    // TODO(issue #100) Implement the rejection mechanism described here.
+    /// A report will be accepted if its timestamp is no more than the specified number of seconds
+    /// before the current time.
     pub report_storage_epoch_duration: Duration,
+
+    /// The report storage maximum future time skew. Reports with timestamps greater than the
+    /// current time plus this value will be rejected.
+    pub report_storage_max_future_time_skew: Duration,
 
     /// Maximum interval duration permitted in CollectReq.
     /// Prevents Collectors from requesting wide range or reports.

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -69,7 +69,8 @@ impl Test {
         // Global config. In a real deployment, the Leader and Helper may make different choices
         // here.
         let global_config = DapGlobalConfig {
-            report_storage_epoch_duration: 604800, // one week
+            report_storage_epoch_duration: 604800,    // one week
+            report_storage_max_future_time_skew: 300, // 5 minutes
             max_batch_duration: 360000,
             min_batch_interval_start: 259200,
             max_batch_interval_end: 259200,

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -125,6 +125,7 @@ impl TestRunner {
         // This block needs to be kept in-sync with daphne_worker_test/wrangler.toml.
         let global_config = DapGlobalConfig {
             report_storage_epoch_duration: 604800,
+            report_storage_max_future_time_skew: 300,
             max_batch_duration: 360000,
             min_batch_interval_start: 259200,
             max_batch_interval_end: 259200,
@@ -248,7 +249,8 @@ impl TestRunner {
     }
 
     pub fn batch_interval(&self) -> Interval {
-        let start = self.now - (self.now % self.task_config.time_precision);
+        let epoch_start = self.now - (self.now % self.global_config.report_storage_epoch_duration);
+        let start = epoch_start - (epoch_start % self.task_config.time_precision);
         Interval {
             start,
             duration: self.task_config.time_precision * 2,

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -28,6 +28,7 @@ DAP_REPORT_SHARD_KEY = "61cd9685547370cfea76c2eb8d156ad9" # SECRET
 DAP_REPORT_SHARD_COUNT = "2"
 DAP_GLOBAL_CONFIG = """{
      "report_storage_epoch_duration": 604800,
+     "report_storage_max_future_time_skew": 300,
      "max_batch_duration": 360000,
      "min_batch_interval_start": 259200,
      "max_batch_interval_end": 259200,
@@ -35,6 +36,8 @@ DAP_GLOBAL_CONFIG = """{
      "allow_taskprov": true,
      "taskprov_version": "v02"
 }"""
+DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
+DAP_DEPLOYMENT = "dev"
 DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
   "id": 23,
   "kem_id": "p256_hkdf_sha256",
@@ -86,6 +89,7 @@ DAP_REPORT_SHARD_COUNT = "2"
 DAP_HELPER_STATE_STORE_GARBAGE_COLLECT_AFTER_SECS = "10"
 DAP_GLOBAL_CONFIG = """{
   "report_storage_epoch_duration": 604800,
+  "report_storage_max_future_time_skew": 300,
   "max_batch_duration": 360000,
   "min_batch_interval_start": 259200,
   "max_batch_interval_end": 259200,
@@ -93,6 +97,8 @@ DAP_GLOBAL_CONFIG = """{
   "allow_taskprov": true,
   "taskprov_version": "v02"
 }"""
+DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
+DAP_DEPLOYMENT = "dev"
 DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
   "id": 23,
   "kem_id": "p256_hkdf_sha256",


### PR DESCRIPTION
This is a first cut at time-based GC.  Processed report ids are chunked into epochs, we reject things that are too old or too far in the future, and we delete the chunk once it is impossible for any replay of the report id in that epoch.