### PR TITLE
Improve miniflare Dockerfile and wrangler config.

### DIFF
--- a/docker/wrangler.toml
+++ b/docker/wrangler.toml
@@ -1,0 +1,170 @@
+name = "daphne_worker_test"
+main = "build/worker/shim.mjs"
+compatibility_date = "2022-10-14"
+
+[build]
+command = "cargo install --git https://github.com/cloudflare/workers-rs && worker-build"
+
+[[rules]]
+globs = ["**/*.wasm"]
+type = "CompiledWasm"
+fallthrough = false
+
+#
+# leader
+#
+
+
+[env.leader.vars]
+# NOTE: Variables marked as SECRET need to be provisioned securely in
+# production. In particular, they will not be passed as environment variables
+# as they are here. See
+# https://developers.cloudflare.com/workers/wrangler/commands/#secret.
+DAP_AGGREGATOR_ROLE = "leader"
+DAP_BASE_URL = "http://127.0.0.1:8080/"
+DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
+DAP_COLLECTION_JOB_ID_KEY = "b416a85d280591d6da14e5b75a7d6e31" # SECRET
+DAP_REPORT_SHARD_KEY = "61cd9685547370cfea76c2eb8d156ad9" # SECRET
+DAP_REPORT_SHARD_COUNT = "2"
+DAP_GLOBAL_CONFIG = """{
+     "report_storage_epoch_duration": 604800,
+     "report_storage_max_future_time_skew": 300,
+     "max_batch_duration": 360000,
+     "min_batch_interval_start": 259200,
+     "max_batch_interval_end": 259200,
+     "supported_hpke_kems": ["x25519_hkdf_sha256"],
+     "allow_taskprov": true,
+     "taskprov_version": "v02"
+}"""
+DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
+DAP_DEPLOYMENT = "dev"
+DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
+  "id": 23,
+  "kem_id": "p256_hkdf_sha256",
+  "kdf_id": "hkdf_sha256",
+  "aead_id": "aes128_gcm",
+  "public_key": "047dab625e0d269abcc28c611bebf5a60987ddf7e23df0e0aa343e5774ad81a1d0160d9252b82b4b5c52354205f5ec945645cb79facff8d85c9c31b490cdf35466"
+}"""
+# The secret key for the HPKE collector public key, recorded here for testing convenience:
+#     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
+DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
+DAP_TASKPROV_LEADER_AUTH = """{
+  "bearer_token": "I am the leader!"
+}""" # SECRET
+DAP_TASKPROV_COLLECTOR_AUTH = """{
+  "bearer_token": "I am the collector!"
+}""" # SECRET
+DAP_DEFAULT_VERSION = "v04"
+DAP_TRACING = "debug"
+
+[env.leader.durable_objects]
+bindings = [
+    { name = "DAP_AGGREGATE_STORE", class_name = "AggregateStore" },
+    { name = "DAP_LEADER_AGG_JOB_QUEUE", class_name = "LeaderAggregationJobQueue" },
+    { name = "DAP_LEADER_BATCH_QUEUE", class_name = "LeaderBatchQueue" },
+    { name = "DAP_LEADER_COL_JOB_QUEUE", class_name = "LeaderCollectionJobQueue" },
+    { name = "DAP_GARBAGE_COLLECTOR", class_name = "GarbageCollector" },
+    { name = "DAP_REPORTS_PENDING", class_name = "ReportsPending" },
+    { name = "DAP_REPORTS_PROCESSED", class_name = "ReportsProcessed" },
+]
+
+
+[[env.leader.kv_namespaces]]
+binding = "DAP_CONFIG"
+# KV bindings are in a looked up in a namespace identified by a 16-byte id number.
+# This number is assigned by calling
+#
+#    wrangler kv:namespace create <NAME>
+#
+# for some unique name you specify, and it returns a unique id number to use.
+# Here we should use something like "leader" for the <NAME>.
+id = "<assign-one-for-the-leader>"
+# A "preview id" is an id used when running in "wrangler dev" mode locally, and
+# can just be made up.  We generated the number below with the following python
+# code:
+#
+#    import secrets
+#    print(secrets.token_hex(16))
+#
+preview_id = "24c4dc92d5cf4680e508fe18eb8f0281"
+
+
+#
+# helper
+#
+
+
+[env.helper.vars]
+# NOTE: Variables marked as SECRET need to be provisioned securely in
+# production. In particular, they will not be passed as environment variables
+# as they are here. See
+# https://developers.cloudflare.com/workers/wrangler/commands/#secret.
+DAP_ADMIN_BEARER_TOKEN = "administrator bearer token" # SECRET
+DAP_AGGREGATOR_ROLE = "helper"
+DAP_BASE_URL = "http://127.0.0.1:8080/"
+DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
+DAP_REPORT_SHARD_KEY = "f79c352056982bae1737e34bdac24d63" # SECRET
+DAP_REPORT_SHARD_COUNT = "2"
+DAP_HELPER_STATE_STORE_GARBAGE_COLLECT_AFTER_SECS = "10"
+DAP_GLOBAL_CONFIG = """{
+  "report_storage_epoch_duration": 604800,
+  "report_storage_max_future_time_skew": 300,
+  "max_batch_duration": 360000,
+  "min_batch_interval_start": 259200,
+  "max_batch_interval_end": 259200,
+  "supported_hpke_kems": ["x25519_hkdf_sha256"],
+  "allow_taskprov": true,
+  "taskprov_version": "v02"
+}"""
+DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
+DAP_DEPLOYMENT = "dev"
+DAP_TASKPROV_HPKE_COLLECTOR_CONFIG = """{
+  "id": 23,
+  "kem_id": "p256_hkdf_sha256",
+  "kdf_id": "hkdf_sha256",
+  "aead_id": "aes128_gcm",
+  "public_key": "047dab625e0d269abcc28c611bebf5a60987ddf7e23df0e0aa343e5774ad81a1d0160d9252b82b4b5c52354205f5ec945645cb79facff8d85c9c31b490cdf35466"
+}"""
+# The secret key for the HPKE collector public key, recorded here for testing convenience:
+#     9ce9851512df3ea674b108b305c3f8c424955a94d93fd53ecf3c3f17f7d1df9e   # SECRET
+DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
+DAP_TASKPROV_LEADER_AUTH = """{
+  "bearer_token": "I am the leader!"
+}""" # SECRET
+DAP_DEFAULT_VERSION = "v04"
+DAP_TRACING = "debug"
+
+[env.helper.durable_objects]
+bindings = [
+    { name = "DAP_AGGREGATE_STORE", class_name = "AggregateStore" },
+    { name = "DAP_HELPER_STATE_STORE", class_name = "HelperStateStore" },
+    { name = "DAP_GARBAGE_COLLECTOR", class_name = "GarbageCollector" },
+    { name = "DAP_REPORTS_PROCESSED", class_name = "ReportsProcessed" },
+]
+
+
+[[env.helper.kv_namespaces]]
+binding = "DAP_CONFIG"
+# See the comments in the leader section for the meaning of these
+# fields.  Note that a different name should be used when
+# creating the helper's namespace, as the id needs to be different from
+# the leader's or there will be errors and cross contamination if both
+# a leader and a helper exist.
+id = "<assign-one-for-the-helper>"
+# This is another unique id generated using the method for preview_id
+# described above.
+preview_id = "5d9c69a19f90be2dbcce95eb6f0a338a"
+
+
+[[migrations]]
+tag = "v1"
+new_classes = [
+    "AggregateStore",
+    "HelperStateStore",
+    "LeaderAggregationJobQueue",
+    "LeaderBatchQueue",
+    "LeaderCollectionJobQueue",
+    "GarbageCollector",
+    "ReportsPending",
+    "ReportsProcessed",
+]


### PR DESCRIPTION
The miniflare Dockerfile now puts services on 8080.

This PR also separates the wrangler.toml for miniflare docker packages from the one we use in testing.  The only difference at the moment is in URLs, and is probably optional, but it seemed good to separate them as they will probably diverge further over time.
