### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -532,7 +532,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -716,13 +716,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -840,7 +840,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1208,14 +1208,14 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1404,9 +1404,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.49"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1425,7 +1425,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -1436,9 +1436,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.84"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
  "cc",
  "libc",
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.8"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aef160324be24d31a62147fae491c14d2204a3865c7ca8c3b0d7f7bcb3ea635"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
  "bitflags",
  "errno",
@@ -1959,18 +1959,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
  "js-sys",
  "serde",
@@ -1979,13 +1979,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -2157,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2205,7 +2205,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -2282,7 +2282,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]
 
 [[package]]
@@ -2510,8 +2510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2792,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.0.12"
+version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca55ce51b3bf01da5a20598af220c5d3abf91f1978a50a0620ef966c39e3180"
+checksum = "301c77ead87587225c6f58104de6c9046afef597e7d39d36cba2640b5af1046a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2806,6 +2804,7 @@ dependencies = [
  "matchit 0.4.6",
  "pin-project",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "url",
  "wasm-bindgen",
@@ -2819,12 +2818,13 @@ dependencies = [
 
 [[package]]
 name = "worker-kv"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682cbd728f179cc810b2ab77a2534da817b973e190ab184ab8efe1058b0dba84"
+checksum = "3d4b9fe1a87b7aef252fceb4f30bf6303036a5de329c81ccad9be9c35d1fdbc7"
 dependencies = [
  "js-sys",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "wasm-bindgen",
@@ -2833,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29ce5a41f5e7e644bc683681b62aed3adac838e01d18eb4e02a4dc30d4ac69"
+checksum = "c86b080d7a6472a244fd1b5b1f36be3dc53942aef13e716724a4b74715708afc"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825732b9b6360d6b1f5f614248317826cebf4878e36f61ccc71ca9dd53de8b41"
+checksum = "b842e2ac2871c2d83e50ce8e8844fc3893666d1c16825b809505de6506ad4487"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2888,5 +2888,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.14",
 ]

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -19,9 +19,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 assert_matches = "1.5.0"
-async-trait = "0.1.66"
+async-trait = "0.1.68"
 base64 = "0.21.0"
-getrandom = { version = "0.2.8", features = ["js"] } # Required for prio
+getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = { version = "0.1.0" , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
@@ -33,11 +33,11 @@ prio = { version = "0.12.0", features = ["prio2"] }
 prometheus = "0.13.3"
 rand = "0.8.5"
 ring = "0.16.20"
-serde = { version = "1.0.154", features = ["derive"] }
-serde_json = "1.0.94"
-thiserror = "1.0.39"
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.95"
+thiserror = "1.0.40"
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.26.0", features = ["rt", "macros"] }
+tokio = { version = "1.27.0", features = ["rt", "macros"] }

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -15,10 +15,10 @@ daphne = { path = ".." }
 assert_matches = "1.5.0"
 base64 = "0.21.0"
 prio = "0.12.0"
-serde = { version = "1.0.154", features = ["derive"] }
-serde_json = "1.0.94"
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.95"
 url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.1.8", features = ["derive"] }
-reqwest = { version = "0.11.14", features = ["blocking"] }
-anyhow = "1.0.69"
-tokio = { version = "1.26.0", features = ["macros", "rt"] }
+clap = { version = "4.2.1", features = ["derive"] }
+reqwest = { version = "0.11.16", features = ["blocking"] }
+anyhow = "1.0.70"
+tokio = { version = "1.27.0", features = ["macros", "rt"] }

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,12 +18,12 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.66"
+async-trait = "0.1.68"
 base64 = "0.21.0"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "wasmbind"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
-futures = "0.3.26"
-getrandom = { version = "0.2.8", features = ["js"] } # Required for prio
+futures = "0.3.28"
+getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 matchit = "0.7.0"
 paste = "1.0.12"
@@ -32,15 +32,15 @@ prometheus = "0.13.3"
 rand = "0.8.5"
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"
-serde = { version = "1.0.154", features = ["derive"] }
-thiserror = "1.0.39"
+serde = { version = "1.0.160", features = ["derive"] }
+thiserror = "1.0.40"
 tracing = "0.1.37"
 tracing-core = "0.1.30"
 tracing-subscriber = {version = "0.3.16", features = ["env-filter"]}
 url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.94"
-serde-wasm-bindgen = "0.4.5"
-worker = "0.0.12"
+serde_json = "1.0.95"
+serde-wasm-bindgen = "0.5.0"
+worker = "0.0.16"
 once_cell = "1.17.1"
 
 [dev-dependencies]

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -907,7 +907,7 @@ impl<'srv> DaphneWorker<'srv> {
             (Some(bearer_token), None) => Some(DaphneWorkerAuth::BearerToken(bearer_token)),
             (None, Some(tls_client_auth)) => Some(DaphneWorkerAuth::CfTlsClientAuth {
                 cert_issuer: tls_client_auth.cert_issuer_dn_rfc2253(),
-                cert_subject: tls_client_auth.cert_subject_dn_rfc225(),
+                cert_subject: tls_client_auth.cert_subject_dn_rfc2253(),
             }),
             (None, None) => None, // No authorization method provided
             (Some(..), Some(..)) => {

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -26,23 +26,23 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.154", features = ["derive"] }
-serde_json = "1.0.94"
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.95"
 tracing = "0.1.37"
-worker = "0.0.12"
+worker = "0.0.16"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 base64 = "0.21.0"
 daphne = { path = "../daphne" }
-futures = "0.3.26"
+futures = "0.3.28"
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
 lazy_static = "1.4.0"
 paste = "1.0.12"
 prio = "0.12.0"
 rand = "0.8.5"
-reqwest = { version = "0.11.14", features = ["json"] }
+reqwest = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"
-tokio = { version = "1.26.0", features = ["full"] }
+tokio = { version = "1.27.0", features = ["full"] }
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
Closes #251.

Run `cargo upgrade --incompatible` and fix API-breaking changes. The following crates were upgraded:

anyhow 1.0.69 => 1.0.70
async-trait 0.1.66 => 0.1.68
chrono 0.4.23 => 0.4.24
clap 4.1.8 => 4.2.1
futures 0.3.26 => 0.3.28
getrandom 0.2.8 => 0.2.9
reqwest 0.11.14 => 0.11.16
thiserror 1.0.39 => 1.0.40
tokio 1.26.0 => 1.27.0
serde 1.0.154 => 1.0.160
serde_json 1.0.94 => 1.0.95
serde-wasm-bindgen 0.4.5 => 0.5.0
worker 0.0.12 => 0.0.16

This change was validated in the live Workers runtime.