### PR TITLE
Add metrics for early rejections

### DIFF
--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -552,16 +552,16 @@ impl Decode for TransitionFailure {
 impl std::fmt::Display for TransitionFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::BatchCollected => write!(f, "batch-collected({})", *self as u8),
-            Self::ReportReplayed => write!(f, "report-replayed({})", *self as u8),
-            Self::ReportDropped => write!(f, "report-dropped({})", *self as u8),
-            Self::HpkeUnknownConfigId => write!(f, "hpke-unknown-config-id({})", *self as u8),
-            Self::HpkeDecryptError => write!(f, "hpke-decrypt-error({})", *self as u8),
-            Self::VdafPrepError => write!(f, "vdaf-prep-error({})", *self as u8),
-            Self::BatchSaturated => write!(f, "batch-saturated({})", *self as u8),
-            Self::TaskExpired => write!(f, "task-expired({})", *self as u8),
-            Self::UnrecognizedMessage => write!(f, "unrecognized-message({})", *self as u8),
-            Self::ReportTooEarly => write!(f, "report-too-early({})", *self as u8),
+            Self::BatchCollected => write!(f, "batch_collected"),
+            Self::ReportReplayed => write!(f, "report_replayed"),
+            Self::ReportDropped => write!(f, "report_dropped"),
+            Self::HpkeUnknownConfigId => write!(f, "hpke_unknown_config_id"),
+            Self::HpkeDecryptError => write!(f, "hpke_decrypt_error"),
+            Self::VdafPrepError => write!(f, "vdaf_prep_error"),
+            Self::BatchSaturated => write!(f, "batch_saturated"),
+            Self::TaskExpired => write!(f, "task_expired"),
+            Self::UnrecognizedMessage => write!(f, "unrecognized_message"),
+            Self::ReportTooEarly => write!(f, "report_too_early"),
         }
     }
 }

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -865,6 +865,10 @@ async fn http_post_aggregate_failure_report_replayed(version: DapVersion) {
         transition.var,
         TransitionVar::Failed(TransitionFailure::ReportReplayed)
     );
+
+    assert_metrics_include!(t.helper_prometheus_registry, {
+        r#"daphne_report_counter{status="rejected_report_replayed"}"#: 1,
+    });
 }
 
 async_test_versions! { http_post_aggregate_failure_report_replayed }
@@ -915,6 +919,10 @@ async fn http_post_aggregate_failure_batch_collected(version: DapVersion) {
         transition.var,
         TransitionVar::Failed(TransitionFailure::BatchCollected)
     );
+
+    assert_metrics_include!(t.helper_prometheus_registry, {
+        r#"daphne_report_counter{status="rejected_batch_collected"}"#: 1,
+    });
 }
 
 async_test_versions! { http_post_aggregate_failure_batch_collected }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -501,10 +501,6 @@ impl VdafConfig {
     ///
     /// * `agg_init_req` is the request sent by the Leader.
     ///
-    /// * `early_rejects` is a tableindicating the set of reports in `agg_init_req` that the Helper
-    /// knows in advance it must reject. Each key is the report ID and the corresponding value is
-    /// the transition failure the Helper is to transmit.
-    ///
     /// * `version` is the DapVersion to use.
     pub(crate) async fn handle_agg_init_req(
         &self,

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -22,7 +22,7 @@ use prio::vdaf::{
     PrepareTransition,
 };
 use rand::prelude::*;
-use std::{collections::HashMap, fmt::Debug, time::SystemTime};
+use std::{fmt::Debug, time::SystemTime};
 use url::Url;
 
 impl<M: Debug> DapLeaderTransition<M> {
@@ -584,7 +584,6 @@ pub(crate) struct Test {
     task_config: DapTaskConfig,
     leader_hpke_receiver_config: HpkeReceiverConfig,
     helper_hpke_receiver_config: HpkeReceiverConfig,
-    early_rejects: HashMap<ReportId, TransitionFailure>,
     client_hpke_config_list: Vec<HpkeConfig>,
     collector_hpke_receiver_config: HpkeReceiverConfig,
 }
@@ -615,7 +614,6 @@ impl Test {
             agg_job_id,
             leader_hpke_receiver_config,
             helper_hpke_receiver_config,
-            early_rejects: HashMap::default(),
             client_hpke_config_list: vec![leader_hpke_config, helper_hpke_config],
             collector_hpke_receiver_config,
             task_config: DapTaskConfig {
@@ -685,14 +683,6 @@ impl Test {
             )
             .await
             .unwrap();
-
-        for report_share in agg_init_req.report_shares {
-            // Make sure the Leader doesn't try to aggregate these reports again.
-            self.early_rejects.insert(
-                report_share.metadata.id.clone(),
-                TransitionFailure::ReportReplayed,
-            );
-        }
 
         agg_resp
     }


### PR DESCRIPTION
Partially addresses #27.

A report is said to be rejected "early" if it was deemd to be invalid by the `DapAggregater::check_early_reject()` callback. Add Prometheus metrics for these. Along the way, revise the implementation of `Display` for `TransitionFailure` so that we can use it for metrics-friendly labels. This will be needed as we add additional transition failures.

Relatedly:

* Remove a redundant task expiration task. In a previous commit (e396236444f70d3b0c168a7b1537da6de3236df4), this check was moved to `VdafConfig::consume_report_share()`, making the check in `DapLeader::run_agg_job()` unnecessary.

* Fix a bug in the early-reject filtering loop in `DapHelper::http_post_aggregate()`. The Helper filters out early rejections only after processing all of the reports in the request. (This is an optimization intended to improve latency.) When a report is removed this way, it is also necessary to remove the corresponding prep state from the Helper's aggregation-job state.

  Previously, if a report was rejected early, the loop would try to remove the next prep state regardless of whether the next report *was also* rejected for another reason. It would fail due to report ID mismatch.

  Fix this bug by checking if the report was already rejected before overwriting it.

* Clean up some test code in `vdaf/mod_test.rs` around early rejections that is no longer needed.