### PR TITLE
Add report collection metrics

### DIFF
--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -9,8 +9,6 @@ use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry
 pub struct DaphneMetrics {
     /// Report metrics. How many reports have been rejected, aggregated, and collected. When
     /// a report is rejected, the failure type is recorded.
-    //
-    // TODO(cjpatton) So far we only count the number of reports aggregated.
     pub(crate) report_counter: IntCounterVec,
 }
 

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -561,6 +561,11 @@ where
         self.mark_collected(&agg_share_req.task_id, &agg_share_req.batch_sel)
             .await?;
 
+        self.metrics()
+            .report_counter
+            .with_label_values(&["collected"])
+            .inc_by(agg_share_req.report_count);
+
         Ok(agg_share_req.report_count)
     }
 
@@ -928,6 +933,11 @@ where
         let agg_share_resp = AggregateShareResp {
             encrypted_agg_share,
         };
+
+        self.metrics()
+            .report_counter
+            .with_label_values(&["collected"])
+            .inc_by(agg_share_req.report_count);
 
         Ok(DapResponse {
             media_type: Some(MEDIA_TYPE_AGG_SHARE_RESP),

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -1391,6 +1391,8 @@ async fn e2e_time_interval(version: DapVersion) {
     assert_metrics_include!(t.prometheus_registry, {
         r#"test_leader_report_counter{status="aggregated"}"#: 1,
         r#"test_helper_report_counter{status="aggregated"}"#: 1,
+        r#"test_leader_report_counter{status="collected"}"#: 1,
+        r#"test_helper_report_counter{status="collected"}"#: 1,
     });
 }
 
@@ -1419,6 +1421,8 @@ async fn e2e_fixed_size(version: DapVersion) {
     assert_metrics_include!(t.prometheus_registry, {
         r#"test_leader_report_counter{status="aggregated"}"#: 1,
         r#"test_helper_report_counter{status="aggregated"}"#: 1,
+        r#"test_leader_report_counter{status="collected"}"#: 1,
+        r#"test_helper_report_counter{status="collected"}"#: 1,
     });
 }
 
@@ -1512,6 +1516,8 @@ async fn e2e_taskprov(version: DapVersion) {
     assert_metrics_include!(t.prometheus_registry, {
         r#"test_leader_report_counter{status="aggregated"}"#: 1,
         r#"test_helper_report_counter{status="aggregated"}"#: 1,
+        r#"test_leader_report_counter{status="collected"}"#: 1,
+        r#"test_helper_report_counter{status="collected"}"#: 1,
     });
 }
 


### PR DESCRIPTION
Partially addresses #27.

Once a collection job is completed, report how many reports were in the batch.