### PR TITLE
Alter chrono configuration to avoid an old vulnerable time crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,6 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
  "wasm-bindgen",
  "winapi",
 ]
@@ -835,7 +834,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1255,7 +1254,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -2143,17 +2142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,12 +2410,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-trait = "0.1.63"
 base64 = "0.21.0"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
 futures = "0.3.25"
 getrandom = { version = "0.2.8", features = ["js"] } # Required for prio


### PR DESCRIPTION
Chrono's default config has the "oldtime" option which pulls in an old version of the time crate which has a vulnerability (RUSTSEC-2020-0071).