### PR TITLE
Use serde-wasm-bindgen to convert JsValues.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,7 @@ dependencies = [
  "reqwest-wasm",
  "ring",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "tracing",
@@ -1914,6 +1915,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -39,5 +39,6 @@ tracing-core = "0.1.30"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = { version = "2.3.1", features = ["serde"] }
 serde_json = "1.0.92"
+serde-wasm-bindgen = "0.4.3"
 worker = "0.0.12"
 once_cell = "1.17.0"

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -401,9 +401,8 @@ async fn get_front<T: for<'a> Deserialize<'a> + Serialize>(
     let mut js_item = iter.next()?;
     let mut res = Vec::new();
     while !js_item.done() {
-        // TODO(issue #118) Remove this deprecated dependency.
-        #[allow(deprecated)]
-        let (key, item): (String, T) = js_item.value().into_serde()?;
+        let (key, item): (String, T) =
+            serde_wasm_bindgen::from_value(js_item.value()).map_err(int_err)?;
         if key[..key_prefix.len()] != key_prefix {
             return Err(int_err("queue element key is improperly formatted"));
         }

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -93,9 +93,8 @@ impl DurableObject for ReportsPending {
                 let mut reports = Vec::with_capacity(reports_requested);
                 let mut keys = Vec::with_capacity(reports_requested);
                 while !item.done() {
-                    // TODO(issue #118) Remove this deprecated dependency.
-                    #[allow(deprecated)]
-                    let (key, report_hex): (String, String) = item.value().into_serde()?;
+                    let (key, report_hex): (String, String) =
+                        serde_wasm_bindgen::from_value(item.value()).map_err(int_err)?;
                     reports.push(report_hex);
                     keys.push(key);
                     item = iter.next()?;


### PR DESCRIPTION
Since workers-rs moves to serde-wasm-bindgen in 0.0.13, we probably should go the same way.