### PR TITLE
Implement fmt::Display for Id and ReportId, instead of ToString.

### DIFF
--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     convert::{TryFrom, TryInto},
-    fmt::Debug,
+    fmt,
     io::{Cursor, Read},
 };
 
@@ -71,9 +71,9 @@ impl AsRef<[u8]> for Id {
     }
 }
 
-impl ToString for Id {
-    fn to_string(&self) -> String {
-        self.to_hex()
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
     }
 }
 
@@ -87,6 +87,13 @@ pub type Time = u64;
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash, Serialize)]
 #[allow(missing_docs)]
 pub struct ReportId(pub [u8; 16]);
+
+impl ReportId {
+    /// Return the ID encoded as a hex string.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
 
 impl Encode for ReportId {
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -105,6 +112,12 @@ impl Decode for ReportId {
 impl AsRef<[u8]> for ReportId {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl fmt::Display for ReportId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_hex())
     }
 }
 


### PR DESCRIPTION
This is a tiny PR that implements fmt::Display instead of ToString for Id, and adds fmt::Display for ReportId as well.  This is the recommended practice, and implementing fmt::Display gives you a ToString implementation automatically.  This lets us have nicer tracing code, e.g. instead of 

    trace!("report {} is ok", report.metadata.id.to_string());

We can say:

    trace!("report {} is ok", report.metadata.id);