### PR TITLE
daphne_worker: Enforce key separation for HPKE across DAP versions

### DIFF
--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -16,7 +16,7 @@ use crate::{
         decode_u16_bytes, encode_u16_bytes, HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId,
         HpkeKemId, Id, TransitionFailure,
     },
-    DapError,
+    DapError, DapVersion,
 };
 use async_trait::async_trait;
 use prio::codec::{CodecError, Decode, Encode};
@@ -98,6 +98,7 @@ pub trait HpkeDecrypter<'a> {
     /// Look up the HPKE configuration to use for the given task ID (if specified).
     async fn get_hpke_config_for(
         &'a self,
+        version: DapVersion,
         task_id: Option<&Id>,
     ) -> Result<Self::WrappedHpkeConfig, DapError>;
 
@@ -206,6 +207,7 @@ impl<'a> HpkeDecrypter<'a> for HpkeReceiverConfig {
 
     async fn get_hpke_config_for(
         &'a self,
+        _version: DapVersion,
         _task_id: Option<&Id>,
     ) -> Result<Self::WrappedHpkeConfig, DapError> {
         unreachable!("not implemented");

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -282,7 +282,7 @@ pub struct ProblemDetails {
 }
 
 /// DAP version used for a task.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum DapVersion {
     #[serde(rename = "v02")]
     Draft02,
@@ -291,6 +291,7 @@ pub enum DapVersion {
     Draft03,
 
     #[serde(other)]
+    #[serde(rename = "unknown_version")]
     Unknown,
 }
 
@@ -311,6 +312,12 @@ impl AsRef<str> for DapVersion {
             DapVersion::Draft03 => "v03",
             _ => panic!("tried to construct string from unknown DAP version"),
         }
+    }
+}
+
+impl std::fmt::Display for DapVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
     }
 }
 

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -157,7 +157,7 @@ where
             id = Some(Id(bytes))
         }
 
-        let hpke_config = self.get_hpke_config_for(id.as_ref()).await?;
+        let hpke_config = self.get_hpke_config_for(req.version, id.as_ref()).await?;
 
         if let Some(task_id) = id {
             let task_config = self

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -296,16 +296,18 @@ impl Test {
     }
 
     async fn gen_test_report(&self, task_id: &Id) -> Report {
+        let version = self.leader.unchecked_get_task_config(task_id).await.version;
+
         // Construct HPKE config list.
         let hpke_config_list = [
             self.leader
-                .get_hpke_config_for(Some(task_id))
+                .get_hpke_config_for(version, Some(task_id))
                 .await
                 .unwrap()
                 .as_ref()
                 .clone(),
             self.helper
-                .get_hpke_config_for(Some(task_id))
+                .get_hpke_config_for(version, Some(task_id))
                 .await
                 .unwrap()
                 .as_ref()
@@ -1465,13 +1467,13 @@ async fn e2e_taskprov(version: DapVersion) {
     // Client: Send upload request to Leader.
     let hpke_config_list = [
         t.leader
-            .get_hpke_config_for(Some(&taskprov_id))
+            .get_hpke_config_for(version, Some(&taskprov_id))
             .await
             .unwrap()
             .as_ref()
             .clone(),
         t.helper
-            .get_hpke_config_for(Some(&taskprov_id))
+            .get_hpke_config_for(version, Some(&taskprov_id))
             .await
             .unwrap()
             .as_ref()

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -240,6 +240,7 @@ impl<'a> HpkeDecrypter<'a> for MockAggregator {
 
     async fn get_hpke_config_for(
         &'a self,
+        _version: DapVersion,
         task_id: Option<&Id>,
     ) -> Result<&'a HpkeConfig, DapError> {
         if self.hpke_receiver_config_list.is_empty() {

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -279,7 +279,7 @@ pub(crate) struct DaphneWorkerState {
 
     /// Cached HPKE receiver config. This will be populated when Daphne-Worker obtains an HPKE
     /// receiver config for the first time from Cloudflare KV.
-    hpke_receiver_configs: Arc<RwLock<HashMap<u8, HpkeReceiverConfig>>>,
+    hpke_receiver_configs: Arc<RwLock<HashMap<HpkeReceiverKvKey, HpkeReceiverConfig>>>,
 
     /// Laeder bearer token per task.
     leader_bearer_tokens: Arc<RwLock<HashMap<Id, BearerToken>>>,
@@ -428,12 +428,12 @@ impl<'srv> DaphneWorker<'srv> {
     /// `hpke_config_id` is cached (if it exists).
     pub(crate) async fn get_hpke_receiver_config(
         &self,
-        hpke_config_id: u8,
+        hpke_receiver_kv_key: HpkeReceiverKvKey,
     ) -> Result<Option<GuardedHpkeReceiverConfig>> {
         self.kv_get_cached(
             &self.state.hpke_receiver_configs,
             KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG,
-            Cow::Owned(hpke_config_id),
+            Cow::Owned(hpke_receiver_kv_key),
         )
         .await
     }
@@ -782,7 +782,7 @@ impl<K: Clone + Eq + std::hash::Hash, V> Guarded<'_, K, V> {
     }
 }
 
-pub(crate) type GuardedHpkeReceiverConfig<'a> = Guarded<'a, u8, HpkeReceiverConfig>;
+pub(crate) type GuardedHpkeReceiverConfig<'a> = Guarded<'a, HpkeReceiverKvKey, HpkeReceiverConfig>;
 
 impl AsRef<HpkeConfig> for GuardedHpkeReceiverConfig<'_> {
     fn as_ref(&self) -> &HpkeConfig {
@@ -817,4 +817,60 @@ pub(crate) enum DaphneWorkerDeployment {
     /// will be registered by the garbage collector so that they can be deleted manually using the
     /// internal test API.
     Dev,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub(crate) struct HpkeReceiverKvKey {
+    pub(crate) version: DapVersion,
+    pub(crate) hpke_config_id: u8,
+}
+
+impl HpkeReceiverKvKey {
+    fn parse_from_name(name: &str) -> Option<Self> {
+        let mut iter = name.split('/');
+
+        // Read "{KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG}/version".
+        if iter.next()? != KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG || iter.next()? != "version" {
+            return None;
+        }
+
+        // Read and parse the version.
+        let version = DapVersion::from(iter.next()?);
+        if matches!(version, DapVersion::Unknown) {
+            return None;
+        }
+
+        // Read "config_id".
+        if iter.next()? != "config_id" {
+            return None;
+        }
+
+        // Read and parse the config ID.
+        let hpke_config_id = iter.next()?.parse::<u8>().ok()?;
+
+        // Make sure there is no trailing data.
+        if iter.next().is_some() {
+            return None;
+        }
+
+        Some(HpkeReceiverKvKey {
+            version,
+            hpke_config_id,
+        })
+    }
+
+    pub(crate) fn try_from_name(name: &str) -> std::result::Result<Self, DapError> {
+        Self::parse_from_name(name)
+            .ok_or_else(|| DapError::Fatal(format!("encountored invalid KV name: {name}")))
+    }
+}
+
+impl std::fmt::Display for HpkeReceiverKvKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "version/{}/config_id/{}",
+            self.version, self.hpke_config_id
+        )
+    }
 }


### PR DESCRIPTION
Closes #212.

It's a good idea to ensure that secrets aren't reused across protocol versions. Luckily, most secrets used by Daphne-Worker, are keyed by task ID, which in turn is bound to a specific version. One exception are the HPKE receiver keys.

To ensure key spearation for HPKE receiver keys, add the DAP version to the KV names. That is, instead of

  hpke_receiver_config/{config_id}

the name is

  hpke_receiver_config/{version}/{config_id}

Relatedly:

* Check for unparsable version number in the list of KV keys for HPKE receiver configurations.

* change the string representation of `DapVersion::Unknown` to "unknown_version". This is to ensure that, if this string ends up in KV, it looks more obvious that something is wrong.

NOTE: This is a deployment-breaking change.