### PR TITLE
Add spans around major async calls from the router.

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -38,7 +38,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard},
     time::Duration,
 };
-use tracing::{debug, info};
+use tracing::trace;
 use worker::{kv::KvStore, *};
 
 pub(crate) const KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG: &str = "hpke_receiver_config";
@@ -173,7 +173,7 @@ impl DaphneWorkerConfig {
             DaphneWorkerDeployment::default()
         };
         if !matches!(deployment, DaphneWorkerDeployment::Prod) {
-            info!("DAP deployment override applied: {:?}", deployment);
+            trace!("DAP deployment override applied: {:?}", deployment);
         }
 
         let taskprov = if global.allow_taskprov {
@@ -208,7 +208,7 @@ impl DaphneWorkerConfig {
         let admin_token = match env.secret("DAP_ADMIN_BEARER_TOKEN") {
             Ok(raw) => Some(BearerToken::from(raw.to_string())),
             Err(err) => {
-                info!("DAP_ADMIN_BEARER_TOKEN not configured: {:?}", err);
+                trace!("DAP_ADMIN_BEARER_TOKEN not configured: {:?}", err);
                 None
             }
         };
@@ -539,7 +539,7 @@ impl<'srv> DaphneWorker<'srv> {
                 .delete(kv_key.name.as_str())
                 .await
                 .map_err(|e| DapError::Fatal(format!("kv_store: {}", e)))?;
-            debug!("deleted KV item {}", kv_key.name);
+            trace!("deleted KV item {}", kv_key.name);
         }
 
         future_delete_durable.await.map_err(dap_err)?;

--- a/daphne_worker/src/durable/garbage_collector.rs
+++ b/daphne_worker/src/durable/garbage_collector.rs
@@ -6,7 +6,7 @@ use crate::{
     durable::{DurableConnector, DurableOrdered, DurableReference},
     initialize_tracing, int_err,
 };
-use tracing::debug;
+use tracing::trace;
 use worker::*;
 
 pub(crate) const DURABLE_GARBAGE_COLLECTOR_PUT: &str = "/internal/do/garbage_collector/put";
@@ -50,7 +50,7 @@ impl DurableObject for GarbageCollector {
 
                 let queued = DurableOrdered::new_roughly_ordered(durable_ref, "object");
                 queued.put(&self.state).await?;
-                debug!(
+                trace!(
                     "GarbageCollector: scheduled {} instance {} for deletion",
                     queued.as_ref().binding,
                     queued.as_ref().id_hex
@@ -81,9 +81,10 @@ impl DurableObject for GarbageCollector {
                             &(),
                         )
                         .await?;
-                    debug!(
+                    trace!(
                         "GarbageCollector: deleted {} instance {}",
-                        durable_ref.binding, durable_ref.id_hex
+                        durable_ref.binding,
+                        durable_ref.id_hex
                     );
                 }
 

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -3,7 +3,7 @@
 
 use crate::{config::DaphneWorkerConfig, durable::state_get, initialize_tracing, int_err};
 use daphne::{messages::Id, DapVersion};
-use tracing::debug;
+use tracing::trace;
 use worker::*;
 
 pub(crate) fn durable_helper_state_name(
@@ -102,7 +102,7 @@ impl DurableObject for HelperStateStore {
     async fn alarm(&mut self) -> Result<Response> {
         self.state.storage().delete_all().await?;
         self.alarmed = false;
-        debug!(
+        trace!(
             "HelperStateStore: deleted instance {}",
             self.state.id().to_string()
         );


### PR DESCRIPTION
Add spans around major async calls (i.e. API entry points) from the URL router.  The span encompasses all work done by the API.

Also adjust the level of a few noisy messages.

