### PR TITLE
Fix docker upload workflow

### DIFF
--- a/.github/workflows/daphneci.yml
+++ b/.github/workflows/daphneci.yml
@@ -60,4 +60,5 @@ jobs:
           file: ./docker/miniflare.Dockerfile
           target: helper
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
tags and labels were mixed. This prevents build and publication to be successful.