### PR TITLE
Refactor Daphne-Worker configuration

### DIFF
--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -75,7 +75,7 @@ pub(crate) fn dap_response_to_worker(resp: DapResponse) -> Result<Response> {
 }
 
 #[async_trait(?Send)]
-impl<'srv, D> HpkeDecrypter<'srv> for DaphneWorker<D> {
+impl<'srv> HpkeDecrypter<'srv> for DaphneWorker {
     type WrappedHpkeConfig = GuardedHpkeReceiverConfig<'srv>;
 
     async fn get_hpke_config_for(
@@ -199,7 +199,7 @@ fn parse_hpke_config_id_from_kv_key_name(name: &str) -> std::result::Result<u8, 
 }
 
 #[async_trait(?Send)]
-impl<'srv, D> BearerTokenProvider<'srv> for DaphneWorker<D> {
+impl<'srv> BearerTokenProvider<'srv> for DaphneWorker {
     type WrappedBearerToken = GuardedBearerToken<'srv>;
 
     async fn get_leader_bearer_token_for(
@@ -236,7 +236,7 @@ impl<'srv, D> BearerTokenProvider<'srv> for DaphneWorker<D> {
 }
 
 #[async_trait(?Send)]
-impl<D> DapAuthorizedSender<BearerToken> for DaphneWorker<D> {
+impl DapAuthorizedSender<BearerToken> for DaphneWorker {
     async fn authorize(
         &self,
         task_id: &Id,
@@ -252,7 +252,7 @@ impl<D> DapAuthorizedSender<BearerToken> for DaphneWorker<D> {
 }
 
 #[async_trait(?Send)]
-impl<'srv, 'req, D> DapAggregator<'srv, 'req, BearerToken> for DaphneWorker<D>
+impl<'srv, 'req> DapAggregator<'srv, 'req, BearerToken> for DaphneWorker
 where
     'srv: 'req,
 {
@@ -616,7 +616,7 @@ fn task_id_from_report(report: &[u8]) -> std::result::Result<Id, DapError> {
 }
 
 #[async_trait(?Send)]
-impl<'srv, 'req, D> DapLeader<'srv, 'req, BearerToken> for DaphneWorker<D>
+impl<'srv, 'req> DapLeader<'srv, 'req, BearerToken> for DaphneWorker
 where
     'srv: 'req,
 {
@@ -934,7 +934,7 @@ where
 }
 
 #[async_trait(?Send)]
-impl<'srv, 'req, D> DapHelper<'srv, 'req, BearerToken> for DaphneWorker<D>
+impl<'srv, 'req> DapHelper<'srv, 'req, BearerToken> for DaphneWorker
 where
     'srv: 'req,
 {

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
+    config::DaphneWorkerConfig,
     durable::{state_get_or_default, BINDING_DAP_AGGREGATE_STORE},
     int_err,
 };
@@ -36,15 +37,19 @@ pub struct AggregateStore {
     #[allow(dead_code)]
     state: State,
     env: Env,
+    config: DaphneWorkerConfig,
     touched: bool,
 }
 
 #[durable_object]
 impl DurableObject for AggregateStore {
     fn new(state: State, env: Env) -> Self {
+        let config =
+            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
+            config,
             touched: false,
         }
     }

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
+    config::DaphneWorkerConfig,
     durable::{DurableOrdered, BINDING_DAP_LEADER_AGG_JOB_QUEUE},
     int_err,
 };
@@ -35,15 +36,19 @@ pub struct LeaderAggregationJobQueue {
     #[allow(dead_code)]
     state: State,
     env: Env,
+    config: DaphneWorkerConfig,
     touched: bool,
 }
 
 #[durable_object]
 impl DurableObject for LeaderAggregationJobQueue {
     fn new(state: State, env: Env) -> Self {
+        let config =
+            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
+            config,
             touched: false,
         }
     }

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
+    config::DaphneWorkerConfig,
     durable::{state_get, DurableOrdered, BINDING_DAP_LEADER_BATCH_QUEUE},
     int_err,
 };
@@ -54,6 +55,7 @@ pub struct LeaderBatchQueue {
     #[allow(dead_code)]
     state: State,
     env: Env,
+    config: DaphneWorkerConfig,
     touched: bool,
 }
 
@@ -88,9 +90,12 @@ impl LeaderBatchQueue {
 #[durable_object]
 impl DurableObject for LeaderBatchQueue {
     fn new(state: State, env: Env) -> Self {
+        let config =
+            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
+            config,
             touched: false,
         }
     }

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -112,8 +112,7 @@ macro_rules! ensure_garbage_collected {
             // The GarbageCollector should only be used when running tests. In production, the DO->DO
             // communication overhead adds unacceptable latency, and there's no need to do the
             // bulk deletes of state that test suites require.
-            let deployment = $object.env.var("DAP_DEPLOYMENT")?.to_string();
-            if deployment != "prod" {
+            if matches!($object.config.deployment, crate::config::DaphneWorkerDeployment::Dev) {
                 let touched: bool =
                     crate::durable::state_set_if_not_exists(&$object.state, "touched", &true)
                         .await?

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
+    config::DaphneWorkerConfig,
     durable::{
         durable_name_queue,
         leader_agg_job_queue::{
@@ -53,15 +54,19 @@ pub struct ReportsPending {
     #[allow(dead_code)]
     state: State,
     env: Env,
+    config: DaphneWorkerConfig,
     touched: bool,
 }
 
 #[durable_object]
 impl DurableObject for ReportsPending {
     fn new(state: State, env: Env) -> Self {
+        let config =
+            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
+            config,
             touched: false,
         }
     }


### PR DESCRIPTION
Currently all of our various configuration parameters are scattered across a set of environment variables. The current pattern is to parse the environment variable wherever the data is needed. This makes maintenance more difficult, since it forces you to read through the code to determine the effect of (not) defining a particular variable, as well as its expected format. The goal of this PR is to begin moving all environment variables into one struct (`DaphneWorkerConfig`). This will also make it easier to move to a more streamlined configuration, such as YAML.