### PR TITLE
Add span timing that works with WASM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-core",
  "tracing-subscriber",
  "url",
  "worker",

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -35,6 +35,7 @@ ring = "0.16.20"
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.38"
 tracing = "0.1.37"
+tracing-core = "0.1.30"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = { version = "2.3.1", features = ["serde"] }
 serde_json = "1.0.91"


### PR DESCRIPTION
We also move emitting timestamps into the abstraction the library prefers instead of just adding them to the front of a log line.

Finally, some redundant info in some DO messages and total request timing is removed.