### PR TITLE
daphne_worker: Add metric for DAP aborts

### DIFF
--- a/daphne/src/aborts.rs
+++ b/daphne/src/aborts.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, thiserror::Error)]
 pub enum DapAbort {
     /// Bad request. Sent in response to an HTTP request that couldn't be handled preoprly.
-    #[error("badRequest")]
+    #[error("bad request")]
     BadRequest(String),
 
     /// Invalid batch. Sent in response to a CollectReq or AggregateShareReq.
@@ -31,7 +31,7 @@ pub enum DapAbort {
     BatchOverlap { detail: String, task_id: TaskId },
 
     /// Internal error.
-    #[error("internalError")]
+    #[error("internal error")]
     Internal(#[source] Box<dyn std::error::Error + 'static + Send + Sync>),
 
     /// Invalid batch size (either too small or too large). Sent in response to a CollectReq or
@@ -259,7 +259,7 @@ impl DapAbort {
                 "Task indicated by request is not recognized",
                 Some(self.to_string()),
             ),
-            Self::BadRequest(..) => ("Invalid request", None),
+            Self::BadRequest(..) => ("Bad request", None),
             Self::Internal(..) => ("Internal server error", None),
         };
 

--- a/daphne_worker/src/metrics.rs
+++ b/daphne_worker/src/metrics.rs
@@ -12,7 +12,10 @@ pub(crate) struct DaphneWorkerMetrics {
     pub(crate) daphne: DaphneMetrics,
 
     /// HTTP response status.
-    pub(crate) http_status_code: IntCounterVec,
+    pub(crate) http_status_code_counter: IntCounterVec,
+
+    /// DAP aborts.
+    pub(crate) dap_abort_counter: IntCounterVec,
 }
 
 impl DaphneWorkerMetrics {
@@ -23,10 +26,17 @@ impl DaphneWorkerMetrics {
             "".into()
         };
 
-        let http_status_code = register_int_counter_vec_with_registry!(
+        let http_status_code_counter = register_int_counter_vec_with_registry!(
             format!("{front}http_status_code"),
             "HTTP response status code.",
             &["host", "code"],
+            registry
+        )?;
+
+        let dap_abort_counter = register_int_counter_vec_with_registry!(
+            format!("{front}dap_abort"),
+            "DAP aborts.",
+            &["host", "type"],
             registry
         )?;
 
@@ -34,7 +44,8 @@ impl DaphneWorkerMetrics {
 
         Ok(Self {
             daphne,
-            http_status_code,
+            http_status_code_counter,
+            dap_abort_counter,
         })
     }
 }


### PR DESCRIPTION
Based on #293.

While at it, change the the string representation of `BadRequest` and `Internal` to "bad request" and "internal error" respectively so that they don't appear to be defined DAP error types.