### PR TITLE
taskprov: Enforce length of the shared secret for VDAF key derivation

### DIFF
--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -147,8 +147,7 @@ impl Test {
         let collector_token = BearerToken::from("This is a DIFFERENT token.");
 
         // taskprov: VDAF verification key.
-        let mut taskprov_vdaf_verify_key_init = vec![0; 32];
-        rng.fill(&mut taskprov_vdaf_verify_key_init[..]);
+        let taskprov_vdaf_verify_key_init = rng.gen::<[u8; 32]>();
 
         let prometheus_registry = prometheus::Registry::new();
 

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -60,7 +60,7 @@ pub fn compute_task_id(version: TaskprovVersion, serialized: &[u8]) -> Result<Id
 /// Extract pseudorandom key from the pre-shared secret used for the "taskprov" extension.
 pub(crate) fn extract_prk_from_verify_key_init(
     version: TaskprovVersion,
-    verify_key_init: &[u8],
+    verify_key_init: &[u8; 32],
 ) -> Prk {
     // The documentation says computing the Salt is expensive, and we use the same PRK all the
     // time, so we compute it once.
@@ -101,7 +101,7 @@ pub(crate) fn expand_prk_into_verify_key(
 #[allow(dead_code)]
 pub(crate) fn compute_vdaf_verify_key(
     version: TaskprovVersion,
-    verify_key_init: &[u8],
+    verify_key_init: &[u8; 32],
     task_id: &Id,
     vdaf_type: VdafType,
 ) -> VdafVerifyKey {
@@ -188,7 +188,7 @@ impl DapTaskConfig {
         taskprov_version: TaskprovVersion,
         task_id: &Id,
         task_config: TaskConfig,
-        vdaf_verify_key_init: &[u8],
+        vdaf_verify_key_init: &[u8; 32],
         collector_hpke_config: &HpkeConfig,
     ) -> Result<DapTaskConfig, DapError> {
         if task_config.aggregator_endpoints.len() != 2 {

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -75,7 +75,7 @@ pub(crate) struct MockAggregator {
     pub(crate) helper_state_store: Arc<Mutex<HashMap<HelperStateInfo, DapHelperState>>>,
     pub(crate) agg_store: Arc<Mutex<HashMap<Id, HashMap<DapBatchBucketOwned, AggStore>>>>,
     pub(crate) collector_hpke_config: HpkeConfig,
-    pub(crate) taskprov_vdaf_verify_key_init: Vec<u8>,
+    pub(crate) taskprov_vdaf_verify_key_init: [u8; 32],
     pub(crate) metrics: DaphneMetrics,
 
     // Leader: Reference to peer. Used to simulate HTTP requests from Leader to Helper, i.e.,

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -325,7 +325,7 @@ where
                 self.state.config.global.taskprov_version,
                 &taskprov_task_id,
                 taskprov_task_config.unwrap(),
-                taskprov.vdaf_verify_key_init.as_ref(),
+                &taskprov.vdaf_verify_key_init,
                 taskprov.hpke_collector_config.as_ref(),
             )?;
 

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -52,7 +52,7 @@ pub struct TestRunner {
     pub leader_bearer_token: String,
     pub collector_bearer_token: String,
     pub collector_hpke_receiver: HpkeReceiverConfig,
-    pub taskprov_vdaf_verify_key_init: Vec<u8>,
+    pub taskprov_vdaf_verify_key_init: [u8; 32],
     pub taskprov_collector_hpke_receiver: HpkeReceiverConfig,
     pub version: DapVersion,
 }
@@ -135,7 +135,10 @@ impl TestRunner {
             taskprov_version: TaskprovVersion::Draft02,
         };
         let taskprov_vdaf_verify_key_init =
-            hex::decode("0074a5dd6e9dac501f73f7a961193b2b").unwrap();
+            hex::decode("b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18")
+                .unwrap()
+                .try_into()
+                .unwrap();
         let taskprov_collector_hpke_receiver = HpkeReceiverConfig::try_from((
             HpkeConfig {
                 id: 23,

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -47,7 +47,7 @@ DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
 }"""
 # The secret key for the HPKE collector public key, recorded here for testing convenience:
 #     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
-DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "0074a5dd6e9dac501f73f7a961193b2b" # SECRET
+DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
 DAP_TASKPROV_LEADER_BEARER_TOKEN = "I am the leader!" # SECRET
 DAP_TASKPROV_COLLECTOR_BEARER_TOKEN = "I am the collector!" # SECRET
 DAP_DEFAULT_VERSION = "v03"
@@ -109,7 +109,7 @@ DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
 }"""
 # The secret key for the HPKE collector public key, recorded here for testing convenience:
 #     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
-DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "0074a5dd6e9dac501f73f7a961193b2b" # SECRET
+DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
 DAP_TASKPROV_LEADER_BEARER_TOKEN = "I am the leader!" # SECRET
 DAP_TASKPROV_COLLECTOR_BEARER_TOKEN = "I am the collector!" # SECRET
 DAP_DEFAULT_VERSION = "v03"


### PR DESCRIPTION
Closes #218 

The spec requires `vdaf_verify_key_init` to be 32 bytes. Our implementation currently allows this sring to any length. Enforce the length properly, and update tests to match.