### PR TITLE
Fix docker image publication tag

### DIFF
--- a/.github/workflows/daphneci.yml
+++ b/.github/workflows/daphneci.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Checking out
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: 🏷️ Docker meta
+        id: meta
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0
         with:
           images: |


### PR DESCRIPTION
`tags` and `labels` of cloudflare/daphne-worker-helper are set by `Docker meta` build step in `daphneci.yml` workflow. We should assign an ID to this step to be able to use its output in a later workflow.

Hopefully that's the final fix.