### PR TITLE
dapf: Add command for generating an HPKE receiver config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "clap",
  "daphne",
  "prio",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -15,6 +15,7 @@ daphne = { path = ".." }
 assert_matches = "1.5.0"
 base64 = "0.21.0"
 prio = "0.12.0"
+rand = "0.8.5"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.95"
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
Also, make `--task-id` optional, as it is not required for this command.

While at it, fix a runtime bug that resulted from a recent upgrade:

```
thread 'main' panicked at 'Cannot drop a runtime in a context where
blocking is not allowed. This happens when a runtime is dropped from
within an asynchronous context.',
/Users/christopherpatton/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/shutdown.rs:51:21
```

This is fixed by using the async versions of reqwest rather than the blocking variants.