### PR TITLE
daphne_worker: Clean up authorization logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,49 +83,58 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "assert_matches"
@@ -141,7 +150,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -200,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byteorder"
@@ -310,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -321,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -341,7 +350,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -372,19 +381,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concolor-override"
+name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
-]
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -420,9 +420,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -515,7 +515,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -532,7 +532,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1093,9 +1093,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1251,9 +1251,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "link-cplusplus"
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "lock_api"
@@ -1405,9 +1405,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1426,7 +1426,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1437,9 +1437,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "poly1305"
@@ -1650,9 +1650,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prio"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2aa1f9faa3fab6f02b54025f411d6f4fcd31765765600db339280e3678ae20"
+checksum = "3675d093a7713f2b861f77b16c3c33fadd6de0a69bf7203014d938b9d5daa6f7"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm 0.10.1",
@@ -1758,11 +1758,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1781,10 +1781,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "reqwest"
-version = "0.11.16"
+name = "regex-syntax"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "reqwest"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -1883,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
  "bitflags",
  "errno",
@@ -1986,14 +1992,14 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2038,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -2158,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2206,7 +2212,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2258,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2272,18 +2278,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2298,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2330,13 +2336,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2372,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2902,5 +2908,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -728,7 +728,7 @@ pub enum Prio3Config {
 }
 
 /// DAP sender role.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum DapSender {
     Client,
     Collector,

--- a/daphne_worker/src/auth.rs
+++ b/daphne_worker/src/auth.rs
@@ -5,11 +5,21 @@
 
 use daphne::auth::BearerToken;
 use serde::{Deserialize, Serialize};
+use worker::TlsClientAuth;
 
 /// HTTP client authorization for Daphne-Worker.
-pub(crate) enum DaphneWorkerAuth {
+///
+/// Multiple authorization methods can be configured. The sender may present multiple authorization
+/// methods; the request is authorized if validation of all presented methods succeed. If an
+/// authorization method is presented, but the server is not configured to validate it, then
+/// validation of that method will fail.
+//
+// TODO(cjpatton) Add an authorization method for Cloudflare Access
+// (https://www.cloudflare.com/products/zero-trust/access/). This allows us to delegate access
+// control to that service; Daphne-Worker would just need to verify that Access granted access.
+pub(crate) struct DaphneWorkerAuth {
     /// Bearer token, expected to appear in the "dap-auth-token" header.
-    BearerToken(BearerToken),
+    pub(crate) bearer_token: Option<BearerToken>,
 
     /// TLS client authentication. The client uses a certificate when establishing the TLS
     /// connection with the expected issuer and subject. This authorization method is
@@ -17,9 +27,12 @@ pub(crate) enum DaphneWorkerAuth {
     /// invoked this Worker. The customer zone is also expected to be configured to require mutual
     /// TLS for the route on which this Worker is listening.
     ///
-    /// When this authorization method is used, we verify that the subject of the end-entity
-    /// certificate is one of a set of allowed subjects. We expect there to be one and only one
-    /// issuer for the end-entity certificate.
+    /// When this authorization method is used, we verify that the following:
+    ///
+    /// * A certificate was presented and was successfully verified by the TLS server
+    ///
+    /// * The certificate details match those of one of a preconfigured set of trusted
+    /// certificates.
     ///
     /// # Caveats
     ///
@@ -28,103 +41,71 @@ pub(crate) enum DaphneWorkerAuth {
     ///
     /// * For now, TLS client auth is only enabled if the taskprov extension is configured.
     ///   Enabling this feature for other tasks will require a bit plumbing.
-    ///
-    /// # Zone configuration
-    ///
-    /// 1. SSL/TLS -> Client Certificates -> Create Client Certificate: Configure a certificate with
-    ///   either by signing a CSR (using Cloudflare's managed CA) or generating a fresh certificate
-    ///   (with the desired subject name) and secret key.
-    ///
-    /// 2. SSL/TLS -> Client Certificates -> Hosts: Add the hostname of the route on which the
-    ///    Worker is listening.
-    ///
-    /// 3. Security -> WAF -> Create mTLS Rule: Create the firewall rule. Since we only require
-    ///    authentication for POST request, the following rule is sufficient:
-    ///
-    ///    When incoming requests match…
-    ///
-    ///    ```text
-    ///        (http.host in {"<HOSTNAME>"}
-    ///          and (
-    ///           (cf.tls_client_auth.cert_verified and http.request.method eq "POST")
-    ///             or http.request.method eq "GET"
-    ///          )
-    ///        )
-    ///    ```
-    ///
-    ///    Then... Allow
-    CfTlsClientAuth {
-        /// Issuer of the end-entity certificate, a distignuished name formatted in compliance with
-        /// RFC2253. Set to the value of the "certIssuerDNRFC2253" field from the "tlsCli:wqentAuth"
-        /// structure of the incoming request:
-        /// https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties
-        cert_issuer: String,
-
-        /// Subject of the end-entity certificate, a distinguished name formatted in
-        /// compliance with RFC2253. Set to the "certSubjectDNRFC2253" field from the request's
-        /// "tlsClientAuth" structure.
-        cert_subject: String,
-    },
+    pub(crate) cf_tls_client_auth: Option<TlsClientAuth>,
 }
 
 impl AsRef<BearerToken> for DaphneWorkerAuth {
     fn as_ref(&self) -> &BearerToken {
-        match self {
-            Self::BearerToken(bearer_token) => bearer_token,
-            Self::CfTlsClientAuth { .. } => {
-                panic!("tried to use TLS client authorization as bearer token")
-            }
+        if let Some(ref bearer_token) = self.bearer_token {
+            bearer_token
+        } else {
+            // We would only try this method if we previously resolved to use a bearer token for
+            // authorization.
+            unreachable!("no bearer token provided by sender")
         }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(try_from = "SerializedDaphneWorkerAuthMethod")]
-pub(crate) enum DaphneWorkerAuthMethod {
+pub(crate) struct DaphneWorkerAuthMethod {
     /// Expected bearer token.
-    BearerToken(BearerToken),
+    pub(crate) bearer_token: Option<BearerToken>,
 
-    /// Valid issuer and subjects of the ent-entity certificate.
-    CfTlsClientAuth {
-        valid_cert_issuer: String,
-        valid_cert_subjects: Vec<String>,
-    },
+    /// Details of trusted TLS client certificates.
+    pub(crate) cf_tls_client_auth: Option<Vec<TlsCertInfo>>,
+}
+
+/// TLS certificate details related to authorization.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct TlsCertInfo {
+    /// Certificate issuer. Checked against the value of the "certIssuerDNRFC2253" field from the
+    /// "tlsClientAuth" object passed by the Workers runtime to the request handler.
+    /// https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties
+    pub(crate) issuer: String,
+
+    /// Certificate subject. Checked against the value of the "certSubjectDNRFC2253" field from the
+    /// "tlsClientAuth" object passed by the Workers runtime to the request handler.
+    pub(crate) subject: String,
 }
 
 impl AsRef<BearerToken> for DaphneWorkerAuthMethod {
     fn as_ref(&self) -> &BearerToken {
-        match self {
-            Self::BearerToken(bearer_token) => bearer_token,
-            Self::CfTlsClientAuth { .. } => {
-                panic!("tried to use TLS client authorization as bearer token")
-            }
+        if let Some(ref bearer_token) = self.bearer_token {
+            bearer_token
+        } else {
+            // We would only try this method if we previously resolved to use a bearer token for
+            // authorization.
+            unreachable!("no bearer token provided by sender")
         }
     }
 }
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum SerializedDaphneWorkerAuthMethod {
-    BearerToken(String),
-    CfTlsClientAuth {
-        valid_cert_issuer: String,
-        valid_cert_subjects: Vec<String>,
-    },
+struct SerializedDaphneWorkerAuthMethod {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bearer_token: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cf_tls_client_auth: Option<Vec<TlsCertInfo>>,
 }
 
 impl From<SerializedDaphneWorkerAuthMethod> for DaphneWorkerAuthMethod {
     fn from(serialized: SerializedDaphneWorkerAuthMethod) -> Self {
-        match serialized {
-            SerializedDaphneWorkerAuthMethod::BearerToken(bearer_token) => {
-                Self::BearerToken(BearerToken::from(bearer_token))
-            }
-            SerializedDaphneWorkerAuthMethod::CfTlsClientAuth {
-                valid_cert_issuer,
-                valid_cert_subjects,
-            } => Self::CfTlsClientAuth {
-                valid_cert_issuer,
-                valid_cert_subjects,
-            },
+        Self {
+            bearer_token: serialized.bearer_token.map(BearerToken::from),
+            cf_tls_client_auth: serialized.cf_tls_client_auth,
         }
     }
 }

--- a/daphne_worker/src/auth_test.rs
+++ b/daphne_worker/src/auth_test.rs
@@ -1,39 +1,73 @@
 // Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use crate::auth::DaphneWorkerAuthMethod;
-use assert_matches::assert_matches;
+use crate::auth::{DaphneWorkerAuthMethod, TlsCertInfo};
 use daphne::auth::BearerToken;
 
 #[test]
 fn daphne_worker_auth_method_json_serialiation() {
     let daphne_worker_auth_method: DaphneWorkerAuthMethod =
         serde_json::from_str(r#"{"bearer_token":"the bearer token"}"#).unwrap();
-    assert_matches!(daphne_worker_auth_method,
-        DaphneWorkerAuthMethod::BearerToken(bearer_token) => {
-            bearer_token == BearerToken::from("the bearer token".to_string())
-        }
+    assert_eq!(
+        daphne_worker_auth_method.bearer_token,
+        Some(BearerToken::from("the bearer token".to_string()))
     );
+    assert!(daphne_worker_auth_method.cf_tls_client_auth.is_none());
+
+    let trusted_certs = vec![
+        TlsCertInfo {
+            issuer: "CN=Steve Kille,O=Isode Limited,C=GB".into(),
+            subject: "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US".into(),
+        },
+        TlsCertInfo {
+            issuer: "CN=Steve Kille,O=Isode Limited,C=GB".into(),
+            subject: "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB".into(),
+        },
+    ];
 
     let daphne_worker_auth_method: DaphneWorkerAuthMethod = serde_json::from_str(
         r#"{
-            "cf_tls_client_auth": {
-                "valid_cert_issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
-                "valid_cert_subjects": [
-                    "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US",
-                    "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
-                ]
-            }
+            "cf_tls_client_auth": [
+                {
+                  "issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
+                  "subject": "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US"
+                },
+                {
+                  "issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
+                  "subject": "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
+                }
+              ]
         }"#,
     )
     .unwrap();
-    assert_matches!(daphne_worker_auth_method,
-        DaphneWorkerAuthMethod::CfTlsClientAuth{ valid_cert_issuer, valid_cert_subjects } => {
-            valid_cert_issuer == "CN=Steve Kille,O=Isode Limited,C=GB" &&
-                valid_cert_subjects == [
-                    "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US",
-                    "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
-                ]
-        }
+    assert_eq!(
+        daphne_worker_auth_method.cf_tls_client_auth,
+        Some(trusted_certs.clone()),
+    );
+    assert!(daphne_worker_auth_method.bearer_token.is_none());
+
+    let daphne_worker_auth_method: DaphneWorkerAuthMethod = serde_json::from_str(
+        r#"{
+            "bearer_token": "the bearer token",
+            "cf_tls_client_auth": [
+                {
+                  "issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
+                  "subject": "OU=Sales+CN=J. Smith,O=Widget Inc.,C=US"
+                },
+                {
+                  "issuer": "CN=Steve Kille,O=Isode Limited,C=GB",
+                  "subject": "CN=L. Eagle,O=Sue\\, Grabbit and Runn,C=GB"
+                }
+             ]
+        }"#,
+    )
+    .unwrap();
+    assert_eq!(
+        daphne_worker_auth_method.bearer_token,
+        Some(BearerToken::from("the bearer token".to_string()))
+    );
+    assert_eq!(
+        daphne_worker_auth_method.cf_tls_client_auth,
+        Some(trusted_certs),
     );
 }

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -45,7 +45,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard},
     time::Duration,
 };
-use tracing::{debug, error, info, trace};
+use tracing::{error, info, trace};
 use worker::{kv::KvStore, *};
 
 pub(crate) const KV_KEY_PREFIX_HPKE_RECEIVER_CONFIG: &str = "hpke_receiver_config";
@@ -930,31 +930,17 @@ impl<'srv> DaphneWorker<'srv> {
         let version = self.extract_version_parameter(&req)?;
 
         // Determine the authorization method used by the sender.
-        let bearer_token = req.headers().get("DAP-Auth-Token")?.map(BearerToken::from);
-        let mut tls_client_auth = req.cf().tls_client_auth();
-        if let Some(auth) = &tls_client_auth {
-            // The runtime gives us a tls_client_auth whether the communication was secured by it or
-            // not, so if a certificate wasn't presented or isn't valid, treat it as if it weren't
-            // there. We don't think the runtime would deliver a verified value that wasn't SUCCESS if a
-            // certificate had been presented, but we're not sure so we are checking. One can argue
-            // that a bad certificate should cause a definitive rejection rather than simply ignoring
-            // the certificate.
-            if auth.cert_presented() != "1" || auth.cert_verified() != "SUCCESS" {
-                tls_client_auth = None;
-            }
-        }
-        let sender_auth = match (bearer_token, tls_client_auth) {
-            (Some(bearer_token), None) => Some(DaphneWorkerAuth::BearerToken(bearer_token)),
-            (None, Some(tls_client_auth)) => Some(DaphneWorkerAuth::CfTlsClientAuth {
-                cert_issuer: tls_client_auth.cert_issuer_dn_rfc2253(),
-                cert_subject: tls_client_auth.cert_subject_dn_rfc2253(),
-            }),
-            (None, None) => None, // No authorization method provided
-            (Some(..), Some(..)) => {
-                debug!("ambiguous authorization method: both a bearer token and TLS client cert were provided");
-                None
-            }
-        };
+        let sender_auth = Some(DaphneWorkerAuth {
+            bearer_token: req.headers().get("DAP-Auth-Token")?.map(BearerToken::from),
+
+            // The runtime gives us a cf_tls_client_auth whether the communication was secured by
+            // it or not, so if a certificate wasn't presented, treat it as if it weren't there.
+            // Literal "1" indicates that a certificate was presented.
+            cf_tls_client_auth: req
+                .cf()
+                .tls_client_auth()
+                .filter(|auth| auth.cert_presented() == "1"),
+        });
 
         let content_type = req.headers().get("Content-Type")?;
         let media_type = DapMediaType::from_str_for_version(version, content_type.as_deref());
@@ -1056,7 +1042,7 @@ impl<'srv> DaphneWorker<'srv> {
             })?,
         );
 
-        if let Some(DaphneWorkerAuth::BearerToken(bearer_token)) = req.sender_auth {
+        if let Some(bearer_token) = req.sender_auth.and_then(|auth| auth.bearer_token) {
             headers.insert(
                 reqwest_wasm::header::HeaderName::from_static("dap-auth-token"),
                 reqwest_wasm::header::HeaderValue::from_str(bearer_token.as_ref()).map_err(


### PR DESCRIPTION
Currently either TLS client auth or a bearer token can be used to
authorize requests for taskprov tasks, but not both. This is problematic
from a deployment perspective, as we're likely to need to have both
methods in use while we transition to the new authorization method (TLS
client auth). This change modifies the authorization logic in
Daphne-Worker to validation all authorization methods presented and
authorize the request if all validate.

In addition, currently only one issuer/subject pair is trusted for the
certificate. In practice we're likely to issue certificates from
multiple issuers. This change replaces the single issuer/subject pair
with a sequence of trusted pairs.