### PR TITLE
Add error reporting trait

### DIFF
--- a/daphne_worker/src/error_reporting.rs
+++ b/daphne_worker/src/error_reporting.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Daphne-Worker error reporting trait and default implementation.
+
+use daphne::aborts::DapAbort;
+
+/// Interface for error reporting in Daphne
+/// Refer to NoopErrorReporter for implementation example.
+pub trait ErrorReporter {
+    fn report_abort(&self, error: &DapAbort);
+}
+
+/// Default implementation of the error reporting trait, which is a no-op.
+pub(crate) struct NoopErrorReporter {}
+
+impl ErrorReporter for NoopErrorReporter {
+    fn report_abort(&self, _error: &DapAbort) {}
+}

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -30,6 +30,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
     let router = DaphneWorkerRouter {
         enable_internal_test: true,
         enable_default_response: false,
+        ..Default::default()
     };
     router.handle_request(req, env).await
 }


### PR DESCRIPTION
This change adds the ability for a Daphne embedder to report internal errors (example to Sentry).

By default, we provide basic error reporting to stderr.