### PR TITLE
Eliminate clippy warnings about directly using variables in format! strings

### DIFF
--- a/daphne/dapf/src/bin/dapf.rs
+++ b/daphne/dapf/src/bin/dapf.rs
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
             let uri =
                 Url::parse(uri_str).with_context(|| "Leader did not respond with valid URI")?;
 
-            println!("{}", uri);
+            println!("{uri}");
             Ok(())
         }
         Action::CollectPoll { uri, vdaf } => {

--- a/daphne/src/auth.rs
+++ b/daphne/src/auth.rs
@@ -94,8 +94,7 @@ pub trait BearerTokenProvider<'a> {
         }
 
         Err(DapError::Fatal(format!(
-            "attempted to authorize request of type '{}'",
-            media_type
+            "attempted to authorize request of type '{media_type}'",
         )))
     }
 

--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -151,7 +151,7 @@ impl HpkeReceiverConfig {
             HpkeKemId::P256HkdfSha256 => KemAlgorithm::DhKemP256,
             HpkeKemId::X25519HkdfSha256 => KemAlgorithm::DhKem25519,
             HpkeKemId::NotImplemented(x) => {
-                return Err(DapError::Fatal(format!("Unsupported KEM ({:?})", x)))
+                return Err(DapError::Fatal(format!("Unsupported KEM ({x:?})")))
             }
         };
         let kdf = KdfAlgorithm::HkdfSha256;
@@ -172,8 +172,7 @@ impl HpkeReceiverConfig {
                 })
             }
             Err(e) => Err(DapError::Fatal(format!(
-                "bad key generation for KEM ({:?}) caused by {:?}",
-                kem_id, e
+                "bad key generation for KEM ({kem_id:?}) caused by {e:?}",
             ))),
         }
     }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -85,25 +85,25 @@ impl DapError {
 
 impl From<prometheus::Error> for DapError {
     fn from(e: prometheus::Error) -> Self {
-        Self::Fatal(format!("prometheus: {}", e))
+        Self::Fatal(format!("prometheus: {e}"))
     }
 }
 
 impl From<serde_json::Error> for DapError {
     fn from(e: serde_json::Error) -> Self {
-        Self::Fatal(format!("serde_json: {}", e))
+        Self::Fatal(format!("serde_json: {e}"))
     }
 }
 
 impl From<hex::FromHexError> for DapError {
     fn from(e: hex::FromHexError) -> Self {
-        Self::Fatal(format!("from hex: {}", e))
+        Self::Fatal(format!("from hex: {e}"))
     }
 }
 
 impl From<CodecError> for DapError {
     fn from(e: CodecError) -> Self {
-        Self::Fatal(format!("codec: {}", e))
+        Self::Fatal(format!("codec: {e}"))
     }
 }
 
@@ -231,7 +231,7 @@ impl DapAbort {
         };
 
         ProblemDetails {
-            typ: format!("urn:ietf:params:ppm:dap:error:{}", typ),
+            typ: format!("urn:ietf:params:ppm:dap:error:{typ}"),
             taskid: None,   // TODO interop: Implement as specified.
             instance: None, // TODO interop: Implement as specified.
             detail,

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -130,7 +130,7 @@ macro_rules! leader_prep_fin {
         // Compute the leader's output share.
         match $vdaf.prepare_step($leader_state, message)? {
             PrepareTransition::Continue(..) => {
-                panic!("prio3_leader_prepare_finish: {}", ERR_EXPECT_FINISH)
+                panic!("prio3_leader_prepare_finish: {ERR_EXPECT_FINISH}")
             }
             PrepareTransition::Finish(out_share) => (out_share, message_data),
         }
@@ -175,7 +175,7 @@ pub(crate) fn prio3_leader_prepare_finish(
             let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
             (agg_share, outbound)
         }
-        _ => panic!("prio3_leader_prepare_finish: {}", ERR_FIELD_TYPE),
+        _ => panic!("prio3_leader_prepare_finish: {ERR_FIELD_TYPE}"),
     };
 
     Ok((agg_share, outbound))
@@ -195,7 +195,7 @@ macro_rules! helper_prep_fin {
         // Compute the Helper's output share.
         match $vdaf.prepare_step($helper_state, leader_message)? {
             PrepareTransition::Continue(..) => {
-                panic!("prio3_helper_prepare_finish: {}", ERR_EXPECT_FINISH)
+                panic!("prio3_helper_prepare_finish: {ERR_EXPECT_FINISH}")
             }
             PrepareTransition::Finish(out_share) => out_share,
         }
@@ -224,7 +224,7 @@ pub(crate) fn prio3_helper_prepare_finish(
             let out_share = helper_prep_fin!(vdaf, state, peer_message_data);
             VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
         }
-        _ => panic!("prio3_helper_prepare_finish: {}", ERR_FIELD_TYPE),
+        _ => panic!("prio3_helper_prepare_finish: {ERR_FIELD_TYPE}"),
     };
 
     Ok(agg_share)
@@ -245,7 +245,7 @@ pub(crate) fn prio3_append_prepare_state(
         | (Prio3Config::Sum { bits: _ }, VdafState::Prio3Field128(state)) => {
             state.encode(bytes);
         }
-        _ => panic!("prio3_append_prepare_state: {}", ERR_FIELD_TYPE),
+        _ => panic!("prio3_append_prepare_state: {ERR_FIELD_TYPE}"),
     }
     Ok(())
 }

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -91,7 +91,7 @@ impl<'srv> HpkeDecrypter<'srv> for DaphneWorker<'srv> {
             .prefix(KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG.to_string())
             .execute()
             .await
-            .map_err(|e| DapError::Fatal(format!("kv_store: {}", e)))?;
+            .map_err(|e| DapError::Fatal(format!("kv_store: {e}")))?;
 
         let hpke_config_id = if keys.keys.is_empty() {
             // Generate a new HPKE receiver config and store it in KV.
@@ -122,10 +122,10 @@ impl<'srv> HpkeDecrypter<'srv> for DaphneWorker<'srv> {
 
                 kv_store
                     .put(&new_kv_config_key, hpke_receiver_config)
-                    .map_err(|e| DapError::Fatal(format!("kv_store: {}", e)))?
+                    .map_err(|e| DapError::Fatal(format!("kv_store: {e}")))?
                     .execute()
                     .await
-                    .map_err(|e| DapError::Fatal(format!("kv_store: {}", e)))?;
+                    .map_err(|e| DapError::Fatal(format!("kv_store: {e}")))?;
             }
 
             hpke_config_id.unwrap()
@@ -196,8 +196,7 @@ fn parse_hpke_config_id_from_kv_key_name(name: &str) -> std::result::Result<u8, 
     }
 
     Err(DapError::Fatal(format!(
-        "malformed kv_store HPKE receiver config key: '{}'",
-        name
+        "malformed kv_store HPKE receiver config key: '{name}'",
     )))
 }
 

--- a/daphne_worker/src/durable/garbage_collector.rs
+++ b/daphne_worker/src/durable/garbage_collector.rs
@@ -41,7 +41,7 @@ impl DurableObject for GarbageCollector {
                     | durable::BINDING_DAP_LEADER_COL_JOB_QUEUE
                     | durable::BINDING_DAP_HELPER_STATE_STORE => (),
                     s => {
-                        let message = format!("GarbageCollector: unrecognized binding: {}", s);
+                        let message = format!("GarbageCollector: unrecognized binding: {s}");
                         error!("{}", message);
                         return Err(int_err(message));
                     }

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -83,7 +83,7 @@ impl LeaderBatchQueue {
             .await?;
 
         // Generate a random batch ID and write the batch count to the queue.
-        debug!("LeaderBatchQueue: created batch {}", batch_id_hex);
+        debug!("LeaderBatchQueue: created batch {batch_id_hex}");
         Ok(queued.into_item())
     }
 }
@@ -192,5 +192,5 @@ impl DurableObject for LeaderBatchQueue {
 }
 
 fn lookup_key(batch_id_hex: &str) -> String {
-    format!("{}/id/{}", PENDING_PREFIX, batch_id_hex)
+    format!("{PENDING_PREFIX}/id/{batch_id_hex}")
 }

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -105,13 +105,10 @@ impl DurableObject for LeaderCollectionJobQueue {
                 let collect_id_hex = collect_id.to_hex();
 
                 // If the the request is new, then put it in the job queue.
-                let pending_key = format!("pending/id/{}", collect_id_hex);
+                let pending_key = format!("pending/id/{collect_id_hex}");
                 let pending: bool = state_get_or_default(&self.state, &pending_key).await?;
-                let processed: Option<CollectResp> = state_get(
-                    &self.state,
-                    &format!("{}/{}", PROCESSED_PREFIX, collect_id_hex),
-                )
-                .await?;
+                let processed: Option<CollectResp> =
+                    state_get(&self.state, &format!("{PROCESSED_PREFIX}/{collect_id_hex}")).await?;
                 if processed.is_none() && !pending {
                     let queued = DurableOrdered::new_strictly_ordered(
                         &self.state,
@@ -147,7 +144,7 @@ impl DurableObject for LeaderCollectionJobQueue {
             (DURABLE_LEADER_COL_JOB_QUEUE_FINISH, Method::Post) => {
                 let (collect_id, collect_resp): (Id, CollectResp) = req.json().await?;
                 let collect_id_hex = collect_id.to_hex();
-                let processed_key = format!("{}/{}", PROCESSED_PREFIX, collect_id_hex);
+                let processed_key = format!("{PROCESSED_PREFIX}/{collect_id_hex}");
                 let processed: Option<CollectResp> = state_get(&self.state, &processed_key).await?;
                 if processed.is_some() {
                     return Err(int_err(
@@ -188,7 +185,7 @@ impl DurableObject for LeaderCollectionJobQueue {
                 let pending = state_get::<String>(&self.state, &pending_lookup_key)
                     .await?
                     .is_some();
-                let processed_key = format!("{}/{}", PROCESSED_PREFIX, collect_id_hex);
+                let processed_key = format!("{PROCESSED_PREFIX}/{collect_id_hex}");
                 let processed: Option<CollectResp> = state_get(&self.state, &processed_key).await?;
                 if let Some(collect_resp) = processed {
                     if pending {
@@ -212,5 +209,5 @@ impl DurableObject for LeaderCollectionJobQueue {
 }
 
 fn lookup_key(collect_id_hex: &str) -> String {
-    format!("{}/id/{}", PENDING_PREFIX, collect_id_hex)
+    format!("{PENDING_PREFIX}/id/{collect_id_hex}")
 }

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -81,19 +81,18 @@ async fn durable_request<I: Serialize, O: for<'a> Deserialize<'a>>(
 ) -> Result<O> {
     let req = match (&method, data) {
         (Method::Post, Some(data)) => Request::new_with_init(
-            &format!("https://fake-host{}", durable_path),
+            &format!("https://fake-host{durable_path}"),
             RequestInit::new().with_method(Method::Post).with_body(Some(
                 wasm_bindgen::JsValue::from_str(&serde_json::to_string(&data)?),
             )),
         )?,
         (Method::Get, None) => Request::new_with_init(
-            &format!("https://fake-host{}", durable_path),
+            &format!("https://fake-host{durable_path}"),
             RequestInit::new().with_method(Method::Get),
         )?,
         _ => {
             return Err(Error::RustError(format!(
-                "durable_request: Unrecognized method: {:?}",
-                method
+                "durable_request: Unrecognized method: {method:?}",
             )));
         }
     };
@@ -194,7 +193,7 @@ pub(crate) async fn state_set_if_not_exists<T: for<'a> Deserialize<'a> + Seriali
 }
 
 pub(crate) fn durable_name_queue(shard: u64) -> String {
-    format!("queue/{}", shard)
+    format!("queue/{shard}")
 }
 
 pub(crate) fn durable_name_report_store(
@@ -230,7 +229,7 @@ pub(crate) fn durable_name_task(version: &DapVersion, task_id_hex: &str) -> Stri
 fn durable_name_bucket(bucket: &DapBatchBucket<'_>) -> String {
     match bucket {
         DapBatchBucket::TimeInterval { batch_window } => {
-            format!("window/{}", batch_window)
+            format!("window/{batch_window}")
         }
         DapBatchBucket::FixedSize { batch_id } => {
             format!("batch/{}", batch_id.to_hex())
@@ -338,9 +337,9 @@ impl<T: for<'a> Deserialize<'a> + Serialize> DurableOrdered<T> {
     /// where `<ordinal>` is the value of the counter at the time of creation.
     pub(crate) async fn new_strictly_ordered(state: &State, item: T, prefix: &str) -> Result<Self> {
         // Get the next ordinal.
-        let next_ordinal_key = format!("{}/next_ordinal", prefix);
+        let next_ordinal_key = format!("{prefix}/next_ordinal");
         let mut next_ordinal: u64 = state_get_or_default(state, &next_ordinal_key).await?;
-        let ordinal = format!("order/{}", next_ordinal);
+        let ordinal = format!("order/{next_ordinal}");
 
         // Update the next ordinal.
         next_ordinal += 1;
@@ -393,7 +392,7 @@ async fn get_front<T: for<'a> Deserialize<'a> + Serialize>(
     prefix: &str,
     limit: Option<usize>,
 ) -> Result<Vec<DurableOrdered<T>>> {
-    let key_prefix = format!("{}/item/", prefix);
+    let key_prefix = format!("{prefix}/item/");
     let mut opt = ListOptions::new().prefix(&key_prefix);
     if let Some(limit) = limit {
         opt = opt.limit(limit);

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -196,7 +196,7 @@ impl DurableObject for ReportsPending {
                 let report_id_hex = report_id_hex_from_report(&report_hex)
                     .ok_or_else(|| int_err("failed to parse report_id from report"))?;
 
-                let key = format!("pending/{}", report_id_hex);
+                let key = format!("pending/{report_id_hex}");
                 let exists = state_set_if_not_exists::<String>(&self.state, &key, &report_hex)
                     .await?
                     .is_some();

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -39,7 +39,7 @@ pub struct ReportsProcessed {
 impl ReportsProcessed {
     /// Check if the report has been processed. If not, return None; otherwise, return the ID.
     async fn to_checked(&self, report_id_hex: String) -> Result<Option<String>> {
-        let key = format!("processed/{}", report_id_hex);
+        let key = format!("processed/{report_id_hex}");
         let processed: bool = state_set_if_not_exists(&self.state, &key, &true)
             .await?
             .unwrap_or(false);

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -523,7 +523,7 @@ pub(crate) fn int_err<S: ToString>(s: S) -> Error {
 /// changes that are on the main branch but not yet released. Thus, synchronizing this dependency
 /// between both crates is not currently feasible.
 pub(crate) fn dap_err(e: Error) -> DapError {
-    DapError::Fatal(format!("worker: {}", e))
+    DapError::Fatal(format!("worker: {e}"))
 }
 
 fn abort(e: DapAbort) -> Result<Response> {


### PR DESCRIPTION
Clippy in rust 1.67.0 is picky about these by default now.  I added a few I found along the way in other format-like things, e.g. trace!.  Probably there are more of these to gradually improve.