### PR TITLE
draft02: Fix media type for AggregateContinueResp

### DIFF
--- a/daphne/dapf/src/bin/dapf.rs
+++ b/daphne/dapf/src/bin/dapf.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use daphne::{
-    constants,
+    constants::DapMediaType,
     hpke::HpkeReceiverConfig,
     messages::{BatchSelector, Collection, CollectionReq, HpkeConfig, Query, TaskId},
     DapMeasurement, DapVersion, ProblemDetails, VdafConfig,
@@ -123,7 +123,12 @@ async fn main() -> Result<()> {
             let mut headers = reqwest::header::HeaderMap::new();
             headers.insert(
                 reqwest::header::CONTENT_TYPE,
-                reqwest::header::HeaderValue::from_static(constants::MEDIA_TYPE_REPORT),
+                reqwest::header::HeaderValue::from_str(
+                    DapMediaType::Report
+                        .as_str_for_version(version)
+                        .expect("failed to construct content-type value"),
+                )
+                .expect("failecd to construct content-type header"),
             );
             let resp = http_client
                 .post(Url::parse(leader_url)?.join("upload")?)
@@ -164,7 +169,12 @@ async fn main() -> Result<()> {
             let mut headers = reqwest::header::HeaderMap::new();
             headers.insert(
                 reqwest::header::CONTENT_TYPE,
-                reqwest::header::HeaderValue::from_static(constants::MEDIA_TYPE_COLLECT_REQ),
+                reqwest::header::HeaderValue::from_str(
+                    DapMediaType::CollectReq
+                        .as_str_for_version(version)
+                        .expect("failed to construct content-type value"),
+                )
+                .expect("failed to construct content-type hader"),
             );
             if let Some(ref token) = cli.bearer_token {
                 headers.insert(

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -6,76 +6,144 @@
 use crate::{DapSender, DapVersion};
 
 // Media types for HTTP requests.
-//
-// TODO spec: Decide if media type should be enforced. (We currently don't.) In any case, it may be
-// useful to enforce this for testing purposes.
-pub const DRAFT02_MEDIA_TYPE_HPKE_CONFIG: &str = "application/dap-hpke-config";
-pub const DRAFT02_MEDIA_TYPE_AGG_INIT_REQ: &str = "application/dap-aggregate-initialize-req";
-pub const DRAFT02_MEDIA_TYPE_AGG_INIT_RESP: &str = "application/dap-aggregate-initialize-resp";
-pub const DRAFT02_MEDIA_TYPE_AGG_CONT_REQ: &str = "application/dap-aggregate-continue-req";
-pub const DRAFT02_MEDIA_TYPE_AGG_CONT_RESP: &str = "application/dap-aggregate-continue-resp";
-pub const DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP: &str = "application/dap-aggregate-share-resp";
-pub const DRAFT02_MEDIA_TYPE_COLLECT_RESP: &str = "application/dap-collect-resp";
-pub const MEDIA_TYPE_HPKE_CONFIG_LIST: &str = "application/dap-hpke-config-list";
-pub const MEDIA_TYPE_REPORT: &str = "application/dap-report";
-pub const MEDIA_TYPE_AGG_INIT_REQ: &str = "application/dap-aggregation-job-init-req";
-pub const MEDIA_TYPE_AGG_INIT_RESP: &str = "application/dap-aggregation-job-resp";
-pub const MEDIA_TYPE_AGG_CONT_REQ: &str = "application/dap-aggregation-job-continue-req";
-pub const MEDIA_TYPE_AGG_CONT_RESP: &str = "application/dap-aggregation-job-continue-resp";
-pub const MEDIA_TYPE_AGG_SHARE_REQ: &str = "application/dap-aggregate-share-req";
-pub const MEDIA_TYPE_AGG_SHARE_RESP: &str = "application/dap-aggregate-share";
-pub const MEDIA_TYPE_COLLECT_REQ: &str = "application/dap-collect-req";
-pub const MEDIA_TYPE_COLLECT_RESP: &str = "application/dap-collection";
+const DRAFT02_MEDIA_TYPE_AGG_CONT_REQ: &str = "application/dap-aggregate-continue-req";
+const DRAFT02_MEDIA_TYPE_AGG_CONT_RESP: &str = "application/dap-aggregate-continue-resp";
+const DRAFT02_MEDIA_TYPE_AGG_INIT_REQ: &str = "application/dap-aggregate-initialize-req";
+const DRAFT02_MEDIA_TYPE_AGG_INIT_RESP: &str = "application/dap-aggregate-initialize-resp";
+const DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP: &str = "application/dap-aggregate-share-resp";
+const DRAFT02_MEDIA_TYPE_COLLECT_RESP: &str = "application/dap-collect-resp";
+const DRAFT02_MEDIA_TYPE_HPKE_CONFIG: &str = "application/dap-hpke-config";
+const MEDIA_TYPE_AGG_JOB_CONT_REQ: &str = "application/dap-aggregation-job-continue-req";
+const MEDIA_TYPE_AGG_JOB_INIT_REQ: &str = "application/dap-aggregation-job-init-req";
+const MEDIA_TYPE_AGG_JOB_RESP: &str = "application/dap-aggregation-job-resp";
+const MEDIA_TYPE_AGG_SHARE_REQ: &str = "application/dap-aggregate-share-req";
+const MEDIA_TYPE_AGG_SHARE: &str = "application/dap-aggregate-share";
+const MEDIA_TYPE_COLLECTION: &str = "application/dap-collection";
+const MEDIA_TYPE_COLLECT_REQ: &str = "application/dap-collect-req";
+const MEDIA_TYPE_HPKE_CONFIG_LIST: &str = "application/dap-hpke-config-list";
+const MEDIA_TYPE_REPORT: &str = "application/dap-report";
 
-/// Check if the provided value for the HTTP Content-Type is valid media type for DAP. If so, then
-/// return a static reference to the media type.
-pub fn media_type_for(content_type: &str) -> Option<&'static str> {
-    match content_type {
-        DRAFT02_MEDIA_TYPE_HPKE_CONFIG => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
-        MEDIA_TYPE_REPORT => Some(MEDIA_TYPE_REPORT),
-        DRAFT02_MEDIA_TYPE_AGG_INIT_REQ => Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ),
-        MEDIA_TYPE_AGG_INIT_REQ => Some(MEDIA_TYPE_AGG_INIT_REQ),
-        DRAFT02_MEDIA_TYPE_AGG_INIT_RESP => Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP),
-        MEDIA_TYPE_AGG_INIT_RESP => Some(MEDIA_TYPE_AGG_INIT_RESP),
-        DRAFT02_MEDIA_TYPE_AGG_CONT_REQ => Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ),
-        MEDIA_TYPE_AGG_CONT_REQ => Some(MEDIA_TYPE_AGG_CONT_REQ),
-        DRAFT02_MEDIA_TYPE_AGG_CONT_RESP => Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP),
-        MEDIA_TYPE_AGG_CONT_RESP => Some(MEDIA_TYPE_AGG_CONT_RESP),
-        MEDIA_TYPE_AGG_SHARE_REQ => Some(MEDIA_TYPE_AGG_SHARE_REQ),
-        DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-        MEDIA_TYPE_AGG_SHARE_RESP => Some(MEDIA_TYPE_AGG_SHARE_RESP),
-        MEDIA_TYPE_COLLECT_REQ => Some(MEDIA_TYPE_COLLECT_REQ),
-        DRAFT02_MEDIA_TYPE_COLLECT_RESP => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-        MEDIA_TYPE_COLLECT_RESP => Some(MEDIA_TYPE_COLLECT_RESP),
-        _ => None,
-    }
+/// Media type for each DAP request. This is included in the "content-type" HTTP header.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DapMediaType {
+    AggregationJobInitReq,
+    AggregationJobResp,
+    AggregationJobContinueReq,
+    /// draft02 compatibility: the latest draft doesn't define a separate media type for initialize
+    /// and continue responses, but draft02 does.
+    Draft02AggregateContinueResp,
+    AggregateShareReq,
+    AggregateShare,
+    CollectReq,
+    Collection,
+    HpkeConfigList,
+    Report,
+    /// The content-type does not match a known media type.
+    Invalid(String),
+    /// No content-type header found.
+    Missing,
 }
 
-/// draft02 compatibility: Substitute the content type with the corresponding media type for the
-/// older version of the protocol if necessary.
-pub fn versioned_media_type_for(version: &DapVersion, content_type: &str) -> Option<&'static str> {
-    match (version, content_type) {
-        (DapVersion::Draft02, MEDIA_TYPE_AGG_INIT_REQ) => Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ),
-        (DapVersion::Draft02, MEDIA_TYPE_AGG_INIT_RESP) => Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP),
-        (DapVersion::Draft02, MEDIA_TYPE_AGG_CONT_REQ) => Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ),
-        (DapVersion::Draft02, MEDIA_TYPE_AGG_CONT_RESP) => Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP),
-        (DapVersion::Draft02, MEDIA_TYPE_AGG_SHARE_RESP) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-        (DapVersion::Draft02, MEDIA_TYPE_COLLECT_RESP) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-        _ => media_type_for(content_type),
+impl DapMediaType {
+    /// Return the sender that would send a DAP request or response with the given media type (or
+    /// none if the sender can't be determined).
+    pub fn sender(&self) -> Option<DapSender> {
+        match self {
+            Self::AggregationJobInitReq
+            | Self::AggregationJobContinueReq
+            | Self::AggregateShareReq
+            | Self::Collection
+            | Self::HpkeConfigList => Some(DapSender::Leader),
+            Self::AggregationJobResp
+            | Self::Draft02AggregateContinueResp
+            | Self::AggregateShare => Some(DapSender::Helper),
+            Self::Report => Some(DapSender::Client),
+            Self::CollectReq => Some(DapSender::Collector),
+            Self::Invalid(..) | Self::Missing => None,
+        }
     }
-}
 
-/// Return the sender that would send a message with the given media type (or none if the sender
-/// can't be determined).
-pub fn sender_for_media_type(media_type: &'static str) -> Option<DapSender> {
-    match media_type {
-        DRAFT02_MEDIA_TYPE_HPKE_CONFIG | MEDIA_TYPE_REPORT => Some(DapSender::Client),
-        MEDIA_TYPE_COLLECT_REQ => Some(DapSender::Collector),
-        MEDIA_TYPE_AGG_INIT_REQ
-        | MEDIA_TYPE_AGG_CONT_REQ
-        | MEDIA_TYPE_AGG_SHARE_REQ
-        | DRAFT02_MEDIA_TYPE_AGG_INIT_REQ
-        | DRAFT02_MEDIA_TYPE_AGG_CONT_REQ => Some(DapSender::Leader),
-        _ => None,
+    /// Parse the media type from the content-type HTTP header.
+    pub fn from_str_for_version(version: DapVersion, content_type: Option<&str>) -> Self {
+        match (version, content_type) {
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)) => {
+                Self::AggregationJobContinueReq
+            }
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)) => {
+                Self::Draft02AggregateContinueResp
+            }
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)) => {
+                Self::AggregationJobInitReq
+            }
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_RESP)) => Self::AggregationJobResp,
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_SHARE)) => Self::AggregateShare,
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
+            (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
+            (DapVersion::Draft02, Some(MEDIA_TYPE_AGG_SHARE_REQ))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => Self::AggregateShareReq,
+            (DapVersion::Draft02, Some(MEDIA_TYPE_COLLECT_REQ))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_COLLECT_REQ)) => Self::CollectReq,
+            (DapVersion::Draft02, Some(MEDIA_TYPE_REPORT))
+            | (DapVersion::Draft04, Some(MEDIA_TYPE_REPORT)) => Self::Report,
+            (_, Some(content_type)) => Self::Invalid(content_type.to_string()),
+            (_, None) => Self::Missing,
+        }
+    }
+
+    /// Get the content-type representation of the media type.
+    pub fn as_str_for_version(&self, version: DapVersion) -> Option<&str> {
+        match (version, self) {
+            (DapVersion::Draft02, Self::AggregationJobInitReq) => {
+                Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
+            }
+            (DapVersion::Draft04, Self::AggregationJobInitReq) => Some(MEDIA_TYPE_AGG_JOB_INIT_REQ),
+            (DapVersion::Draft02, Self::AggregationJobResp) => {
+                Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
+            }
+            (DapVersion::Draft04, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
+            (DapVersion::Draft02, Self::AggregationJobContinueReq) => {
+                Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
+            }
+            (DapVersion::Draft04, Self::AggregationJobContinueReq) => {
+                Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)
+            }
+            (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
+                Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
+            }
+            (_, Self::Draft02AggregateContinueResp) => None,
+            (DapVersion::Draft02, Self::AggregateShareReq)
+            | (DapVersion::Draft04, Self::AggregateShareReq) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
+            (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
+            (DapVersion::Draft04, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
+            (DapVersion::Draft02, Self::CollectReq) | (DapVersion::Draft04, Self::CollectReq) => {
+                Some(MEDIA_TYPE_COLLECT_REQ)
+            }
+            (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
+            (DapVersion::Draft04, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
+            (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
+            (DapVersion::Draft04, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
+            (DapVersion::Draft02, Self::Report) | (DapVersion::Draft04, Self::Report) => {
+                Some(MEDIA_TYPE_REPORT)
+            }
+            (_, Self::Invalid(ref content_type)) => Some(content_type),
+            (_, Self::Missing) => None,
+            (DapVersion::Unknown, _) => unreachable!("unhandled version {version:?}"),
+        }
+    }
+
+    /// draft02 compatibility: Construct the media type for the response to an
+    /// AggregatecontinueResp. This various depending upon the version used.
+    pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
+        match version {
+            DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
+            DapVersion::Draft04 => Self::AggregationJobResp,
+            _ => unreachable!("unhandled version {version:?}"),
+        }
     }
 }

--- a/daphne/src/constants_test.rs
+++ b/daphne/src/constants_test.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{constants::DapMediaType, DapVersion};
+
+#[test]
+fn from_str_for_version() {
+    // draft02, Section 8.1
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-hpke-config")
+        ),
+        DapMediaType::HpkeConfigList
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-initialize-req")
+        ),
+        DapMediaType::AggregationJobInitReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-initialize-resp")
+        ),
+        DapMediaType::AggregationJobResp,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-continue-req")
+        ),
+        DapMediaType::AggregationJobContinueReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-continue-resp")
+        ),
+        DapMediaType::Draft02AggregateContinueResp,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-share-req")
+        ),
+        DapMediaType::AggregateShareReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-aggregate-share-resp")
+        ),
+        DapMediaType::AggregateShare,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-collect-req")
+        ),
+        DapMediaType::CollectReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft02,
+            Some("application/dap-collect-resp")
+        ),
+        DapMediaType::Collection,
+    );
+
+    // draft04, Section 8.1
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-hpke-config-list")
+        ),
+        DapMediaType::HpkeConfigList
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-aggregation-job-init-req")
+        ),
+        DapMediaType::AggregationJobInitReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-aggregation-job-resp")
+        ),
+        DapMediaType::AggregationJobResp,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-aggregation-job-continue-req")
+        ),
+        DapMediaType::AggregationJobContinueReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-aggregate-share-req")
+        ),
+        DapMediaType::AggregateShareReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-aggregate-share")
+        ),
+        DapMediaType::AggregateShare,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(
+            DapVersion::Draft04,
+            Some("application/dap-collect-req")
+        ),
+        DapMediaType::CollectReq,
+    );
+    assert_eq!(
+        DapMediaType::from_str_for_version(DapVersion::Draft04, Some("application/dap-collection")),
+        DapMediaType::Collection,
+    );
+
+    // Invalid media type
+    assert_eq!(
+        DapMediaType::from_str_for_version(DapVersion::Draft04, Some("blah-blah-blah")),
+        DapMediaType::Invalid("blah-blah-blah".into()),
+    );
+
+    // Missing media type
+    assert_eq!(
+        DapMediaType::from_str_for_version(DapVersion::Draft04, None),
+        DapMediaType::Missing,
+    );
+}
+
+#[test]
+fn round_trip() {
+    for (version, media_type) in [
+        (DapVersion::Draft02, DapMediaType::AggregationJobInitReq),
+        (DapVersion::Draft04, DapMediaType::AggregationJobInitReq),
+        (DapVersion::Draft02, DapMediaType::AggregationJobResp),
+        (DapVersion::Draft04, DapMediaType::AggregationJobResp),
+        (DapVersion::Draft02, DapMediaType::AggregationJobContinueReq),
+        (DapVersion::Draft04, DapMediaType::AggregationJobContinueReq),
+        (
+            DapVersion::Draft02,
+            DapMediaType::Draft02AggregateContinueResp,
+        ),
+        (DapVersion::Draft02, DapMediaType::AggregateShareReq),
+        (DapVersion::Draft04, DapMediaType::AggregateShareReq),
+        (DapVersion::Draft02, DapMediaType::AggregateShare),
+        (DapVersion::Draft04, DapMediaType::AggregateShare),
+        (DapVersion::Draft02, DapMediaType::CollectReq),
+        (DapVersion::Draft04, DapMediaType::CollectReq),
+        (DapVersion::Draft02, DapMediaType::Collection),
+        (DapVersion::Draft04, DapMediaType::Collection),
+        (DapVersion::Draft02, DapMediaType::HpkeConfigList),
+        (DapVersion::Draft04, DapMediaType::HpkeConfigList),
+        (DapVersion::Draft02, DapMediaType::Report),
+        (DapVersion::Draft04, DapMediaType::Report),
+    ] {
+        assert_eq!(
+            DapMediaType::from_str_for_version(version, media_type.as_str_for_version(version)),
+            media_type,
+            "round trip test failed for {version:?} and {media_type:?}"
+        );
+    }
+}
+
+// Issue #269: Ensure the media type included with the AggregateContinueResp in draft02 is not
+// overwritten by the media type for AggregationJobResp.
+#[test]
+fn media_type_for_agg_cont_req() {
+    assert_eq!(
+        DapMediaType::Draft02AggregateContinueResp,
+        DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft02)
+    );
+
+    assert_eq!(
+        DapMediaType::AggregationJobResp,
+        DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft04)
+    );
+}

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -5,7 +5,7 @@
 
 use assert_matches::assert_matches;
 use daphne::{
-    constants::MEDIA_TYPE_COLLECT_REQ,
+    constants::DapMediaType,
     hpke::HpkeReceiverConfig,
     messages::{
         encode_base64url, BatchId, CollectionJobId, Duration, HpkeAeadId, HpkeConfig,
@@ -306,15 +306,23 @@ impl TestRunner {
         &self,
         client: &reqwest::Client,
         path: &str,
-        media_type: &str,
+        media_type: DapMediaType,
         data: Vec<u8>,
     ) {
         let url = self.leader_url.join(path).unwrap();
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::CONTENT_TYPE, media_type.parse().unwrap());
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            media_type
+                .as_str_for_version(self.version)
+                .unwrap()
+                .parse()
+                .unwrap(),
+        );
         let resp = client
             .post(url.as_str())
             .body(data)
+            .headers(headers)
             .send()
             .await
             .expect("request failed");
@@ -333,7 +341,7 @@ impl TestRunner {
         client: &reqwest::Client,
         dap_auth_token: Option<&str>,
         path: &str,
-        media_type: &str,
+        media_type: DapMediaType,
         data: Vec<u8>,
         expected_status: u16,
         expected_err_type: &str,
@@ -341,7 +349,14 @@ impl TestRunner {
         let url = self.leader_url.join(path).unwrap();
 
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::CONTENT_TYPE, media_type.parse().unwrap());
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            media_type
+                .as_str_for_version(self.version)
+                .unwrap()
+                .parse()
+                .unwrap(),
+        );
         if let Some(token) = dap_auth_token {
             headers.insert(
                 reqwest::header::HeaderName::from_static("dap-auth-token"),
@@ -382,7 +397,7 @@ impl TestRunner {
         &self,
         client: &reqwest::Client,
         path: &str,
-        media_type: &str,
+        media_type: DapMediaType,
         data: Vec<u8>,
     ) {
         // draft02 always POSTs
@@ -393,10 +408,19 @@ impl TestRunner {
         }
         let url = self.leader_url.join(path).unwrap();
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::CONTENT_TYPE, media_type.parse().unwrap());
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            media_type
+                .as_str_for_version(self.version)
+                .unwrap()
+                .parse()
+                .unwrap(),
+        );
+
         let resp = client
             .put(url.as_str())
             .body(data)
+            .headers(headers)
             .send()
             .await
             .expect("request failed");
@@ -416,7 +440,7 @@ impl TestRunner {
         client: &reqwest::Client,
         dap_auth_token: Option<&str>,
         path: &str,
-        media_type: &str,
+        media_type: DapMediaType,
         data: Vec<u8>,
         expected_status: u16,
         expected_err_type: &str,
@@ -439,7 +463,14 @@ impl TestRunner {
         let url = self.leader_url.join(path).unwrap();
 
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::CONTENT_TYPE, media_type.parse().unwrap());
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            media_type
+                .as_str_for_version(self.version)
+                .unwrap()
+                .parse()
+                .unwrap(),
+        );
         if let Some(token) = dap_auth_token {
             headers.insert(
                 reqwest::header::HeaderName::from_static("dap-auth-token"),
@@ -486,7 +517,12 @@ impl TestRunner {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             reqwest::header::CONTENT_TYPE,
-            reqwest::header::HeaderValue::from_static(MEDIA_TYPE_COLLECT_REQ),
+            reqwest::header::HeaderValue::from_str(
+                DapMediaType::CollectReq
+                    .as_str_for_version(self.version)
+                    .unwrap(),
+            )
+            .unwrap(),
         );
         headers.insert(
             reqwest::header::HeaderName::from_static("dap-auth-token"),
@@ -665,7 +701,12 @@ impl TestRunner {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             reqwest::header::CONTENT_TYPE,
-            reqwest::header::HeaderValue::from_static(MEDIA_TYPE_COLLECT_REQ),
+            reqwest::header::HeaderValue::from_str(
+                DapMediaType::CollectReq
+                    .as_str_for_version(self.version)
+                    .unwrap(),
+            )
+            .unwrap(),
         );
         builder.headers(headers).send().await.unwrap()
     }


### PR DESCRIPTION
Partially addresses #255.
Closes #269.

The correct media type for this message is
"application/dap-aggregation-job-continue-resp"; we were incorrectly returning "application/dap-aggregate-continue-resp". There two issues here happening at once. First, we are overwriting the content type for this message with the content type for draft04. Second, we are using the incorrect content type for draft04. It should be
"application/dap-aggregation-job-resp".

This bug was introduced by the commit in which draft03 was replaced by draft04. The code for resolving the media type for requests and responses is quite complex. To make this sort of bug less likely in the future, we replace the current string-matching functions with an enumerated type that forces us to explicitly enumerate all the cases.

An enum is introduced, called `DapMediaType`, that replaces the `Option<&'static str>` in the `DapRequest` and `DapResponse` structs. Methods are defined on for decoding from and encoding to the content-type HTTP header. These methods take the version, as is required in order to properly resolve which representation of the media type is needed.

All media types have a 1:1 mapping across the two versions, with one exception: in draft02, there is a different media type for responses to aggregate initialization and continuation requests, but in draft04, there is no distinction made. For all other media types we prefer the name in the latest draft.

Other minor things related to this change:

* This change requires adding the DAP version to the `DapResponse` so that the caller can figure out how to encode the media type.

* Strictly enforce the media type for all DAP requests. Doing so revealed a bug in the E2E test suite in which we failed to add the content-type header to certain requests.

The following unrelated changes are made:

* Replace `sender_for_media_type()` with a method on `DapMediaType` that not only resolves the sender for DAP requests, but the sender for DAP responses.

* tracing: Add a warning if the BearerToken denies a request due to unknown media type.

* editorial: Rename "Content-Type" to "content-type" in a few different places. The latter is the more canonical spelling.

* Improve error handling in various places.