### PR TITLE
daphne_worker: Remove prefix from metrics names

### DIFF
--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -19,17 +19,24 @@ pub struct DaphneMetrics {
 }
 
 impl DaphneMetrics {
-    /// Register Daphne metrics with the specified registry.
-    pub fn register(registry: &Registry, prefix: &str) -> Result<Self, DapError> {
+    /// Register Daphne metrics with the specified registry. If a prefix is provided, then
+    /// "{prefix_}" is prepended to the name.
+    pub fn register(registry: &Registry, prefix: Option<&str>) -> Result<Self, DapError> {
+        let front = if let Some(prefix) = prefix {
+            format!("{prefix}_")
+        } else {
+            "".into()
+        };
+
         let report_counter = register_int_counter_vec_with_registry!(
-            format!("{prefix}_report_counter"),
+            format!("{front}report_counter"),
             "Total number reports rejected, aggregated, and collected.",
             &["status"],
             registry
         )?;
 
         let aggregation_job_gauge = register_int_gauge_with_registry!(
-            format!("{prefix}_aggregation_job_gauge"),
+            format!("{front}aggregation_job_gauge"),
             "Number of running aggregation jobs.",
             registry
         )?;

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -167,7 +167,7 @@ impl Test {
             agg_store: Arc::new(Mutex::new(HashMap::new())),
             collector_hpke_config: collector_hpke_receiver_config.config.clone(),
             taskprov_vdaf_verify_key_init,
-            metrics: DaphneMetrics::register(&prometheus_registry, "test_helper").unwrap(),
+            metrics: DaphneMetrics::register(&prometheus_registry, Some("test_helper")).unwrap(),
             peer: None,
         });
 
@@ -187,7 +187,7 @@ impl Test {
             agg_store: Arc::new(Mutex::new(HashMap::new())),
             collector_hpke_config: collector_hpke_receiver_config.config,
             taskprov_vdaf_verify_key_init,
-            metrics: DaphneMetrics::register(&prometheus_registry, "test_leader").unwrap(),
+            metrics: DaphneMetrics::register(&prometheus_registry, Some("test_leader")).unwrap(),
             peer: Some(Arc::clone(&helper)),
         });
 

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -695,8 +695,10 @@ impl Test {
         let helper_hpke_config = helper_hpke_receiver_config.clone().config;
         let collector_hpke_config = collector_hpke_receiver_config.clone().config;
         let prometheus_registry = prometheus::Registry::new();
-        let leader_metrics = DaphneMetrics::register(&prometheus_registry, "test_leader").unwrap();
-        let helper_metrics = DaphneMetrics::register(&prometheus_registry, "test_helper").unwrap();
+        let leader_metrics =
+            DaphneMetrics::register(&prometheus_registry, Some("test_leader")).unwrap();
+        let helper_metrics =
+            DaphneMetrics::register(&prometheus_registry, Some("test_helper")).unwrap();
 
         Test {
             now,

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -356,9 +356,8 @@ impl DaphneWorkerState {
         // TODO Configure this client to use HTTPS only, except if running in a test environment.
         let client = reqwest_wasm::Client::new();
 
-        // TODO(cjpatton) Push metrics to gateway after handling the request.
         let prometheus_registry = Registry::new();
-        let metrics = DaphneWorkerMetrics::register(&prometheus_registry, "daphne_worker")
+        let metrics = DaphneWorkerMetrics::register(&prometheus_registry, None)
             .map_err(|e| Error::RustError(format!("failed to register metrics: {e}")))?;
 
         Ok(Self {

--- a/daphne_worker/src/metrics.rs
+++ b/daphne_worker/src/metrics.rs
@@ -16,15 +16,21 @@ pub(crate) struct DaphneWorkerMetrics {
 }
 
 impl DaphneWorkerMetrics {
-    pub(crate) fn register(registry: &Registry, prefix: &str) -> Result<Self, DapError> {
-        let daphne = DaphneMetrics::register(registry, prefix)?;
+    pub(crate) fn register(registry: &Registry, prefix: Option<&str>) -> Result<Self, DapError> {
+        let front = if let Some(prefix) = prefix {
+            format!("{prefix}_")
+        } else {
+            "".into()
+        };
 
         let http_status_code = register_int_counter_vec_with_registry!(
-            format!("{prefix}_http_status_code"),
+            format!("{front}_http_status_code"),
             "HTTP response status code.",
             &["code"],
             registry
         )?;
+
+        let daphne = DaphneMetrics::register(registry, prefix)?;
 
         Ok(Self {
             daphne,


### PR DESCRIPTION
Based on #226.

Daphne-Worker uses "daphne_worker" for the custom prefix. To make name of our service distinctive, we have named it "daphne_worker_helper1". This means that metrics pretty redundant, e.g.:

"daphne_worker_helper0_daphne_worker_http_status_code"

Make the prefix optional and remove it from Daphne-Worker. As a result, the same metric will show up as

"daphne_worker_helper0_http_status_code"