### PR TITLE
Revert "Upgrade worker and serde-wasm-bindgen"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
 dependencies = [
  "js-sys",
  "serde",
@@ -2445,6 +2445,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2650,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.0.14"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebe8a8b8570b17d9d012f48a3b4edf833ce96caa15a9270317640bf39f87e59"
+checksum = "0ca55ce51b3bf01da5a20598af220c5d3abf91f1978a50a0620ef966c39e3180"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2664,7 +2666,6 @@ dependencies = [
  "matchit 0.4.6",
  "pin-project",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
  "url",
  "wasm-bindgen",
@@ -2678,13 +2679,12 @@ dependencies = [
 
 [[package]]
 name = "worker-kv"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4b9fe1a87b7aef252fceb4f30bf6303036a5de329c81ccad9be9c35d1fdbc7"
+checksum = "682cbd728f179cc810b2ab77a2534da817b973e190ab184ab8efe1058b0dba84"
 dependencies = [
  "js-sys",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "wasm-bindgen",
@@ -2693,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.0.8"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86b080d7a6472a244fd1b5b1f36be3dc53942aef13e716724a4b74715708afc"
+checksum = "1c29ce5a41f5e7e644bc683681b62aed3adac838e01d18eb4e02a4dc30d4ac69"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -2709,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.0.8"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b842e2ac2871c2d83e50ce8e8844fc3893666d1c16825b809505de6506ad4487"
+checksum = "825732b9b6360d6b1f5f614248317826cebf4878e36f61ccc71ca9dd53de8b41"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -39,8 +39,8 @@ tracing-core = "0.1.30"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = { version = "2.3.1", features = ["serde"] }
 serde_json = "1.0.94"
-serde-wasm-bindgen = "0.5.0"
-worker = "0.0.14"
+serde-wasm-bindgen = "0.4.5"
+worker = "0.0.12"
 once_cell = "1.17.1"
 
 [dev-dependencies]

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -875,7 +875,7 @@ impl<'srv> DaphneWorker<'srv> {
             (Some(bearer_token), None) => Some(DaphneWorkerAuth::BearerToken(bearer_token)),
             (None, Some(tls_client_auth)) => Some(DaphneWorkerAuth::CfTlsClientAuth {
                 cert_issuer: tls_client_auth.cert_issuer_dn_rfc2253(),
-                cert_subject: tls_client_auth.cert_subject_dn_rfc2253(),
+                cert_subject: tls_client_auth.cert_subject_dn_rfc225(),
             }),
             (None, None) => None, // No authorization method provided
             (Some(..), Some(..)) => {

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -29,7 +29,7 @@ daphne_worker = { path = "../daphne_worker" }
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
 tracing = "0.1.37"
-worker = "0.0.14"
+worker = "0.0.12"
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
Based on #253 (merge that first).

Downgrade worker 0.0.14 -> 0.0.12 and serde-wasm-bindgen -> 0.5.0 -> 0.4.5. In particular:

1. Revert commit 92903d8bdfdd121df588cffa1c9d44a95c2dde97

3. daphne_worker: Address an API-breaking change in worker

We observed bugs in workers-rs 0.0.14 that we could not reproduce locally (wrangler dev), but only in Workers. We have not yet determined the root cause, but it seemed to be associated with known bugs in 0.0.14.

The next version, 0.0.15, is out, but we will need to test it thoroughly before we move to it. See #251.