### PR TITLE
Add report rejection metrics

### DIFF
--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -16,9 +16,9 @@ pub struct DaphneMetrics {
 
 impl DaphneMetrics {
     /// Regstier Daphne metrics with the specified registry.
-    pub fn register(registry: &Registry) -> Result<Self, DapError> {
+    pub fn register(registry: &Registry, prefix: &str) -> Result<Self, DapError> {
         let report_counter = register_int_counter_vec_with_registry!(
-            "daphne_report_counter",
+            format!("{prefix}_report_counter"),
             "Total number reports rejected, aggregated, and collected.",
             &["status"],
             registry

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -316,7 +316,7 @@ impl DaphneWorkerState {
 
         // TODO(cjpatton) Push metrics to gateway after handling the request.
         let prometheus_registry = Registry::new();
-        let daphne_metrics = DaphneMetrics::register(&prometheus_registry)
+        let daphne_metrics = DaphneMetrics::register(&prometheus_registry, "daphne_worker")
             .map_err(|e| Error::RustError(format!("failed to register daphne metrics: {}", e)))?;
 
         Ok(Self {


### PR DESCRIPTION
Partially addresses #27.

Plumb `DapAggregator::metrics()` to `VdafConfig` and count report rejections. Wherever the aggregator transitions a report to "failued", record the failure reason.

Relatedly:

* Refactor `VdafConfig::produce_report_with_extensions()` to allow us to construct invalid input shares in tests.

* Add a prefix to the metrics registered by `DaphneMetrics::register()`, allowing multiple instances of `DaphneMetrics` to be registered with the same registry. This simplifies the testing framework a bit.

* In-line variable names in a few `format!`  instances.

* Move `assert_metrics_include!` macro to the `testing` module so that we can reuse it in `vdaf/mod_test.rs`. Also, only compile it in tests.

* Rename some tests in `vdaf/mod_test.rs` to more closely correspond to the condition being tested.