### PR TITLE
daphne_worker: taskprov: Add support for TLS client authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ dependencies = [
 name = "daphne_worker"
 version = "0.3.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "base64 0.21.0",
  "chrono",

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -3,6 +3,8 @@
 
 //! Constants used in the DAP protocol.
 
+use crate::DapSender;
+
 // Media types for HTTP requests.
 //
 // TODO spec: Decide if media type should be enforced. (We currently don't.) In any case, it may be
@@ -37,10 +39,15 @@ pub fn media_type_for(content_type: &str) -> Option<&'static str> {
     }
 }
 
-/// Returns true if the given media type is for a DAP request sent by the Leader.
-pub(crate) fn media_type_from_leader(media_type: &'static str) -> bool {
-    matches!(
-        media_type,
-        MEDIA_TYPE_AGG_INIT_REQ | MEDIA_TYPE_AGG_CONT_REQ | MEDIA_TYPE_AGG_SHARE_REQ
-    )
+/// Return the sender that would send a message with the given media type (or none if the sender
+/// can't be determined).
+pub fn sender_for_media_type(media_type: &'static str) -> Option<DapSender> {
+    match media_type {
+        DRAFT02_MEDIA_TYPE_HPKE_CONFIG | MEDIA_TYPE_REPORT => Some(DapSender::Client),
+        MEDIA_TYPE_COLLECT_REQ => Some(DapSender::Collector),
+        MEDIA_TYPE_AGG_INIT_REQ | MEDIA_TYPE_AGG_CONT_REQ | MEDIA_TYPE_AGG_SHARE_REQ => {
+            Some(DapSender::Leader)
+        }
+        _ => None,
+    }
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -840,6 +840,14 @@ pub enum Prio3Config {
     Sum { bits: u32 },
 }
 
+/// DAP sender role.
+#[derive(Debug)]
+pub enum DapSender {
+    Client,
+    Collector,
+    Leader,
+}
+
 /// DAP request.
 #[derive(Debug)]
 pub struct DapRequest<S> {

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = "1.0.94"
 serde-wasm-bindgen = "0.5.0"
 worker = "0.0.14"
 once_cell = "1.17.1"
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/daphne_worker/src/auth.rs
+++ b/daphne_worker/src/auth.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Authorization methods for Daphne-Worker.
+
+use daphne::auth::BearerToken;
+use serde::{Deserialize, Serialize};
+
+/// HTTP client authorization for Daphne-Worker.
+pub(crate) enum DaphneWorkerAuth {
+    /// Bearer token, expected to appear in the "dap-auth-token" header.
+    BearerToken(BearerToken),
+
+    /// TLS client authentication. The client uses a certificate when establishing the TLS
+    /// connection with the expected issuer and subject. This authorization method is
+    /// Cloudflare-specific: Verifying the certificate itself is handled by the process that
+    /// invoked this Worker. The customer zone is also expected to be configured to require mutual
+    /// TLS for the route on which this Worker is listening.
+    ///
+    /// When this authorization method is used, we verify that the subject of the end-entity
+    /// certificate is one of a set of allowed subjects. We expect there to be one and only one
+    /// issuer for the end-entity certificate.
+    ///
+    /// # Caveats
+    ///
+    /// * For now, only the Helper supports TLS client auth; the Leader still expects a bearer
+    ///   token to be configured for the task.
+    ///
+    /// * For now, TLS client auth is only enabled if the taskprov extension is configured.
+    ///   Enabling this feature for other tasks will require a bit plumbing.
+    ///
+    /// # Zone configuration
+    ///
+    /// 1. SSL/TLS -> Client Certificates -> Create Client Certificate: Configure a certificate with
+    ///   either by signing a CSR (using Cloudflare's managed CA) or generating a fresh certificate
+    ///   (with the desired subject name) and secret key.
+    ///
+    /// 2. SSL/TLS -> Client Certificates -> Hosts: Add the hostname of the route on which the
+    ///    Worker is listening.
+    ///
+    /// 3. Security -> WAF -> Create mTLS Rule: Create the firewall rule. Since we only require
+    ///    authentication for POST request, the following rule is sufficient:
+    ///
+    ///    When incoming requests match…
+    ///
+    ///    ```text
+    ///        (http.host in {"<HOSTNAME>"}
+    ///          and (
+    ///           (cf.tls_client_auth.cert_verified and http.request.method eq "POST")
+    ///             or http.request.method eq "GET"
+    ///          )
+    ///        )
+    ///    ```
+    ///
+    ///    Then... Allow
+    CfTlsClientAuth {
+        /// Issuer of the end-entity certificate, a distignuished name formatted in compliance with
+        /// RFC2253. Set to the value of the "certIssuerDNRFC2253" field from the "tlsCli:wqentAuth"
+        /// structure of the incoming request:
+        /// https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties
+        cert_issuer: String,
+
+        /// Subject of the end-entity certificate, a distinguished name formatted in
+        /// compliance with RFC2253. Set to the "certSubjectDNRFC2253" field from the request's
+        /// "tlsClientAuth" structure.
+        cert_subject: String,
+    },
+}
+
+impl AsRef<BearerToken> for DaphneWorkerAuth {
+    fn as_ref(&self) -> &BearerToken {
+        match self {
+            Self::BearerToken(bearer_token) => bearer_token,
+            Self::CfTlsClientAuth { .. } => {
+                panic!("tried to use TLS client authorization as bearer token")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(try_from = "SerializedDaphneWorkerAuthMethod")]
+pub(crate) enum DaphneWorkerAuthMethod {
+    /// Expected bearer token.
+    BearerToken(BearerToken),
+
+    /// Valid issuer and subjects of the ent-entity certificate.
+    CfTlsClientAuth {
+        valid_cert_issuer: String,
+        valid_cert_subjects: Vec<String>,
+    },
+}
+
+impl AsRef<BearerToken> for DaphneWorkerAuthMethod {
+    fn as_ref(&self) -> &BearerToken {
+        match self {
+            Self::BearerToken(bearer_token) => bearer_token,
+            Self::CfTlsClientAuth { .. } => {
+                panic!("tried to use TLS client authorization as bearer token")
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SerializedDaphneWorkerAuthMethod {
+    BearerToken(String),
+    CfTlsClientAuth {
+        valid_cert_issuer: String,
+        valid_cert_subjects: Vec<String>,
+    },
+}
+
+impl From<SerializedDaphneWorkerAuthMethod> for DaphneWorkerAuthMethod {
+    fn from(serialized: SerializedDaphneWorkerAuthMethod) -> Self {
+        match serialized {
+            SerializedDaphneWorkerAuthMethod::BearerToken(bearer_token) => {
+                Self::BearerToken(BearerToken::from(bearer_token))
+            }
+            SerializedDaphneWorkerAuthMethod::CfTlsClientAuth {
+                valid_cert_issuer,
+                valid_cert_subjects,
+            } => Self::CfTlsClientAuth {
+                valid_cert_issuer,
+                valid_cert_subjects,
+            },
+        }
+    }
+}

--- a/daphne_worker/src/auth_test.rs
+++ b/daphne_worker/src/auth_test.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::auth::DaphneWorkerAuthMethod;
+use assert_matches::assert_matches;
+use daphne::auth::BearerToken;
+
+#[test]
+fn daphne_worker_auth_method_json_serialiation() {
+    let daphne_worker_auth_method: DaphneWorkerAuthMethod =
+        serde_json::from_str(r#"{"bearer_token":"the bearer token"}"#).unwrap();
+    assert_matches!(daphne_worker_auth_method,
+        DaphneWorkerAuthMethod::BearerToken(bearer_token) => {
+            bearer_token == BearerToken::from("the bearer token".to_string())
+        }
+    );
+
+    let daphne_worker_auth_method: DaphneWorkerAuthMethod = serde_json::from_str(
+        r#"{
+            "cf_tls_client_auth": {
+                "valid_cert_issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
+                "valid_cert_subjects": [
+                    "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US",
+                    "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
+                ]
+            }
+        }"#,
+    )
+    .unwrap();
+    assert_matches!(daphne_worker_auth_method,
+        DaphneWorkerAuthMethod::CfTlsClientAuth{ valid_cert_issuer, valid_cert_subjects } => {
+            valid_cert_issuer == "CN=Steve Kille,O=Isode Limited,C=GB" &&
+                valid_cert_subjects == [
+                    "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US",
+                    "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
+                ]
+        }
+    );
+}

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -596,6 +596,9 @@ pub(crate) struct InternalTestAddTask {
     task_expiration: Time,
 }
 
+mod auth;
+#[cfg(test)]
+mod auth_test;
 mod config;
 mod dap;
 mod durable;

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -48,8 +48,12 @@ DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
 # The secret key for the HPKE collector public key, recorded here for testing convenience:
 #     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
 DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
-DAP_TASKPROV_LEADER_BEARER_TOKEN = "I am the leader!" # SECRET
-DAP_TASKPROV_COLLECTOR_BEARER_TOKEN = "I am the collector!" # SECRET
+DAP_TASKPROV_LEADER_AUTH = """{
+  "bearer_token": "I am the leader!"
+}""" # SECRET
+DAP_TASKPROV_COLLECTOR_AUTH = """{
+  "bearer_token": "I am the collector!"
+}""" # SECRET
 DAP_DEFAULT_VERSION = "v03"
 DAP_TRACING = "debug"
 
@@ -110,8 +114,9 @@ DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
 # The secret key for the HPKE collector public key, recorded here for testing convenience:
 #     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
 DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
-DAP_TASKPROV_LEADER_BEARER_TOKEN = "I am the leader!" # SECRET
-DAP_TASKPROV_COLLECTOR_BEARER_TOKEN = "I am the collector!" # SECRET
+DAP_TASKPROV_LEADER_AUTH = """{
+  "bearer_token": "I am the leader!"
+}""" # SECRET
 DAP_DEFAULT_VERSION = "v03"
 DAP_TRACING = "debug"
 


### PR DESCRIPTION
Dapphne-Worker authorizes DAP sender requests using a bearer token. Replace `BearerToken` with a more general authorization method, called `DaphneWorkerAuth`, that also permits TLS client authentication.

Limitations:

* For now, only the Helper supports TLS client auth; the Leader still expects a bearer token to be configured for the task.

* For now, TLS client auth is only enabled if the taskprov extension is configured. Enabling this feature for other tasks will require a bit plumbing.