### PR TITLE
Clean up the docker image to get it to build

### DIFF
--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -1,9 +1,13 @@
-FROM rust:1.63-alpine AS builder
+FROM rust:1.68-alpine AS builder
 WORKDIR /tmp/dap_test
-RUN apk add --update npm bash g++ openssl-dev
-RUN npm install -g n wasm-pack && \
-    n 18.4.0
-RUN npm install -g wrangler@2.1.13
+RUN apk add --update \
+    bash \
+    g++ \
+    make \
+    npm \
+    openssl-dev \
+    wasm-pack
+RUN npm install -g wrangler@2.12.2
 
 # Pre-install worker-build and Rust's wasm32 target to speed up our custom build command
 RUN cargo install --git https://github.com/cloudflare/workers-rs
@@ -18,9 +22,7 @@ RUN wrangler publish --dry-run
 
 FROM alpine:3.16 AS test
 RUN apk add --update npm bash
-RUN npm install -g n && \
-    n 18.4.0
-RUN npm install -g miniflare@2.11.0
+RUN npm install -g miniflare@2.12.2
 COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
 COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
 # `-B ""` to skip build command.


### PR DESCRIPTION
* Update the base image for rust 1.68
* Use alpine's distribution of wasm-pack
* Update wrangler and miniflare to latest we're testing with (2.12.2)
* Don't specify the node version to use