### PR TITLE
daphne_worker: Add HTTP response status code metrics

### DIFF
--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -13,7 +13,7 @@ pub struct DaphneMetrics {
 }
 
 impl DaphneMetrics {
-    /// Regstier Daphne metrics with the specified registry.
+    /// Register Daphne metrics with the specified registry.
     pub fn register(registry: &Registry, prefix: &str) -> Result<Self, DapError> {
         let report_counter = register_int_counter_vec_with_registry!(
             format!("{prefix}_report_counter"),

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -605,7 +605,7 @@ where
     }
 
     fn metrics(&self) -> &DaphneMetrics {
-        &self.state.daphne_metrics
+        &self.state.metrics.daphne
     }
 }
 

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -479,10 +479,20 @@ impl DaphneWorkerRouter {
         };
 
         let start = Date::now().as_millis();
-        let resp = router.run(req, env).await?;
+        let result = router.run(req, env).await;
         let end = Date::now().as_millis();
+
+        state
+            .metrics
+            .http_status_code
+            .with_label_values(&[&format!(
+                "{}",
+                result.as_ref().map_or(500, |resp| resp.status_code())
+            )])
+            .inc();
+
         info!("request completed in {}ms", end - start);
-        Ok(resp)
+        result
     }
 }
 
@@ -634,3 +644,4 @@ pub fn initialize_tracing(env: &Env) {
 mod config;
 mod dap;
 mod durable;
+mod metrics;

--- a/daphne_worker/src/metrics.rs
+++ b/daphne_worker/src/metrics.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Daphne-Worker metrics.
+
+use crate::DapError;
+use daphne::metrics::DaphneMetrics;
+use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
+
+pub(crate) struct DaphneWorkerMetrics {
+    /// Daphne metrics.
+    pub(crate) daphne: DaphneMetrics,
+
+    /// HTTP response status.
+    pub(crate) http_status_code: IntCounterVec,
+}
+
+impl DaphneWorkerMetrics {
+    pub(crate) fn register(registry: &Registry, prefix: &str) -> Result<Self, DapError> {
+        let daphne = DaphneMetrics::register(registry, prefix)?;
+
+        let http_status_code = register_int_counter_vec_with_registry!(
+            format!("{prefix}_http_status_code"),
+            "HTTP response status code.",
+            &["code"],
+            registry
+        )?;
+
+        Ok(Self {
+            daphne,
+            http_status_code,
+        })
+    }
+}


### PR DESCRIPTION
Based on #209 (merge that first).
Partially addresses #27.

Add a counter vector for HTTP response status codes output by Daphne-Worker.