### PR TITLE
daphne: Add plumbing for Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,9 +432,11 @@ dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
+ "lazy_static",
  "matchit 0.7.0",
  "paste",
  "prio",
+ "prometheus",
  "rand",
  "ring",
  "serde",
@@ -483,6 +485,7 @@ dependencies = [
  "matchit 0.7.0",
  "paste",
  "prio",
+ "prometheus",
  "rand",
  "reqwest-wasm",
  "ring",
@@ -1487,6 +1490,27 @@ checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -26,9 +26,11 @@ hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = { version = "0.1.0" , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
+lazy_static = "1.4.0"
 matchit = "0.7.0"
 paste = "1.0.11"
 prio = { version = "0.10.0", features = ["prio2"] }
+prometheus = "0.13.3"
 rand = "0.8.5"
 ring = "0.16.20"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -83,6 +83,12 @@ impl DapError {
     }
 }
 
+impl From<prometheus::Error> for DapError {
+    fn from(e: prometheus::Error) -> Self {
+        Self::Fatal(format!("prometheus: {}", e))
+    }
+}
+
 impl From<serde_json::Error> for DapError {
     fn from(e: serde_json::Error) -> Self {
         Self::Fatal(format!("serde_json: {}", e))
@@ -886,6 +892,7 @@ pub mod hpke;
 #[cfg(test)]
 mod hpke_test;
 pub mod messages;
+pub mod metrics;
 pub mod roles;
 #[cfg(test)]
 mod roles_test;

--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Daphne metrics.
+
+use crate::DapError;
+use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
+
+pub struct DaphneMetrics {
+    /// Report metrics. How many reports have been rejected, aggregated, and collected. When
+    /// a report is rejected, the failure type is recorded.
+    //
+    // TODO(cjpatton) So far we only count the number of reports aggregated.
+    pub(crate) report_counter: IntCounterVec,
+}
+
+impl DaphneMetrics {
+    /// Regstier Daphne metrics with the specified registry.
+    pub fn register(registry: &Registry) -> Result<Self, DapError> {
+        let report_counter = register_int_counter_vec_with_registry!(
+            "daphne_report_counter",
+            "Total number reports rejected, aggregated, and collected.",
+            &["status"],
+            registry
+        )?;
+
+        Ok(Self { report_counter })
+    }
+}

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -10,6 +10,7 @@ use crate::{
         BatchSelector, CollectReq, CollectResp, HpkeCiphertext, HpkeConfig, Id,
         PartialBatchSelector, Report, ReportId, ReportMetadata, Time, TransitionFailure,
     },
+    metrics::DaphneMetrics,
     roles::{DapAggregator, DapAuthorizedSender, DapHelper, DapLeader},
     taskprov, DapAbort, DapAggregateShare, DapBatchBucket, DapCollectJob, DapError,
     DapGlobalConfig, DapHelperState, DapOutputShare, DapQueryConfig, DapRequest, DapResponse,
@@ -76,6 +77,7 @@ pub(crate) struct MockAggregator {
     pub(crate) agg_store: Arc<Mutex<HashMap<Id, HashMap<DapBatchBucketOwned, AggStore>>>>,
     pub(crate) collector_hpke_config: HpkeConfig,
     pub(crate) taskprov_vdaf_verify_key_init: Vec<u8>,
+    pub(crate) metrics: DaphneMetrics,
 }
 
 #[allow(dead_code)]
@@ -523,6 +525,10 @@ where
                 "unknown version".to_string(),
             )))
         }
+    }
+
+    fn metrics(&self) -> &DaphneMetrics {
+        &self.metrics
     }
 }
 

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -27,6 +27,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 matchit = "0.7.0"
 paste = "1.0.11"
 prio = "0.10.0"
+prometheus = "0.13.3"
 rand = "0.8.5"
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -49,6 +49,7 @@ use daphne::{
         BatchSelector, CollectReq, CollectResp, HpkeCiphertext, Id, PartialBatchSelector, Report,
         ReportId, ReportMetadata, TransitionFailure,
     },
+    metrics::DaphneMetrics,
     roles::{early_metadata_check, DapAggregator, DapAuthorizedSender, DapHelper, DapLeader},
     taskprov::{bad_request, get_taskprov_task_config},
     DapAggregateShare, DapBatchBucket, DapCollectJob, DapError, DapGlobalConfig, DapHelperState,
@@ -598,6 +599,10 @@ where
 
     async fn current_batch(&self, task_id: &Id) -> std::result::Result<Id, DapError> {
         self.internal_current_batch(task_id).await
+    }
+
+    fn metrics(&self) -> &DaphneMetrics {
+        &self.daphne_metrics
     }
 }
 


### PR DESCRIPTION
Based on #195.
Partially closes #27.

Defines a struct `DaphneMetrics` where any metrics recorded while processing or sending a DAP request will be enumerated. A registry is required to construct this type. All of its members are crate-private.

Adds a new method to the `DapAggregator` that provides access to the `DaphneMetrics` in use. This intended to be used by derived methods that implement the protocol logic.

It's more common to see the ["static metric" pattern](https://docs.rs/prometheus/latest/prometheus/index.html#static-metrics) for this library. The advantage of non-static metrics is that they are not re-used across unit tests, which makes it possible to write unit tests for the metrics.