### PR TITLE
Upgrade dependencies and clippy 1.68.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1150,9 +1150,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -2087,9 +2087,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,18 +2133,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2215,7 +2215,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 assert_matches = "1.5.0"
-async-trait = "0.1.64"
+async-trait = "0.1.66"
 base64 = "0.21.0"
 getrandom = { version = "0.2.8", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
@@ -28,16 +28,16 @@ hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
 lazy_static = "1.4.0"
 matchit = "0.7.0"
-paste = "1.0.11"
+paste = "1.0.12"
 prio = { version = "0.10.0", features = ["prio2"] }
 prometheus = "0.13.3"
 rand = "0.8.5"
 ring = "0.16.20"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.92"
-thiserror = "1.0.38"
+serde = { version = "1.0.154", features = ["derive"] }
+serde_json = "1.0.94"
+thiserror = "1.0.39"
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.25.0", features = ["rt", "macros"] }
+tokio = { version = "1.26.0", features = ["rt", "macros"] }

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -15,10 +15,10 @@ daphne = { path = ".." }
 assert_matches = "1.5.0"
 base64 = "0.21.0"
 prio = "0.10.0"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.92"
+serde = { version = "1.0.154", features = ["derive"] }
+serde_json = "1.0.94"
 url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 reqwest = { version = "0.11.14", features = ["blocking"] }
 anyhow = "1.0.69"
-tokio = { version = "1.25.0", features = ["macros", "rt"] }
+tokio = { version = "1.26.0", features = ["macros", "rt"] }

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -848,8 +848,7 @@ impl Test {
         &mut self,
         agg_init_req: AggregateInitializeReq,
     ) -> DapHelperTransition<AggregateResp> {
-        let agg_resp = self
-            .task_config
+        self.task_config
             .vdaf
             .handle_agg_init_req(
                 &self.helper_hpke_receiver_config,
@@ -858,9 +857,7 @@ impl Test {
                 &self.helper_metrics,
             )
             .await
-            .unwrap();
-
-        agg_resp
+            .unwrap()
     }
 
     fn handle_agg_resp(

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.64"
+async-trait = "0.1.66"
 base64 = "0.21.0"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
@@ -26,19 +26,19 @@ futures = "0.3.26"
 getrandom = { version = "0.2.8", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 matchit = "0.7.0"
-paste = "1.0.11"
+paste = "1.0.12"
 prio = "0.10.0"
 prometheus = "0.13.3"
 rand = "0.8.5"
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"
-serde = { version = "1.0.152", features = ["derive"] }
-thiserror = "1.0.38"
+serde = { version = "1.0.154", features = ["derive"] }
+thiserror = "1.0.39"
 tracing = "0.1.37"
 tracing-core = "0.1.30"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.92"
-serde-wasm-bindgen = "0.4.3"
+serde_json = "1.0.94"
+serde-wasm-bindgen = "0.4.5"
 worker = "0.0.12"
-once_cell = "1.17.0"
+once_cell = "1.17.1"

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -26,8 +26,8 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.92"
+serde = { version = "1.0.154", features = ["derive"] }
+serde_json = "1.0.94"
 tracing = "0.1.37"
 worker = "0.0.12"
 
@@ -39,10 +39,10 @@ futures = "0.3.26"
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
 lazy_static = "1.4.0"
-paste = "1.0.11"
+paste = "1.0.12"
 prio = "0.10.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.14", features = ["json"] }
 ring = "0.16.20"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.26.0", features = ["full"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -60,8 +60,7 @@ pub struct TestRunner {
 #[allow(dead_code)]
 impl TestRunner {
     pub async fn default_with_version(version: DapVersion) -> Self {
-        let t = Self::with(version, &DapQueryConfig::TimeInterval).await;
-        t
+        Self::with(version, &DapQueryConfig::TimeInterval).await
     }
 
     pub async fn default() -> Self {
@@ -69,14 +68,13 @@ impl TestRunner {
     }
 
     pub async fn fixed_size(version: DapVersion) -> Self {
-        let t = Self::with(
+        Self::with(
             version,
             &DapQueryConfig::FixedSize {
                 max_batch_size: MAX_BATCH_SIZE,
             },
         )
-        .await;
-        t
+        .await
     }
 
     async fn with(version: DapVersion, query_config: &DapQueryConfig) -> Self {


### PR DESCRIPTION
async-trait 0.1.64 => 0.1.66
clap 4.1.4 => 4.1.8
once_cell 1.17.0 => 1.17.1
paste 1.0.11 => 1.0.12
serde 1.0.152 => 1.0.154
serde_json 1.0.92 => 1.0.94
tokio 1.25.0 => 1.26.0
thiserror 1.0.38 => 1.0.39

Skipped due to known incompatibilities
prio 0.10.0 => 0.11.1 (API changes, which will be addressed for DAP-04) worker 0.0.12 => 0.0.13 (https://github.com/cloudflare/daphne/issues/239) serde-wasm-bindgen 0.4.3 => 0.4.5 (blocked on issue 239)