### PR TITLE
draft05: Move to ping-pong aggregation flow

### DIFF
--- a/.github/workflows/daphneci.yml
+++ b/.github/workflows/daphneci.yml
@@ -30,6 +30,16 @@ jobs:
         run: cargo build --release
       - name: Testing
         run: cargo test -- --nocapture
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v3
+      - name: Run integration tests
+        uses: isbang/compose-action@v1.4.1
+        with:
+          compose-file: "./docker-compose.yaml"
+          up-flags: "--build --abort-on-container-exit --exit-code-from test"
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 wasm-pack.log
 build/
 dist
+.wrangler

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @armfazh @bhalleycf @chris-wood @cjpatton @oliy
+* @armfazh @bhalleycf @captain-mota @chris-wood @cjpatton @lbaquerofierro- @mendess @will118

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.21.2",
+ "futures",
  "hex",
  "hpke-rs",
  "hpke-rs-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.0.16"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301c77ead87587225c6f58104de6c9046afef597e7d39d36cba2640b5af1046a"
+checksum = "c64a08abf27a129f60be182b26635bbd281fe1c4e4d4b4375383cb1a4ef9e2c2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2742,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86b080d7a6472a244fd1b5b1f36be3dc53942aef13e716724a4b74715708afc"
+checksum = "6e052efe546b1571f03abaafac252a8103a4a698c2bfa8d5c48ca634f1817323"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -2758,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b842e2ac2871c2d83e50ce8e8844fc3893666d1c16825b809505de6506ad4487"
+checksum = "2ad510995e943256afb8b7524366014bd4a2f6a4ffef00b8121db97a8056b4c3"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,14 +492,11 @@ name = "dapf"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "assert_matches",
- "base64 0.21.2",
  "clap",
  "daphne",
  "prio",
  "rand",
  "reqwest",
- "serde",
  "serde_json",
  "tokio",
  "url",
@@ -512,12 +509,10 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.21.2",
- "getrandom",
  "hex",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
- "lazy_static",
  "matchit 0.7.0",
  "paste",
  "prio",
@@ -537,15 +532,12 @@ name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.2",
  "cfg-if",
  "console_error_panic_hook",
  "daphne",
  "daphne_worker",
- "futures",
  "hex",
  "hpke-rs",
- "lazy_static",
  "paste",
  "prio",
  "rand",
@@ -563,13 +555,10 @@ dependencies = [
 name = "daphne_worker"
 version = "0.3.0"
 dependencies = [
- "assert_matches",
  "async-trait",
- "base64 0.21.2",
  "chrono",
  "daphne",
  "futures",
- "getrandom",
  "hex",
  "matchit 0.7.0",
  "once_cell",
@@ -578,15 +567,12 @@ dependencies = [
  "prometheus",
  "rand",
  "reqwest-wasm",
- "ring",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "thiserror",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "url",
  "worker",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.2",
@@ -71,6 +71,12 @@ dependencies = [
  "ghash 0.5.0",
  "subtle",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -150,7 +156,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -173,9 +179,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -209,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -264,13 +270,13 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "wasm-bindgen",
  "winapi",
@@ -319,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -330,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
@@ -343,21 +349,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cmac"
@@ -367,17 +373,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher 0.4.4",
  "dbl",
- "digest 0.10.6",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -492,56 +488,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "dapf"
 version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.21.0",
+ "base64 0.21.2",
  "clap",
  "daphne",
  "prio",
@@ -559,7 +511,7 @@ version = "0.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "getrandom",
  "hex",
  "hpke-rs",
@@ -585,7 +537,7 @@ name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.0",
+ "base64 0.21.2",
  "cfg-if",
  "console_error_panic_hook",
  "daphne",
@@ -613,7 +565,7 @@ version = "0.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "chrono",
  "daphne",
  "futures",
@@ -667,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
@@ -841,7 +793,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -930,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1008,7 +960,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1144,12 +1096,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1251,24 +1202,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1363,16 +1305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "opaque-debug"
@@ -1426,7 +1358,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1639,7 +1571,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.5.0",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -1650,13 +1582,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prio"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3675d093a7713f2b861f77b16c3c33fadd6de0a69bf7203014d938b9d5daa6f7"
+checksum = "9028a8aba9ba6b647c6d6931c20473d1119079a68d9898c07a488c5180dccb58"
 dependencies = [
  "aes 0.8.2",
- "aes-gcm 0.10.1",
- "base64 0.21.0",
+ "aes-gcm 0.10.2",
+ "base64 0.21.2",
  "byteorder",
  "cmac",
  "ctr 0.9.2",
@@ -1671,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1701,9 +1633,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -1788,11 +1720,11 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1923,12 +1855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sec1"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1956,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1966,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -1986,13 +1912,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2039,16 +1965,16 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2164,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2187,15 +2113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,7 +2129,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2264,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2289,7 +2206,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2342,14 +2259,14 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2440,12 +2357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "universal-hash"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -2627,15 +2538,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2908,5 +2810,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,10 @@ opt-level = "s"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 async-trait = "0.1.68"
-base64 = "0.21.2"
 futures = "0.3.28"
 getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
-lazy_static = "1.4.0"
 matchit = "0.7.0"
 paste = "1.0.12"
 prio = "0.12.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,27 @@ members = [
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+[workspace.dependencies]
+assert_matches = "1.5.0"
+async-trait = "0.1.68"
+base64 = "0.21.2"
+futures = "0.3.28"
+getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
+hex = { version = "0.4.3", features = ["serde"] }
+hpke-rs = "0.1.0"
+lazy_static = "1.4.0"
+matchit = "0.7.0"
+paste = "1.0.12"
+prio = "0.12.2"
+prometheus = "0.13.3"
+rand = "0.8.5"
+reqwest = "0.11.18"
+ring = "0.16.20"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+thiserror = "1.0.40"
+tokio = { version = "1.28.2", features = ["macros", "rt"] }
+tracing = "0.1.37"
+url = { version = "2.3.1", features = ["serde"] }
+worker = "0.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["macros", "rt"] }
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
-worker = "0.0.16"
+worker = "0.0.17"

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -29,15 +29,15 @@ hpke-rs-rust-crypto = { version = "0.1.1"}
 lazy_static = "1.4.0"
 matchit = "0.7.0"
 paste = "1.0.12"
-prio = { version = "0.12.0", features = ["prio2"] }
+prio = { version = "0.12.1", features = ["prio2"] }
 prometheus = "0.13.3"
 rand = "0.8.5"
 ring = "0.16.20"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version = "1.0.162", features = ["derive"] }
+serde_json = "1.0.96"
 thiserror = "1.0.40"
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.27.0", features = ["rt", "macros"] }
+tokio = { version = "1.28.0", features = ["rt", "macros"] }

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -20,15 +20,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 assert_matches.workspace = true
 async-trait.workspace = true
-base64.workspace = true
-getrandom.workspace = true
+base64 = "0.21.2"
 hex.workspace = true
 hpke-rs = { workspace = true , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
-lazy_static.workspace = true
-matchit.workspace = true
-paste.workspace = true
 prio = { workspace = true, features = ["prio2"] }
 prometheus.workspace = true
 rand.workspace = true
@@ -40,4 +36,6 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+matchit.workspace = true
+paste.workspace = true
 tokio.workspace = true

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["cdylib", "rlib"]
 assert_matches.workspace = true
 async-trait.workspace = true
 base64 = "0.21.2"
+futures.workspace = true
 hex.workspace = true
 hpke-rs = { workspace = true , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 assert_matches = "1.5.0"
 async-trait = "0.1.68"
-base64 = "0.21.0"
+base64 = "0.21.2"
 getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = { version = "0.1.0" , features = ["hazmat", "serialization"] }
@@ -29,15 +29,15 @@ hpke-rs-rust-crypto = { version = "0.1.1"}
 lazy_static = "1.4.0"
 matchit = "0.7.0"
 paste = "1.0.12"
-prio = { version = "0.12.1", features = ["prio2"] }
+prio = { version = "0.12.2", features = ["prio2"] }
 prometheus = "0.13.3"
 rand = "0.8.5"
 ring = "0.16.20"
-serde = { version = "1.0.162", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 thiserror = "1.0.40"
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.28.0", features = ["rt", "macros"] }
+tokio = { version = "1.28.2", features = ["rt", "macros"] }

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -18,26 +18,26 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-assert_matches = "1.5.0"
-async-trait = "0.1.68"
-base64 = "0.21.2"
-getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
-hex = { version = "0.4.3", features = ["serde"] }
-hpke-rs = { version = "0.1.0" , features = ["hazmat", "serialization"] }
+assert_matches.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+getrandom.workspace = true
+hex.workspace = true
+hpke-rs = { workspace = true , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
-lazy_static = "1.4.0"
-matchit = "0.7.0"
-paste = "1.0.12"
-prio = { version = "0.12.2", features = ["prio2"] }
-prometheus = "0.13.3"
-rand = "0.8.5"
-ring = "0.16.20"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-thiserror = "1.0.40"
-tracing = "0.1.37"
-url = { version = "2.3.1", features = ["serde"] }
+lazy_static.workspace = true
+matchit.workspace = true
+paste.workspace = true
+prio = { workspace = true, features = ["prio2"] }
+prometheus.workspace = true
+rand.workspace = true
+ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1.28.2", features = ["rt", "macros"] }
+tokio.workspace = true

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -14,12 +14,12 @@ license = "BSD-3-Clause"
 daphne = { path = ".." }
 assert_matches = "1.5.0"
 base64 = "0.21.0"
-prio = "0.12.0"
+prio = "0.12.1"
 rand = "0.8.5"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version = "1.0.162", features = ["derive"] }
+serde_json = "1.0.96"
 url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.2.1", features = ["derive"] }
-reqwest = { version = "0.11.16", features = ["blocking"] }
-anyhow = "1.0.70"
-tokio = { version = "1.27.0", features = ["macros", "rt"] }
+clap = { version = "4.2.7", features = ["derive"] }
+reqwest = { version = "0.11.17", features = ["blocking"] }
+anyhow = "1.0.71"
+tokio = { version = "1.28.0", features = ["macros", "rt"] }

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -13,13 +13,13 @@ license = "BSD-3-Clause"
 [dependencies]
 daphne = { path = ".." }
 assert_matches = "1.5.0"
-base64 = "0.21.0"
-prio = "0.12.1"
+base64 = "0.21.2"
+prio = "0.12.2"
 rand = "0.8.5"
-serde = { version = "1.0.162", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.2.7", features = ["derive"] }
-reqwest = { version = "0.11.17", features = ["blocking"] }
+clap = { version = "4.3.0", features = ["derive"] }
+reqwest = { version = "0.11.18", features = ["blocking"] }
 anyhow = "1.0.71"
-tokio = { version = "1.28.0", features = ["macros", "rt"] }
+tokio = { version = "1.28.2", features = ["macros", "rt"] }

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -12,14 +12,11 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.71"
-assert_matches.workspace = true
-base64.workspace = true
 clap = { version = "4.3.0", features = ["derive"] }
 daphne = { path = ".." }
 prio.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
-serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -11,15 +11,15 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-daphne = { path = ".." }
-assert_matches = "1.5.0"
-base64 = "0.21.2"
-prio = "0.12.2"
-rand = "0.8.5"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.3.0", features = ["derive"] }
-reqwest = { version = "0.11.18", features = ["blocking"] }
 anyhow = "1.0.71"
-tokio = { version = "1.28.2", features = ["macros", "rt"] }
+assert_matches.workspace = true
+base64.workspace = true
+clap = { version = "4.3.0", features = ["derive"] }
+daphne = { path = ".." }
+prio.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+url.workspace = true

--- a/daphne/dapf/src/bin/dapf.rs
+++ b/daphne/dapf/src/bin/dapf.rs
@@ -4,8 +4,8 @@
 use anyhow::{anyhow, Context, Result};
 use clap::{builder::PossibleValue, Parser, Subcommand, ValueEnum};
 use daphne::{
-    aborts::ProblemDetails,
     constants::DapMediaType,
+    error::aborts::ProblemDetails,
     hpke::HpkeReceiverConfig,
     messages::{BatchSelector, Collection, CollectionReq, HpkeConfig, HpkeKemId, Query, TaskId},
     DapMeasurement, DapVersion, VdafConfig,

--- a/daphne/src/aborts.rs
+++ b/daphne/src/aborts.rs
@@ -4,6 +4,7 @@
 //! Definitions and tooling for DAP protocol aborts.
 
 use crate::{
+    fatal_error,
     messages::{BatchSelector, TaskId, TransitionFailure},
     DapError, DapMediaType, DapRequest, DapVersion,
 };
@@ -210,7 +211,10 @@ impl DapAbort {
             TransitionFailure::ReportReplayed => {
                 "A report with the same ID was uploaded previously."
             }
-            _ => return DapError::Fatal(format!("Attempted to construct a \"reportRejected\" abort with unexpected transition failure: {failure_reason:?}")).into(),
+            _ => return fatal_error!(
+                err = "Attempted to construct a \"reportRejected\" abort with unexpected transition failure",
+                unexpected_transition_failure = ?failure_reason,
+            ).into(),
         };
 
         Self::ReportRejected {

--- a/daphne/src/aborts.rs
+++ b/daphne/src/aborts.rs
@@ -31,7 +31,7 @@ pub enum DapAbort {
     BatchOverlap { detail: String, task_id: TaskId },
 
     /// Internal error.
-    #[error("internal error")]
+    #[error("internal error: {0:?}")]
     Internal(#[source] Box<dyn std::error::Error + 'static + Send + Sync>),
 
     /// Invalid batch size (either too small or too large). Sent in response to a CollectReq or

--- a/daphne/src/aborts.rs
+++ b/daphne/src/aborts.rs
@@ -138,8 +138,7 @@ impl DapAbort {
                 Some(agg_job_id_base64url),
             ),
             Self::UnrecognizedMessage { detail, task_id } => (task_id, Some(detail), None),
-            Self::ReportTooLate | Self::UnrecognizedTask => (None, None, None),
-            Self::Internal(e) => (None, Some(e.to_string()), None),
+            Self::ReportTooLate | Self::UnrecognizedTask | Self::Internal(_) => (None, None, None),
         };
 
         ProblemDetails {

--- a/daphne/src/audit_log.rs
+++ b/daphne/src/audit_log.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{messages::TaskId, DapTaskConfig};
+
+pub enum AggregationJobAuditAction {
+    Init,
+    Continue,
+}
+
+pub trait AuditLog {
+    fn on_aggregation_job(
+        &self,
+        host: &str,
+        task_id: &TaskId,
+        task_config: &DapTaskConfig,
+        report_count: u64,
+        action: AggregationJobAuditAction,
+    );
+}
+
+/// Default implementation of the trait, which is a no-op.
+pub struct NoopAuditLog;
+
+impl AuditLog for NoopAuditLog {
+    fn on_aggregation_job(
+        &self,
+        _host: &str,
+        _task_id: &TaskId,
+        _task_config: &DapTaskConfig,
+        _report_count: u64,
+        _action: AggregationJobAuditAction,
+    ) {
+    }
+}

--- a/daphne/src/auth.rs
+++ b/daphne/src/auth.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     constants::DapMediaType,
+    fatal_error,
     messages::{constant_time_eq, TaskId},
     DapError, DapRequest, DapSender,
 };
@@ -87,14 +88,15 @@ pub trait BearerTokenProvider {
                 .get_leader_bearer_token_for(task_id)
                 .await?
                 .ok_or_else(|| {
-                    DapError::Fatal("attempted to authorize request with unknown task ID".into())
+                    fatal_error!(err = "attempted to authorize request with unknown task ID")
                 })?;
             return Ok(token);
         }
 
-        Err(DapError::Fatal(format!(
-            "attempted to authorize request of type '{media_type:?}'",
-        )))
+        Err(fatal_error!(
+            err = "attempted to authorize request of type",
+            ?media_type,
+        ))
     }
 
     /// Check that the bearer token carried by a request can be used to authorize that request.

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -68,30 +68,30 @@ impl DapMediaType {
     pub fn from_str_for_version(version: DapVersion, content_type: Option<&str>) -> Self {
         match (version, content_type) {
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)) => {
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)) => {
                 Self::AggregationJobContinueReq
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)) => {
                 Self::Draft02AggregateContinueResp
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)) => {
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)) => {
                 Self::AggregationJobInitReq
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_JOB_RESP)) => Self::AggregationJobResp,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_AGG_JOB_RESP)) => Self::AggregationJobResp,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_SHARE)) => Self::AggregateShare,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_AGG_SHARE)) => Self::AggregateShare,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
             (DapVersion::Draft02, Some(MEDIA_TYPE_AGG_SHARE_REQ))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => Self::AggregateShareReq,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => Self::AggregateShareReq,
             (DapVersion::Draft02, Some(MEDIA_TYPE_COLLECT_REQ))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_COLLECT_REQ)) => Self::CollectReq,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_COLLECT_REQ)) => Self::CollectReq,
             (DapVersion::Draft02, Some(MEDIA_TYPE_REPORT))
-            | (DapVersion::Draft04, Some(MEDIA_TYPE_REPORT)) => Self::Report,
+            | (DapVersion::Draft05, Some(MEDIA_TYPE_REPORT)) => Self::Report,
             (_, Some(content_type)) => Self::Invalid(content_type.to_string()),
             (_, None) => Self::Missing,
         }
@@ -103,15 +103,15 @@ impl DapMediaType {
             (DapVersion::Draft02, Self::AggregationJobInitReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
             }
-            (DapVersion::Draft04, Self::AggregationJobInitReq) => Some(MEDIA_TYPE_AGG_JOB_INIT_REQ),
+            (DapVersion::Draft05, Self::AggregationJobInitReq) => Some(MEDIA_TYPE_AGG_JOB_INIT_REQ),
             (DapVersion::Draft02, Self::AggregationJobResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
             }
-            (DapVersion::Draft04, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
+            (DapVersion::Draft05, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
             (DapVersion::Draft02, Self::AggregationJobContinueReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
             }
-            (DapVersion::Draft04, Self::AggregationJobContinueReq) => {
+            (DapVersion::Draft05, Self::AggregationJobContinueReq) => {
                 Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)
             }
             (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
@@ -119,17 +119,17 @@ impl DapMediaType {
             }
             (_, Self::Draft02AggregateContinueResp) => None,
             (DapVersion::Draft02, Self::AggregateShareReq)
-            | (DapVersion::Draft04, Self::AggregateShareReq) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
+            | (DapVersion::Draft05, Self::AggregateShareReq) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
             (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-            (DapVersion::Draft04, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
-            (DapVersion::Draft02, Self::CollectReq) | (DapVersion::Draft04, Self::CollectReq) => {
+            (DapVersion::Draft05, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
+            (DapVersion::Draft02, Self::CollectReq) | (DapVersion::Draft05, Self::CollectReq) => {
                 Some(MEDIA_TYPE_COLLECT_REQ)
             }
             (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-            (DapVersion::Draft04, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
+            (DapVersion::Draft05, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
             (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
-            (DapVersion::Draft04, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
-            (DapVersion::Draft02, Self::Report) | (DapVersion::Draft04, Self::Report) => {
+            (DapVersion::Draft05, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
+            (DapVersion::Draft02, Self::Report) | (DapVersion::Draft05, Self::Report) => {
                 Some(MEDIA_TYPE_REPORT)
             }
             (_, Self::Invalid(ref content_type)) => Some(content_type),
@@ -143,7 +143,7 @@ impl DapMediaType {
     pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
         match version {
             DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
-            DapVersion::Draft04 => Self::AggregationJobResp,
+            DapVersion::Draft05 => Self::AggregationJobResp,
             _ => unreachable!("unhandled version {version:?}"),
         }
     }

--- a/daphne/src/constants_test.rs
+++ b/daphne/src/constants_test.rs
@@ -70,70 +70,70 @@ fn from_str_for_version() {
         DapMediaType::Collection,
     );
 
-    // draft04, Section 8.1
+    // draft05, Section 8.1
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-hpke-config-list")
         ),
         DapMediaType::HpkeConfigList
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-aggregation-job-init-req")
         ),
         DapMediaType::AggregationJobInitReq,
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-aggregation-job-resp")
         ),
         DapMediaType::AggregationJobResp,
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-aggregation-job-continue-req")
         ),
         DapMediaType::AggregationJobContinueReq,
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-aggregate-share-req")
         ),
         DapMediaType::AggregateShareReq,
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-aggregate-share")
         ),
         DapMediaType::AggregateShare,
     );
     assert_eq!(
         DapMediaType::from_str_for_version(
-            DapVersion::Draft04,
+            DapVersion::Draft05,
             Some("application/dap-collect-req")
         ),
         DapMediaType::CollectReq,
     );
     assert_eq!(
-        DapMediaType::from_str_for_version(DapVersion::Draft04, Some("application/dap-collection")),
+        DapMediaType::from_str_for_version(DapVersion::Draft05, Some("application/dap-collection")),
         DapMediaType::Collection,
     );
 
     // Invalid media type
     assert_eq!(
-        DapMediaType::from_str_for_version(DapVersion::Draft04, Some("blah-blah-blah")),
+        DapMediaType::from_str_for_version(DapVersion::Draft05, Some("blah-blah-blah")),
         DapMediaType::Invalid("blah-blah-blah".into()),
     );
 
     // Missing media type
     assert_eq!(
-        DapMediaType::from_str_for_version(DapVersion::Draft04, None),
+        DapMediaType::from_str_for_version(DapVersion::Draft05, None),
         DapMediaType::Missing,
     );
 }
@@ -142,27 +142,27 @@ fn from_str_for_version() {
 fn round_trip() {
     for (version, media_type) in [
         (DapVersion::Draft02, DapMediaType::AggregationJobInitReq),
-        (DapVersion::Draft04, DapMediaType::AggregationJobInitReq),
+        (DapVersion::Draft05, DapMediaType::AggregationJobInitReq),
         (DapVersion::Draft02, DapMediaType::AggregationJobResp),
-        (DapVersion::Draft04, DapMediaType::AggregationJobResp),
+        (DapVersion::Draft05, DapMediaType::AggregationJobResp),
         (DapVersion::Draft02, DapMediaType::AggregationJobContinueReq),
-        (DapVersion::Draft04, DapMediaType::AggregationJobContinueReq),
+        (DapVersion::Draft05, DapMediaType::AggregationJobContinueReq),
         (
             DapVersion::Draft02,
             DapMediaType::Draft02AggregateContinueResp,
         ),
         (DapVersion::Draft02, DapMediaType::AggregateShareReq),
-        (DapVersion::Draft04, DapMediaType::AggregateShareReq),
+        (DapVersion::Draft05, DapMediaType::AggregateShareReq),
         (DapVersion::Draft02, DapMediaType::AggregateShare),
-        (DapVersion::Draft04, DapMediaType::AggregateShare),
+        (DapVersion::Draft05, DapMediaType::AggregateShare),
         (DapVersion::Draft02, DapMediaType::CollectReq),
-        (DapVersion::Draft04, DapMediaType::CollectReq),
+        (DapVersion::Draft05, DapMediaType::CollectReq),
         (DapVersion::Draft02, DapMediaType::Collection),
-        (DapVersion::Draft04, DapMediaType::Collection),
+        (DapVersion::Draft05, DapMediaType::Collection),
         (DapVersion::Draft02, DapMediaType::HpkeConfigList),
-        (DapVersion::Draft04, DapMediaType::HpkeConfigList),
+        (DapVersion::Draft05, DapMediaType::HpkeConfigList),
         (DapVersion::Draft02, DapMediaType::Report),
-        (DapVersion::Draft04, DapMediaType::Report),
+        (DapVersion::Draft05, DapMediaType::Report),
     ] {
         assert_eq!(
             DapMediaType::from_str_for_version(version, media_type.as_str_for_version(version)),
@@ -183,6 +183,6 @@ fn media_type_for_agg_cont_req() {
 
     assert_eq!(
         DapMediaType::AggregationJobResp,
-        DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft04)
+        DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft05)
     );
 }

--- a/daphne/src/dap_error.rs
+++ b/daphne/src/dap_error.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::fmt::Display;
+
+use crate::{aborts::DapAbort, messages::TransitionFailure, vdaf::VdafError};
+
+/// DAP errors.
+#[derive(Debug, thiserror::Error)]
+pub enum DapError {
+    /// Fatal error. If this triggers an abort, then treat this as an internal error.
+    ///
+    /// To create an instance of this variant the [`fatal_error`] must be used. This ensures that
+    /// all fatal errors are logged with tracing when created.
+    #[error("fatal error: {0}")]
+    Fatal(#[from] FatalDapError),
+
+    /// Error triggered by peer, resulting in an abort.
+    #[error("abort: {0}")]
+    Abort(#[from] DapAbort),
+
+    /// Transition failure. This error blocks processing of a paritcular report and may, under
+    /// certain conditions, trigger an abort.
+    #[error("transition error: {0}")]
+    Transition(#[from] TransitionFailure),
+}
+
+impl FatalDapError {
+    #[doc(hidden)]
+    pub fn __use_the_macro(s: String) -> Self {
+        FatalDapError(s)
+    }
+}
+
+impl From<VdafError> for DapError {
+    fn from(e: VdafError) -> Self {
+        match e {
+            VdafError::Codec(..) | VdafError::Vdaf(..) => {
+                Self::Transition(TransitionFailure::VdafPrepError)
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FatalDapError(String);
+
+impl std::error::Error for FatalDapError {}
+
+impl Display for FatalDapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// This macro is to be used when constructing fatal errors ([`DapError::Fatal`]).
+///
+/// It follows the exact same syntax as
+/// [tracing](https://docs.rs/tracing/latest/tracing/index.html#using-the-macros) macros with one
+/// added thing: You must always have an `err` field at the start, like so:
+///
+/// ```
+/// # use daphne::fatal_error;
+/// fatal_error!(err = "the error");
+/// ```
+/// After this field you can do all the same things as tracing, use the `%` sign sintax to use the
+/// display implementation of a type, the `?` sigil for the debug representation of a type, etc.
+/// ```
+/// # use daphne::fatal_error;
+/// let some_id = 1;
+///
+/// fatal_error!(err = "the error", id = %some_id);
+/// ```
+/// ```
+/// # use daphne::fatal_error;
+/// use std::io::{Error, ErrorKind};
+///
+/// let some_id = 1;
+/// let e = Error::new(ErrorKind::Other, "the error");
+/// fatal_error!(err = e, id = %some_id, "operation failed");
+/// ```
+///
+/// # Note
+/// If you have an error that caused the fatal error, it should be passed in the `err` field of the
+/// macro, pass a string only when there is no error value you can use.
+#[macro_export]
+macro_rules! fatal_error {
+    (err = $e:expr $(,)?) => {
+        $crate::fatal_error!(@@@ err = $e,)
+    };
+    (err = $e:expr $(, $($rest:tt)*)?) => {
+        $crate::fatal_error!(@@@ err = $e, $($($rest)*)*)
+    };
+    (@@@ err = $e:expr $(, $($rest:tt)*)?) => {{
+        let error = &$e;
+        ::tracing::error!(fatal_error = ?error, $($($rest)*)*);
+        $crate::dap_error::DapError::Fatal(
+            $crate::dap_error::FatalDapError::__use_the_macro(::std::format!("{error}"))
+        )
+    }};
+}

--- a/daphne/src/error/aborts.rs
+++ b/daphne/src/error/aborts.rs
@@ -8,6 +8,7 @@ use crate::{
     messages::{BatchSelector, TaskId, TransitionFailure},
     DapError, DapMediaType, DapRequest, DapVersion,
 };
+use hex::FromHexError;
 use prio::codec::CodecError;
 use serde::{Deserialize, Serialize};
 
@@ -285,11 +286,18 @@ impl From<DapError> for DapAbort {
     }
 }
 
-impl From<CodecError> for DapAbort {
-    fn from(e: CodecError) -> Self {
+impl DapAbort {
+    pub fn from_codec_error<Id: Into<Option<TaskId>>>(e: CodecError, task_id: Id) -> Self {
         Self::UnrecognizedMessage {
             detail: format!("codec error: {e}"),
-            task_id: None,
+            task_id: task_id.into(),
+        }
+    }
+
+    pub fn from_hex_error(e: FromHexError, task_id: TaskId) -> Self {
+        Self::UnrecognizedMessage {
+            detail: format!("invalid hexadecimal string {e:?}"),
+            task_id: Some(task_id),
         }
     }
 }

--- a/daphne/src/error/mod.rs
+++ b/daphne/src/error/mod.rs
@@ -1,9 +1,12 @@
 // Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+pub mod aborts;
+
 use std::fmt::Display;
 
-use crate::{aborts::DapAbort, messages::TransitionFailure, vdaf::VdafError};
+use crate::{messages::TransitionFailure, vdaf::VdafError};
+pub use aborts::DapAbort;
 
 /// DAP errors.
 #[derive(Debug, thiserror::Error)]
@@ -94,8 +97,8 @@ macro_rules! fatal_error {
     (@@@ err = $e:expr $(, $($rest:tt)*)?) => {{
         let error = &$e;
         ::tracing::error!(fatal_error = ?error, $($($rest)*)*);
-        $crate::dap_error::DapError::Fatal(
-            $crate::dap_error::FatalDapError::__use_the_macro(::std::format!("{error}"))
+        $crate::error::DapError::Fatal(
+            $crate::error::FatalDapError::__use_the_macro(::std::format!("{error}"))
         )
     }};
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -62,7 +62,7 @@ use std::{
     borrow::Cow,
     cmp::{max, min},
     collections::{HashMap, HashSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
 };
 use url::Url;
 
@@ -702,7 +702,7 @@ pub enum DapHelperTransition<M: Debug> {
     Finish(Vec<DapOutputShare>, M),
 }
 
-/// Specificaiton of a concrete VDAF.
+/// Specification of a concrete VDAF.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VdafConfig {
@@ -715,6 +715,15 @@ impl std::str::FromStr for VdafConfig {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         serde_json::from_str(s)
+    }
+}
+
+impl Display for VdafConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VdafConfig::Prio3(prio3_config) => write!(f, "Prio3({prio3_config})"),
+            VdafConfig::Prio2 { dimension } => write!(f, "Prio2({dimension})"),
+        }
     }
 }
 
@@ -737,6 +746,19 @@ pub enum Prio3Config {
     /// The element-wise sum of vectors. Each vector has `len` elements.
     /// Each element is a 64-bit unsigned integer in range `[0,2^bits)`.
     SumVec { bits: usize, len: usize },
+}
+
+impl Display for Prio3Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Prio3Config::Count => write!(f, "Count"),
+            Prio3Config::Histogram { buckets } => {
+                write!(f, "Histogram({})", buckets.len())
+            }
+            Prio3Config::Sum { bits } => write!(f, "Sum({bits})"),
+            Prio3Config::SumVec { bits, len } => write!(f, "SumVec({bits},{len})"),
+        }
+    }
 }
 
 /// DAP sender role.
@@ -951,6 +973,7 @@ impl MetaAggregationJobId<'_> {
 }
 
 pub mod aborts;
+pub mod audit_log;
 pub mod auth;
 pub mod constants;
 #[cfg(test)]

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -9,7 +9,7 @@
 //! PPM working group of the IETF. See [`VdafConfig`] for a listing of supported
 //! [VDAFs](https://github.com/cfrg/draft-irtf-cfrg-vdaf).
 //!
-//! Daphne implements draft-ietf-ppm-dap-02 and draft-ietf-ppm-dap-03.
+//! Daphne implements draft-ietf-ppm-dap-02 and draft-ietf-ppm-dap-05.
 //!
 //! Daphne does not provide the complete, end-to-end functionality of any party in the protocol.
 //! Instead, it defines traits for the functionalities that a concrete instantiation of the
@@ -74,8 +74,8 @@ pub enum DapVersion {
     #[serde(rename = "v02")]
     Draft02,
 
-    #[serde(rename = "v04")]
-    Draft04,
+    #[serde(rename = "v05")]
+    Draft05,
 
     #[serde(other)]
     #[serde(rename = "unknown_version")]
@@ -87,7 +87,7 @@ impl From<&str> for DapVersion {
     fn from(version: &str) -> Self {
         match version {
             "v02" => DapVersion::Draft02,
-            "v04" => DapVersion::Draft04,
+            "v05" => DapVersion::Draft05,
             _ => DapVersion::Unknown,
         }
     }
@@ -97,8 +97,8 @@ impl AsRef<str> for DapVersion {
     fn as_ref(&self) -> &str {
         match self {
             DapVersion::Draft02 => "v02",
-            DapVersion::Draft04 => "v04",
-            _ => panic!("tried to construct string from unknown DAP version"),
+            DapVersion::Draft05 => "v05",
+            _ => unreachable!("tried to construct string from unknown DAP version"),
         }
     }
 }
@@ -862,13 +862,13 @@ pub struct DapLeaderProcessTelemetry {
 }
 
 /// draft02 compatibility: A logical aggregation job ID. In the latest draft, this is a 32-byte
-/// string included in the HTTP request payload; in draft04, this is a 16-byte string included in
+/// string included in the HTTP request payload; in draft05, this is a 16-byte string included in
 /// the HTTP request path. This type unifies these into one type so that any protocol logic that
 /// is agnostic to these details can use the same object.
 #[derive(Clone, Debug)]
 pub enum MetaAggregationJobId<'a> {
     Draft02(Cow<'a, Draft02AggregationJobId>),
-    Draft04(Cow<'a, AggregationJobId>),
+    Draft05(Cow<'a, AggregationJobId>),
 }
 
 impl MetaAggregationJobId<'_> {
@@ -877,7 +877,7 @@ impl MetaAggregationJobId<'_> {
         let mut rng = thread_rng();
         match version {
             DapVersion::Draft02 => Self::Draft02(Cow::Owned(Draft02AggregationJobId(rng.gen()))),
-            DapVersion::Draft04 => Self::Draft04(Cow::Owned(AggregationJobId(rng.gen()))),
+            DapVersion::Draft05 => Self::Draft05(Cow::Owned(AggregationJobId(rng.gen()))),
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         }
     }
@@ -887,7 +887,7 @@ impl MetaAggregationJobId<'_> {
     pub(crate) fn for_request_payload(&self) -> Option<Draft02AggregationJobId> {
         match self {
             Self::Draft02(agg_job_id) => Some(agg_job_id.clone().into_owned()),
-            Self::Draft04(..) => None,
+            Self::Draft05(..) => None,
         }
     }
 
@@ -897,7 +897,7 @@ impl MetaAggregationJobId<'_> {
         match self {
             // In draft02, the aggregation job ID is not determined until the payload is parsed.
             Self::Draft02(..) => DapResource::Undefined,
-            Self::Draft04(agg_job_id) => {
+            Self::Draft05(agg_job_id) => {
                 DapResource::AggregationJob(agg_job_id.clone().into_owned())
             }
         }
@@ -907,7 +907,7 @@ impl MetaAggregationJobId<'_> {
     pub fn to_hex(&self) -> String {
         match self {
             Self::Draft02(agg_job_id) => agg_job_id.to_hex(),
-            Self::Draft04(agg_job_id) => agg_job_id.to_hex(),
+            Self::Draft05(agg_job_id) => agg_job_id.to_hex(),
         }
     }
 
@@ -915,7 +915,7 @@ impl MetaAggregationJobId<'_> {
     pub fn to_base64url(&self) -> String {
         match self {
             Self::Draft02(agg_job_id) => agg_job_id.to_base64url(),
-            Self::Draft04(agg_job_id) => agg_job_id.to_base64url(),
+            Self::Draft05(agg_job_id) => agg_job_id.to_base64url(),
         }
     }
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -420,11 +420,11 @@ impl DapTaskConfig {
     }
 
     /// Return the batch span of a set of reports with the given metadata.
-    pub fn batch_span_for_meta<'a>(
+    pub fn batch_span_for_meta<'sel, 'rep>(
         &self,
-        part_batch_sel: &'a PartialBatchSelector,
-        report_meta: impl Iterator<Item = &'a ReportMetadata>,
-    ) -> Result<HashMap<DapBatchBucket<'a>, Vec<&'a ReportMetadata>>, DapError> {
+        part_batch_sel: &'sel PartialBatchSelector,
+        report_meta: impl Iterator<Item = &'rep ReportMetadata>,
+    ) -> Result<HashMap<DapBatchBucket<'sel>, Vec<&'rep ReportMetadata>>, DapError> {
         if !self.query.is_valid_part_batch_sel(part_batch_sel) {
             return Err(DapError::fatal(
                 "partial batch selector not compatible with task",

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -850,7 +850,10 @@ impl<S> DapRequest<S> {
             // draft02: Handle missing task ID as decoding failure. Normally the task ID would be
             // encoded by the message payload; it may be missing becvause parsing failed earlier on
             // in the request.
-            Err(DapAbort::UnrecognizedMessage)
+            Err(DapAbort::UnrecognizedMessage {
+                detail: "missing or malformed task ID".into(),
+                task_id: None,
+            })
         } else {
             // Handle missing task ID as a bad request. The task ID is normally conveyed by the
             // request path; if missing at this point, it is because it was missing or couldn't be

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -483,6 +483,7 @@ impl AsRef<DapTaskConfig> for DapTaskConfig {
 pub enum DapMeasurement {
     U64(u64),
     U32Vec(Vec<u32>),
+    U128Vec(Vec<u128>),
 }
 
 /// The aggregate result computed by the Collector.
@@ -730,6 +731,10 @@ pub enum Prio3Config {
     /// The sum of 64-bit, unsigned integers. Each measurement is an integer in range `[0,
     /// 2^bits)`.
     Sum { bits: usize },
+
+    /// The element-wise sum of vectors. Each vector has `len` elements.
+    /// Each element is a 64-bit unsigned integer in range `[0,2^bits)`.
+    SumVec { bits: usize, len: usize },
 }
 
 /// DAP sender role.

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![warn(unused_crate_dependencies)]
+
 //! This crate implements the core protocol logic for the Distributed Aggregation Protocol
 //! ([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard under development in the
 //! PPM working group of the IETF. See [`VdafConfig`] for a listing of supported

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -3,7 +3,7 @@
 
 //! Messages in the DAP protocol.
 
-use crate::{hpke::HpkePublicKeySerde, DapError, DapVersion};
+use crate::{fatal_error, hpke::HpkePublicKeySerde, DapError, DapVersion};
 use base64::engine::{general_purpose::URL_SAFE_NO_PAD, Engine};
 use hpke_rs::HpkePublicKey;
 use prio::codec::{
@@ -395,8 +395,8 @@ impl TryFrom<Query> for BatchSelector {
         match query {
             Query::TimeInterval { batch_interval } => Ok(Self::TimeInterval { batch_interval }),
             Query::FixedSizeByBatchId { batch_id } => Ok(Self::FixedSizeByBatchId { batch_id }),
-            Query::FixedSizeCurrentBatch => Err(DapError::Fatal(
-                "tried to make a BatchSelector from a FixedSizeCurrentBatch query".to_string(),
+            Query::FixedSizeCurrentBatch => Err(fatal_error!(
+                err = "tried to make a BatchSelector from a FixedSizeCurrentBatch query",
             )),
         }
     }
@@ -580,7 +580,7 @@ impl Decode for TransitionVar {
 }
 
 /// Transition error.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, thiserror::Error)]
 #[serde(rename_all = "snake_case")]
 pub enum TransitionFailure {
     BatchCollected = 0,

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -97,11 +97,11 @@ id_struct!(TaskId, 32, "Task ID");
 impl TaskId {
     /// draft02 compatibility: Convert the task ID to the field that would be added to the DAP
     /// request for the given version. In draft02, the task ID is generally included in the HTTP
-    /// request payload; in draft04, the task ID is included in the HTTP request path.
+    /// request payload; in draft05, the task ID is included in the HTTP request path.
     pub fn for_request_payload(&self, version: &DapVersion) -> Option<TaskId> {
         match version {
             DapVersion::Draft02 => Some(self.clone()),
-            DapVersion::Draft04 => None,
+            DapVersion::Draft05 => None,
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         }
     }
@@ -426,7 +426,7 @@ impl ParameterizedEncode<DapVersion> for AggregationJobInitReq {
                     .encode(bytes);
                 encode_u16_bytes(bytes, &self.agg_param);
             }
-            DapVersion::Draft04 => encode_u32_bytes(bytes, &self.agg_param),
+            DapVersion::Draft05 => encode_u32_bytes(bytes, &self.agg_param),
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         self.part_batch_sel.encode(bytes);
@@ -445,7 +445,7 @@ impl ParameterizedDecode<DapVersion> for AggregationJobInitReq {
                 Some(Draft02AggregationJobId::decode(bytes)?),
                 decode_u16_bytes(bytes)?,
             ),
-            DapVersion::Draft04 => (None, None, decode_u32_bytes(bytes)?),
+            DapVersion::Draft05 => (None, None, decode_u32_bytes(bytes)?),
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
 
@@ -481,10 +481,10 @@ impl ParameterizedEncode<DapVersion> for AggregationJobContinueReq {
                     .expect("draft02: missing aggregation job ID")
                     .encode(bytes);
             }
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 self.round
                     .as_ref()
-                    .expect("draft04: missing round")
+                    .expect("draft05: missing round")
                     .encode(bytes);
             }
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
@@ -504,7 +504,7 @@ impl ParameterizedDecode<DapVersion> for AggregationJobContinueReq {
                 Some(Draft02AggregationJobId::decode(bytes)?),
                 None,
             ),
-            DapVersion::Draft04 => (None, None, Some(u16::decode(bytes)?)),
+            DapVersion::Draft05 => (None, None, Some(u16::decode(bytes)?)),
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         Ok(Self {
@@ -519,7 +519,7 @@ impl ParameterizedDecode<DapVersion> for AggregationJobContinueReq {
 /// Transition message. This conveyes a message sent from one Aggregator to another during the
 /// preparation phase of VDAF evaluation.
 //
-// TODO Consider renaming this to `PrepareStep` to align with draft04.
+// TODO Consider renaming this to `PrepareStep` to align with draft05.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Transition {
     pub report_id: ReportId,
@@ -787,13 +787,13 @@ impl ParameterizedEncode<DapVersion> for CollectionReq {
                     .expect("draft02: missing task ID")
                     .encode(bytes);
             }
-            DapVersion::Draft04 => {}
+            DapVersion::Draft05 => {}
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         }
         self.query.encode_with_param(version, bytes);
         match version {
             DapVersion::Draft02 => encode_u16_bytes(bytes, &self.agg_param),
-            DapVersion::Draft04 => encode_u32_bytes(bytes, &self.agg_param),
+            DapVersion::Draft05 => encode_u32_bytes(bytes, &self.agg_param),
             _ => panic!("unimplemented DapVersion"),
         };
     }
@@ -806,7 +806,7 @@ impl ParameterizedDecode<DapVersion> for CollectionReq {
     ) -> Result<Self, CodecError> {
         let draft02_task_id = match version {
             DapVersion::Draft02 => Some(TaskId::decode(bytes)?),
-            DapVersion::Draft04 => None,
+            DapVersion::Draft05 => None,
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         Ok(Self {
@@ -814,7 +814,7 @@ impl ParameterizedDecode<DapVersion> for CollectionReq {
             query: Query::decode_with_param(version, bytes)?,
             agg_param: match version {
                 DapVersion::Draft02 => decode_u16_bytes(bytes)?,
-                DapVersion::Draft04 => decode_u32_bytes(bytes)?,
+                DapVersion::Draft05 => decode_u32_bytes(bytes)?,
                 _ => panic!("unimplemented DapVersion"),
             },
         })
@@ -838,10 +838,10 @@ impl ParameterizedEncode<DapVersion> for Collection {
         self.report_count.encode(bytes);
         match version {
             DapVersion::Draft02 => {}
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 self.interval
                     .as_ref()
-                    .expect("draft04: missing interval")
+                    .expect("draft05: missing interval")
                     .encode(bytes);
             }
             DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
@@ -860,7 +860,7 @@ impl ParameterizedDecode<DapVersion> for Collection {
             report_count: u64::decode(bytes)?,
             interval: match version {
                 DapVersion::Draft02 => None,
-                DapVersion::Draft04 => Some(Interval::decode(bytes)?),
+                DapVersion::Draft05 => Some(Interval::decode(bytes)?),
                 _ => panic!("unimplemented DapVersion"),
             },
             encrypted_agg_shares: decode_u32_items(&(), bytes)?,
@@ -891,7 +891,7 @@ impl ParameterizedEncode<DapVersion> for AggregateShareReq {
                 self.batch_sel.encode_with_param(version, bytes);
                 encode_u16_bytes(bytes, &self.agg_param);
             }
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 self.batch_sel.encode_with_param(version, bytes);
                 encode_u32_bytes(bytes, &self.agg_param);
             }
@@ -913,7 +913,7 @@ impl ParameterizedDecode<DapVersion> for AggregateShareReq {
                 BatchSelector::decode_with_param(version, bytes)?,
                 decode_u16_bytes(bytes)?,
             ),
-            DapVersion::Draft04 => (
+            DapVersion::Draft05 => (
                 None,
                 BatchSelector::decode_with_param(version, bytes)?,
                 decode_u32_bytes(bytes)?,

--- a/daphne/src/messages/mod_test.rs
+++ b/daphne/src/messages/mod_test.rs
@@ -4,13 +4,7 @@
 use crate::messages::taskprov::{
     DpConfig, QueryConfig, QueryConfigVar, TaskConfig, UrlBytes, VdafConfig, VdafTypeVar,
 };
-use crate::messages::{
-    decode_base64url, decode_base64url_vec, encode_base64url, AggregateShareReq,
-    AggregationJobContinueReq, AggregationJobId, AggregationJobInitReq, AggregationJobResp,
-    BatchId, BatchSelector, CollectionJobId, DapVersion, Draft02AggregationJobId, Extension,
-    HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId, HpkeKemId, PartialBatchSelector, Report,
-    ReportId, ReportMetadata, ReportShare, TaskId, Transition, TransitionFailure, TransitionVar,
-};
+use crate::messages::*;
 use crate::taskprov::{compute_task_id, TaskprovVersion};
 use crate::{test_version, test_versions};
 use hpke_rs::HpkePublicKey;
@@ -97,32 +91,38 @@ fn roundtrip_agg_job_init_req() {
         part_batch_sel: PartialBatchSelector::FixedSizeByBatchId {
             batch_id: BatchId([0; 32]),
         },
-        report_shares: vec![
-            ReportShare {
-                report_metadata: ReportMetadata {
-                    id: ReportId([99; 16]),
-                    time: 1637361337,
-                    extensions: Vec::default(),
+        report_inits: vec![
+            ReportInit {
+                helper_report_share: ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([99; 16]),
+                        time: 1637361337,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 23,
+                        enc: b"encapsulated key".to_vec(),
+                        payload: b"ciphertext".to_vec(),
+                    },
                 },
-                public_share: b"public share".to_vec(),
-                encrypted_input_share: HpkeCiphertext {
-                    config_id: 23,
-                    enc: b"encapsulated key".to_vec(),
-                    payload: b"ciphertext".to_vec(),
-                },
+                draft05_leader_prep_share: None,
             },
-            ReportShare {
-                report_metadata: ReportMetadata {
-                    id: ReportId([17; 16]),
-                    time: 163736423,
-                    extensions: Vec::default(),
+            ReportInit {
+                helper_report_share: ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([17; 16]),
+                        time: 163736423,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 0,
+                        enc: vec![],
+                        payload: b"ciphertext".to_vec(),
+                    },
                 },
-                public_share: b"public share".to_vec(),
-                encrypted_input_share: HpkeCiphertext {
-                    config_id: 0,
-                    enc: vec![],
-                    payload: b"ciphertext".to_vec(),
-                },
+                draft05_leader_prep_share: None,
             },
         ],
     };
@@ -141,32 +141,38 @@ fn roundtrip_agg_job_init_req() {
         part_batch_sel: PartialBatchSelector::FixedSizeByBatchId {
             batch_id: BatchId([0; 32]),
         },
-        report_shares: vec![
-            ReportShare {
-                report_metadata: ReportMetadata {
-                    id: ReportId([99; 16]),
-                    time: 1637361337,
-                    extensions: Vec::default(),
+        report_inits: vec![
+            ReportInit {
+                helper_report_share: ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([99; 16]),
+                        time: 1637361337,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 23,
+                        enc: b"encapsulated key".to_vec(),
+                        payload: b"ciphertext".to_vec(),
+                    },
                 },
-                public_share: b"public share".to_vec(),
-                encrypted_input_share: HpkeCiphertext {
-                    config_id: 23,
-                    enc: b"encapsulated key".to_vec(),
-                    payload: b"ciphertext".to_vec(),
-                },
+                draft05_leader_prep_share: Some(b"leader prep share".to_vec()),
             },
-            ReportShare {
-                report_metadata: ReportMetadata {
-                    id: ReportId([17; 16]),
-                    time: 163736423,
-                    extensions: Vec::default(),
+            ReportInit {
+                helper_report_share: ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([17; 16]),
+                        time: 163736423,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 0,
+                        enc: vec![],
+                        payload: b"ciphertext".to_vec(),
+                    },
                 },
-                public_share: b"public share".to_vec(),
-                encrypted_input_share: HpkeCiphertext {
-                    config_id: 0,
-                    enc: vec![],
-                    payload: b"ciphertext".to_vec(),
-                },
+                draft05_leader_prep_share: Some(b"leader prep share".to_vec()),
             },
         ],
     };
@@ -207,32 +213,39 @@ fn read_agg_job_init_req_draft02() {
             part_batch_sel: PartialBatchSelector::FixedSizeByBatchId {
                 batch_id: BatchId([0; 32]),
             },
-            report_shares: vec![
-                ReportShare {
-                    report_metadata: ReportMetadata {
-                        id: ReportId([99; 16]),
-                        time: 1637361337,
-                        extensions: Vec::default(),
+
+            report_inits: vec![
+                ReportInit {
+                    helper_report_share: ReportShare {
+                        report_metadata: ReportMetadata {
+                            id: ReportId([99; 16]),
+                            time: 1637361337,
+                            extensions: Vec::default(),
+                        },
+                        public_share: b"public share".to_vec(),
+                        encrypted_input_share: HpkeCiphertext {
+                            config_id: 23,
+                            enc: b"encapsulated key".to_vec(),
+                            payload: b"ciphertext".to_vec(),
+                        },
                     },
-                    public_share: b"public share".to_vec(),
-                    encrypted_input_share: HpkeCiphertext {
-                        config_id: 23,
-                        enc: b"encapsulated key".to_vec(),
-                        payload: b"ciphertext".to_vec(),
-                    },
+                    draft05_leader_prep_share: None,
                 },
-                ReportShare {
-                    report_metadata: ReportMetadata {
-                        id: ReportId([17; 16]),
-                        time: 163736423,
-                        extensions: Vec::default(),
+                ReportInit {
+                    helper_report_share: ReportShare {
+                        report_metadata: ReportMetadata {
+                            id: ReportId([17; 16]),
+                            time: 163736423,
+                            extensions: Vec::default(),
+                        },
+                        public_share: b"public share".to_vec(),
+                        encrypted_input_share: HpkeCiphertext {
+                            config_id: 0,
+                            enc: vec![],
+                            payload: b"ciphertext".to_vec(),
+                        },
                     },
-                    public_share: b"public share".to_vec(),
-                    encrypted_input_share: HpkeCiphertext {
-                        config_id: 0,
-                        enc: vec![],
-                        payload: b"ciphertext".to_vec(),
-                    },
+                    draft05_leader_prep_share: None,
                 },
             ],
         },

--- a/daphne/src/messages/mod_test.rs
+++ b/daphne/src/messages/mod_test.rs
@@ -172,8 +172,8 @@ fn read_agg_job_init_req() {
     };
 
     let got = AggregationJobInitReq::get_decoded_with_param(
-        &DapVersion::Draft04,
-        &want.get_encoded_with_param(&DapVersion::Draft04),
+        &DapVersion::Draft05,
+        &want.get_encoded_with_param(&DapVersion::Draft05),
     )
     .unwrap();
     assert_eq!(got, want);
@@ -225,8 +225,8 @@ fn read_agg_job_cont_req() {
     };
 
     let got = AggregationJobContinueReq::get_decoded_with_param(
-        &DapVersion::Draft04,
-        &want.get_encoded_with_param(&DapVersion::Draft04),
+        &DapVersion::Draft05,
+        &want.get_encoded_with_param(&DapVersion::Draft05),
     )
     .unwrap();
     assert_eq!(got, want);
@@ -261,8 +261,8 @@ fn read_agg_share_req() {
         checksum: [0; 32],
     };
     let got = AggregateShareReq::get_decoded_with_param(
-        &DapVersion::Draft04,
-        &want.get_encoded_with_param(&DapVersion::Draft04),
+        &DapVersion::Draft05,
+        &want.get_encoded_with_param(&DapVersion::Draft05),
     )
     .unwrap();
     assert_eq!(got, want);

--- a/daphne/src/messages/mod_test.rs
+++ b/daphne/src/messages/mod_test.rs
@@ -9,7 +9,7 @@ use crate::messages::{
     AggregationJobContinueReq, AggregationJobId, AggregationJobInitReq, AggregationJobResp,
     BatchId, BatchSelector, CollectionJobId, DapVersion, Draft02AggregationJobId, Extension,
     HpkeAeadId, HpkeCiphertext, HpkeConfig, HpkeKdfId, HpkeKemId, PartialBatchSelector, Report,
-    ReportId, ReportMetadata, ReportShare, TaskId, Transition, TransitionVar,
+    ReportId, ReportMetadata, ReportShare, TaskId, Transition, TransitionFailure, TransitionVar,
 };
 use crate::taskprov::{compute_task_id, TaskprovVersion};
 use crate::{test_version, test_versions};
@@ -89,7 +89,7 @@ fn read_report_with_unknown_extensions_draft02() {
 }
 
 #[test]
-fn read_agg_job_init_req() {
+fn roundtrip_agg_job_init_req() {
     let want = AggregationJobInitReq {
         draft02_task_id: Some(TaskId([23; 32])),
         draft02_agg_job_id: Some(Draft02AggregationJobId([1; 32])),
@@ -180,7 +180,67 @@ fn read_agg_job_init_req() {
 }
 
 #[test]
-fn read_agg_job_cont_req() {
+fn read_agg_job_init_req_draft02() {
+    const TEST_DATA: &[u8] = &[
+        23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
+        23, 23, 23, 23, 23, 23, 23, 23, 23, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 32, 116, 104, 105, 115, 32, 105, 115, 32, 97,
+        110, 32, 97, 103, 103, 114, 101, 103, 97, 116, 105, 111, 110, 32, 112, 97, 114, 97, 109,
+        101, 116, 101, 114, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 134, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
+        99, 99, 99, 99, 0, 0, 0, 0, 97, 152, 38, 185, 0, 0, 0, 0, 0, 12, 112, 117, 98, 108, 105,
+        99, 32, 115, 104, 97, 114, 101, 23, 0, 16, 101, 110, 99, 97, 112, 115, 117, 108, 97, 116,
+        101, 100, 32, 107, 101, 121, 0, 0, 0, 10, 99, 105, 112, 104, 101, 114, 116, 101, 120, 116,
+        17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 0, 0, 0, 0, 9, 194, 107,
+        103, 0, 0, 0, 0, 0, 12, 112, 117, 98, 108, 105, 99, 32, 115, 104, 97, 114, 101, 0, 0, 0, 0,
+        0, 0, 10, 99, 105, 112, 104, 101, 114, 116, 101, 120, 116,
+    ];
+
+    let got =
+        AggregationJobInitReq::get_decoded_with_param(&DapVersion::Draft02, TEST_DATA).unwrap();
+    assert_eq!(
+        got,
+        AggregationJobInitReq {
+            draft02_task_id: Some(TaskId([23; 32])),
+            draft02_agg_job_id: Some(Draft02AggregationJobId([1; 32])),
+            agg_param: b"this is an aggregation parameter".to_vec(),
+            part_batch_sel: PartialBatchSelector::FixedSizeByBatchId {
+                batch_id: BatchId([0; 32]),
+            },
+            report_shares: vec![
+                ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([99; 16]),
+                        time: 1637361337,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 23,
+                        enc: b"encapsulated key".to_vec(),
+                        payload: b"ciphertext".to_vec(),
+                    },
+                },
+                ReportShare {
+                    report_metadata: ReportMetadata {
+                        id: ReportId([17; 16]),
+                        time: 163736423,
+                        extensions: Vec::default(),
+                    },
+                    public_share: b"public share".to_vec(),
+                    encrypted_input_share: HpkeCiphertext {
+                        config_id: 0,
+                        enc: vec![],
+                        payload: b"ciphertext".to_vec(),
+                    },
+                },
+            ],
+        },
+    );
+}
+
+#[test]
+fn roundtrip_agg_job_cont_req() {
     let want = AggregationJobContinueReq {
         draft02_task_id: Some(TaskId([23; 32])),
         draft02_agg_job_id: Some(Draft02AggregationJobId([1; 32])),
@@ -195,6 +255,14 @@ fn read_agg_job_cont_req() {
                 var: TransitionVar::Continued(
                     b"believe it or not this is *also* a VDAF-specific message".to_vec(),
                 ),
+            },
+            Transition {
+                report_id: ReportId([2; 16]),
+                var: TransitionVar::Finished,
+            },
+            Transition {
+                report_id: ReportId([3; 16]),
+                var: TransitionVar::Failed(TransitionFailure::ReportReplayed),
             },
         ],
     };
@@ -211,6 +279,10 @@ fn read_agg_job_cont_req() {
         draft02_agg_job_id: None,
         round: Some(1),
         transitions: vec![
+            Transition {
+                report_id: ReportId([99; 16]),
+                var: TransitionVar::Failed(TransitionFailure::BatchCollected),
+            },
             Transition {
                 report_id: ReportId([0; 16]),
                 var: TransitionVar::Continued(b"this is a VDAF-specific message".to_vec()),
@@ -230,6 +302,53 @@ fn read_agg_job_cont_req() {
     )
     .unwrap();
     assert_eq!(got, want);
+}
+
+#[test]
+fn read_agg_job_cont_req_draft02() {
+    const TEST_DATA: &[u8] = &[
+        23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
+        23, 23, 23, 23, 23, 23, 23, 23, 23, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 164, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 31, 116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 86, 68, 65, 70,
+        45, 115, 112, 101, 99, 105, 102, 105, 99, 32, 109, 101, 115, 115, 97, 103, 101, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 56, 98, 101, 108, 105, 101, 118, 101, 32,
+        105, 116, 32, 111, 114, 32, 110, 111, 116, 32, 116, 104, 105, 115, 32, 105, 115, 32, 42,
+        97, 108, 115, 111, 42, 32, 97, 32, 86, 68, 65, 70, 45, 115, 112, 101, 99, 105, 102, 105,
+        99, 32, 109, 101, 115, 115, 97, 103, 101, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1,
+    ];
+
+    let got =
+        AggregationJobContinueReq::get_decoded_with_param(&DapVersion::Draft02, TEST_DATA).unwrap();
+    assert_eq!(
+        got,
+        AggregationJobContinueReq {
+            draft02_task_id: Some(TaskId([23; 32])),
+            draft02_agg_job_id: Some(Draft02AggregationJobId([1; 32])),
+            round: None,
+            transitions: vec![
+                Transition {
+                    report_id: ReportId([0; 16]),
+                    var: TransitionVar::Continued(b"this is a VDAF-specific message".to_vec()),
+                },
+                Transition {
+                    report_id: ReportId([1; 16]),
+                    var: TransitionVar::Continued(
+                        b"believe it or not this is *also* a VDAF-specific message".to_vec(),
+                    ),
+                },
+                Transition {
+                    report_id: ReportId([2; 16]),
+                    var: TransitionVar::Finished,
+                },
+                Transition {
+                    report_id: ReportId([3; 16]),
+                    var: TransitionVar::Failed(TransitionFailure::ReportReplayed),
+                },
+            ],
+        },
+    );
 }
 
 #[test]
@@ -269,7 +388,7 @@ fn read_agg_share_req() {
 }
 
 #[test]
-fn read_agg_job_resp() {
+fn roundtrip_agg_job_resp() {
     let want = AggregationJobResp {
         transitions: vec![
             Transition {
@@ -282,11 +401,52 @@ fn read_agg_job_resp() {
                     b"believe it or not this is *also* a VDAF-specific message".to_vec(),
                 ),
             },
+            Transition {
+                report_id: ReportId([17; 16]),
+                var: TransitionVar::Failed(TransitionFailure::TaskExpired),
+            },
         ],
     };
 
     let got = AggregationJobResp::get_decoded(&want.get_encoded()).unwrap();
     assert_eq!(got, want);
+}
+
+#[test]
+fn read_agg_job_resp_draft02() {
+    const TEST_DATA: &[u8] = &[
+        0, 0, 0, 147, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 0, 0, 0, 0,
+        31, 116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 86, 68, 65, 70, 45, 115, 112, 101, 99,
+        105, 102, 105, 99, 32, 109, 101, 115, 115, 97, 103, 101, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 56, 98, 101, 108, 105, 101, 118,
+        101, 32, 105, 116, 32, 111, 114, 32, 110, 111, 116, 32, 116, 104, 105, 115, 32, 105, 115,
+        32, 42, 97, 108, 115, 111, 42, 32, 97, 32, 86, 68, 65, 70, 45, 115, 112, 101, 99, 105, 102,
+        105, 99, 32, 109, 101, 115, 115, 97, 103, 101, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
+        17, 17, 17, 17, 17, 2, 7,
+    ];
+
+    let got = AggregationJobResp::get_decoded(TEST_DATA).unwrap();
+    assert_eq!(
+        got,
+        AggregationJobResp {
+            transitions: vec![
+                Transition {
+                    report_id: ReportId([22; 16]),
+                    var: TransitionVar::Continued(b"this is a VDAF-specific message".to_vec()),
+                },
+                Transition {
+                    report_id: ReportId([255; 16]),
+                    var: TransitionVar::Continued(
+                        b"believe it or not this is *also* a VDAF-specific message".to_vec(),
+                    ),
+                },
+                Transition {
+                    report_id: ReportId([17; 16]),
+                    var: TransitionVar::Failed(TransitionFailure::TaskExpired),
+                },
+            ],
+        },
+    );
 }
 
 #[test]

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -161,7 +161,7 @@ impl Decode for VdafConfig {
 }
 
 /// A URL encode / decode helper struct, essentially a box for
-/// a Vec<u8>.
+/// a `Vec<u8>`.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct UrlBytes {
     pub bytes: Vec<u8>,

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -179,7 +179,7 @@ pub trait DapAggregator<S>: HpkeDecrypter + Sized {
 
         let payload = match req.version {
             DapVersion::Draft02 => hpke_config.as_ref().get_encoded(),
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 let hpke_config_list = HpkeConfigList {
                     hpke_configs: vec![hpke_config.as_ref().clone()],
                 };
@@ -443,10 +443,10 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         // from the request path.
         let collect_job_id = match (req.version, &req.resource) {
             (DapVersion::Draft02, DapResource::Undefined) => None,
-            (DapVersion::Draft04, DapResource::CollectionJob(ref collect_job_id)) => {
+            (DapVersion::Draft05, DapResource::CollectionJob(ref collect_job_id)) => {
                 Some(collect_job_id.clone())
             }
-            (DapVersion::Draft04, DapResource::Undefined) => {
+            (DapVersion::Draft05, DapResource::Undefined) => {
                 return Err(DapAbort::BadRequest("undefined resource".into()));
             }
             _ => unreachable!("unhandled resource {:?}", req.resource),
@@ -658,11 +658,11 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         );
         let agg_share_resp = AggregateShare::get_decoded(&resp.payload)
             .map_err(|e| DapAbort::from_codec_error(e, task_id.clone()))?;
-        // For draft04 and later, the Collection message includes the smallest quantized time
+        // For draft05 and later, the Collection message includes the smallest quantized time
         // interval containing all reports in the batch.
         let interval = match task_config.version {
             DapVersion::Draft02 => None,
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 let low = task_config.quantized_time_lower_bound(leader_agg_share.min_time);
                 let high = task_config.quantized_time_upper_bound(leader_agg_share.max_time);
                 Some(Interval {
@@ -861,10 +861,10 @@ pub trait DapHelper<S>: DapAggregator<S> {
                     (DapVersion::Draft02, DapResource::Undefined, Some(ref agg_job_id)) => {
                         MetaAggregationJobId::Draft02(Cow::Borrowed(agg_job_id))
                     }
-                    (DapVersion::Draft04, DapResource::AggregationJob(ref agg_job_id), None) => {
-                        MetaAggregationJobId::Draft04(Cow::Borrowed(agg_job_id))
+                    (DapVersion::Draft05, DapResource::AggregationJob(ref agg_job_id), None) => {
+                        MetaAggregationJobId::Draft05(Cow::Borrowed(agg_job_id))
                     }
-                    (DapVersion::Draft04, DapResource::Undefined, None) => {
+                    (DapVersion::Draft05, DapResource::Undefined, None) => {
                         return Err(DapAbort::BadRequest("undefined resource".into()));
                     }
                     _ => unreachable!("unhandled resource {:?}", req.resource),
@@ -1005,10 +1005,10 @@ pub trait DapHelper<S>: DapAggregator<S> {
                     (DapVersion::Draft02, DapResource::Undefined, Some(ref agg_job_id)) => {
                         MetaAggregationJobId::Draft02(Cow::Borrowed(agg_job_id))
                     }
-                    (DapVersion::Draft04, DapResource::AggregationJob(ref agg_job_id), None) => {
-                        MetaAggregationJobId::Draft04(Cow::Borrowed(agg_job_id))
+                    (DapVersion::Draft05, DapResource::AggregationJob(ref agg_job_id), None) => {
+                        MetaAggregationJobId::Draft05(Cow::Borrowed(agg_job_id))
                     }
-                    (DapVersion::Draft04, DapResource::Undefined, None) => {
+                    (DapVersion::Draft05, DapResource::Undefined, None) => {
                         return Err(DapAbort::BadRequest("undefined resource".into()));
                     }
                     _ => unreachable!("unhandled resource {:?}", req.resource),

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -288,7 +288,7 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         &self,
     ) -> Result<Vec<(TaskId, CollectionJobId, CollectionReq)>, DapError>;
 
-    /// Complete a collect job by assigning it the completed [`CollectResp`](crate::messages::CollectResp).
+    /// Complete a collect job by assigning it the completed [`CollectResp`](crate::messages::Collection).
     async fn finish_collect_job(
         &self,
         task_id: &TaskId,

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -690,7 +690,7 @@ async fn handle_agg_job_req_zero_round(version: DapVersion) {
         .await;
     assert_matches!(
         t.helper.handle_agg_job_req(&req).await,
-        Err(DapAbort::UnrecognizedMessage)
+        Err(DapAbort::UnrecognizedMessage { .. })
     );
 
     // AggregationJobContinueReq fails
@@ -1164,7 +1164,7 @@ async fn handle_upload_req_fail_send_invalid_report(version: DapVersion) {
     // Expect failure due to incorrect number of input shares
     assert_matches!(
         t.leader.handle_upload_req(&req).await,
-        Err(DapAbort::UnrecognizedMessage)
+        Err(DapAbort::UnrecognizedMessage { .. })
     );
 }
 

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -635,7 +635,7 @@ async fn handle_agg_job_req_bad_round(version: DapVersion) {
     // Test wrong round
     let req = t
         .gen_test_agg_job_cont_req_with_round(
-            &MetaAggregationJobId::Draft04(Cow::Borrowed(&agg_job_id)),
+            &MetaAggregationJobId::Draft05(Cow::Borrowed(&agg_job_id)),
             Vec::default(),
             Some(2),
         )
@@ -683,7 +683,7 @@ async fn handle_agg_job_req_zero_round(version: DapVersion) {
     // Test wrong round
     let req = t
         .gen_test_agg_job_cont_req_with_round(
-            &MetaAggregationJobId::Draft04(Cow::Borrowed(&agg_job_id)),
+            &MetaAggregationJobId::Draft05(Cow::Borrowed(&agg_job_id)),
             Vec::default(),
             Some(0),
         )

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -205,8 +205,8 @@ fn get_taskprov_task_config<S>(
     }
 
     // Return unrecognizedMessage if parsing fails following section 5.1 of the taskprov draft.
-    let task_config =
-        TaskConfig::get_decoded_with_param(&taskprov_version, taskprov_data.as_ref())?;
+    let task_config = TaskConfig::get_decoded_with_param(&taskprov_version, taskprov_data.as_ref())
+        .map_err(|e| DapAbort::from_codec_error(e, task_id.clone()))?;
 
     Ok(Some(task_config))
 }

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
+    fatal_error,
     messages::{
         decode_base64url_vec,
         taskprov::{QueryConfigVar, TaskConfig, VdafType, VdafTypeVar},
@@ -49,8 +50,8 @@ fn compute_task_id_draft02(serialized: &[u8]) -> TaskId {
 pub fn compute_task_id(version: TaskprovVersion, serialized: &[u8]) -> Result<TaskId, DapError> {
     match version {
         TaskprovVersion::Draft02 => Ok(compute_task_id_draft02(serialized)),
-        TaskprovVersion::Unknown => Err(DapError::fatal(
-            "attempted to resolve taskprov task with unknown version",
+        TaskprovVersion::Unknown => Err(fatal_error!(
+            err = "attempted to resolve taskprov task with unknown version",
         )),
     }
 }

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -870,7 +870,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                     .peer
                     .as_ref()
                     .expect("peer not configured")
-                    .http_post_aggregate(&req)
+                    .handle_agg_job_req(&req)
                     .await
                     .expect("peer aborted unexpectedly"))
             }
@@ -878,7 +878,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                 .peer
                 .as_ref()
                 .expect("peer not configured")
-                .http_post_aggregate_share(&req)
+                .handle_agg_share_req(&req)
                 .await
                 .expect("peer aborted unexpectedly")),
             _ => unreachable!("unhandled media type: {:?}", req.media_type),
@@ -891,7 +891,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                 .peer
                 .as_ref()
                 .expect("peer not configured")
-                .http_post_aggregate(&req)
+                .handle_agg_job_req(&req)
                 .await
                 .expect("peer aborted unexpectedly"))
         } else {

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -40,7 +40,7 @@ use url::Url;
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) enum MetaAggregationJobIdOwned {
     Draft02(Draft02AggregationJobId),
-    Draft04(AggregationJobId),
+    Draft05(AggregationJobId),
 }
 
 impl From<&MetaAggregationJobId<'_>> for MetaAggregationJobIdOwned {
@@ -49,8 +49,8 @@ impl From<&MetaAggregationJobId<'_>> for MetaAggregationJobIdOwned {
             MetaAggregationJobId::Draft02(agg_job_id) => {
                 Self::Draft02(agg_job_id.clone().into_owned())
             }
-            MetaAggregationJobId::Draft04(agg_job_id) => {
-                Self::Draft04(agg_job_id.clone().into_owned())
+            MetaAggregationJobId::Draft05(agg_job_id) => {
+                Self::Draft05(agg_job_id.clone().into_owned())
             }
         }
     }
@@ -953,7 +953,7 @@ pub(crate) struct AggStore {
 //
 // and
 //
-//     something_draft04
+//     something_draft05
 //
 // that called something(version) with the appropriate version.
 //
@@ -977,7 +977,7 @@ macro_rules! test_versions {
     ($($fname:ident),*) => {
         $(
             test_version! { $fname, Draft02 }
-            test_version! { $fname, Draft04 }
+            test_version! { $fname, Draft05 }
         )*
     };
 }
@@ -999,7 +999,7 @@ macro_rules! async_test_versions {
     ($($fname:ident),*) => {
         $(
             async_test_version! { $fname, Draft02 }
-            async_test_version! { $fname, Draft04 }
+            async_test_version! { $fname, Draft05 }
         )*
     };
 }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -340,7 +340,7 @@ impl VdafConfig {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn consume_report_share(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         is_leader: bool,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
@@ -420,7 +420,7 @@ impl VdafConfig {
     #[allow(clippy::too_many_arguments)]
     pub async fn produce_agg_job_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_id: &MetaAggregationJobId<'_>,
@@ -519,7 +519,7 @@ impl VdafConfig {
     /// * `version` is the DapVersion to use.
     pub(crate) async fn handle_agg_job_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_init_req: &AggregationJobInitReq,
@@ -885,7 +885,7 @@ impl VdafConfig {
     // TODO spec: Allow the collector to have multiple HPKE public keys (the way Aggregators do).
     pub async fn consume_encrypted_agg_shares(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         batch_sel: &BatchSelector,
         report_count: u64,

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -233,7 +233,7 @@ impl VdafConfig {
 
         let input_share_text = match version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
-            DapVersion::Draft04 => CTX_INPUT_SHARE_DRAFT04,
+            DapVersion::Draft05 => CTX_INPUT_SHARE_DRAFT04,
             _ => return Err(unimplemented_version()),
         };
         let n: usize = input_share_text.len();
@@ -358,7 +358,7 @@ impl VdafConfig {
 
         let input_share_text = match task_config.version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
-            DapVersion::Draft04 => CTX_INPUT_SHARE_DRAFT04,
+            DapVersion::Draft05 => CTX_INPUT_SHARE_DRAFT04,
             _ => return Err(unimplemented_version()),
         };
         let n: usize = input_share_text.len();
@@ -966,7 +966,7 @@ impl VdafConfig {
     ) -> Result<DapAggregateResult, DapError> {
         let agg_share_text = match version {
             DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
-            DapVersion::Draft04 => CTX_AGG_SHARE_DRAFT04,
+            DapVersion::Draft05 => CTX_AGG_SHARE_DRAFT04,
             _ => return Err(unimplemented_version()),
         };
         let n: usize = agg_share_text.len();
@@ -1028,7 +1028,7 @@ fn produce_encrypted_agg_share(
 
     let agg_share_text = match version {
         DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
-        DapVersion::Draft04 => CTX_AGG_SHARE_DRAFT04,
+        DapVersion::Draft05 => CTX_AGG_SHARE_DRAFT04,
         _ => return Err(unimplemented_version_abort()),
     };
     let n: usize = agg_share_text.len();

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -919,7 +919,7 @@ impl VdafConfig {
         produce_encrypted_agg_share(true, hpke_config, task_id, batch_sel, agg_share, version)
     }
 
-    /// Like [`produce_leader_encrypted_agg_share`] but run by the Helper in response to an
+    /// Like [`produce_leader_encrypted_agg_share`](Self::produce_leader_encrypted_agg_share) but run by the Helper in response to an
     /// aggregate-share request.
     pub fn produce_helper_encrypted_agg_share(
         &self,

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -386,7 +386,7 @@ async fn agg_job_resp_abort_transition_out_of_order(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -408,7 +408,7 @@ async fn agg_job_resp_abort_report_id_repeated(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -433,7 +433,7 @@ async fn agg_job_resp_abort_unrecognized_report_id(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -454,7 +454,7 @@ async fn agg_job_resp_abort_invalid_transition(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -590,7 +590,7 @@ async fn agg_cont_abort_unrecognized_report_id(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -616,7 +616,7 @@ async fn agg_job_cont_req_abort_transition_out_of_order(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -641,7 +641,7 @@ async fn agg_job_cont_req_abort_report_id_repeated(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -4,6 +4,7 @@
 use crate::{
     assert_metrics_include, assert_metrics_include_auxiliary_function, async_test_version,
     async_test_versions,
+    error::DapAbort,
     hpke::HpkeReceiverConfig,
     messages::{
         AggregationJobContinueReq, AggregationJobInitReq, AggregationJobResp, BatchSelector,
@@ -12,10 +13,10 @@ use crate::{
         TransitionFailure, TransitionVar,
     },
     metrics::DaphneMetrics,
-    test_version, test_versions, DapAbort, DapAggregateResult, DapAggregateShare, DapError,
-    DapHelperState, DapHelperTransition, DapLeaderState, DapLeaderTransition, DapLeaderUncommitted,
-    DapMeasurement, DapOutputShare, DapQueryConfig, DapTaskConfig, DapVersion,
-    MetaAggregationJobId, Prio3Config, VdafAggregateShare, VdafConfig, VdafMessage, VdafState,
+    test_version, test_versions, DapAggregateResult, DapAggregateShare, DapError, DapHelperState,
+    DapHelperTransition, DapLeaderState, DapLeaderTransition, DapLeaderUncommitted, DapMeasurement,
+    DapOutputShare, DapQueryConfig, DapTaskConfig, DapVersion, MetaAggregationJobId, Prio3Config,
+    VdafAggregateShare, VdafConfig, VdafMessage, VdafState,
 };
 use assert_matches::assert_matches;
 use hpke_rs::HpkePublicKey;

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -174,7 +174,10 @@ fn roundtrip_report_unsupported_hpke_suite(version: DapVersion) {
         DapMeasurement::U64(1),
         version,
     );
-    assert_matches!(res, Err(DapError::Fatal(s)) => assert_eq!(s, "HPKE ciphersuite not implemented (999, 1, 1)"));
+    assert_matches!(
+        res,
+        Err(DapError::Fatal(s)) => assert_eq!(s.to_string(), "HPKE ciphersuite not implemented (999, 1, 1)")
+    );
 }
 
 test_versions! { roundtrip_report_unsupported_hpke_suite }

--- a/daphne/src/vdaf/prio3_test.rs
+++ b/daphne/src/vdaf/prio3_test.rs
@@ -2,118 +2,75 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
-    vdaf::{
-        prio3::{
-            prio3_encode_prepare_message, prio3_helper_prepare_finish, prio3_leader_prepare_finish,
-            prio3_prepare_init, prio3_shard, prio3_unshard,
-        },
-        VdafError,
-    },
-    DapAggregateResult, DapMeasurement, Prio3Config,
+    async_test_version, async_test_versions, vdaf::mod_test::Test, DapAggregateResult,
+    DapMeasurement, DapVersion, Prio3Config, VdafConfig,
 };
-use prio::codec::Encode;
-use rand::prelude::*;
+use paste::paste;
 
-#[test]
-fn prepare_count() {
-    test_prepare(
-        &Prio3Config::Count,
-        DapMeasurement::U64(0),
-        DapAggregateResult::U64(0),
-    )
-    .unwrap();
+async fn roundtrip_count(version: DapVersion) {
+    let mut t = Test::new(&VdafConfig::Prio3(Prio3Config::Count), version);
+    let got = t
+        .roundtrip(vec![
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(0),
+            DapMeasurement::U64(1),
+        ])
+        .await;
+    assert_eq!(got, DapAggregateResult::U64(5));
 }
 
-#[test]
-fn prepare_sum() {
-    test_prepare(
-        &Prio3Config::Sum { bits: 23 },
-        DapMeasurement::U64(1337),
-        DapAggregateResult::U128(1337),
-    )
-    .unwrap();
+async_test_versions! { roundtrip_count }
+
+async fn roundtrip_sum(version: DapVersion) {
+    let mut t = Test::new(&VdafConfig::Prio3(Prio3Config::Sum { bits: 23 }), version);
+    let got = t
+        .roundtrip(vec![
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(1337),
+            DapMeasurement::U64(1),
+            DapMeasurement::U64(0),
+            DapMeasurement::U64(1),
+        ])
+        .await;
+    assert_eq!(got, DapAggregateResult::U128(1340));
 }
 
-#[test]
-fn prepare_histogram() {
-    test_prepare(
-        &Prio3Config::Histogram {
-            buckets: vec![0, 23, 9999999],
-        },
-        DapMeasurement::U64(1337),
-        DapAggregateResult::U128Vec(vec![0, 0, 1, 0]),
-    )
-    .unwrap();
+async_test_versions! { roundtrip_sum }
+
+async fn roundtrip_histogram(version: DapVersion) {
+    let mut t = Test::new(
+        &VdafConfig::Prio3(Prio3Config::Histogram {
+            buckets: vec![0, 23, 999999],
+        }),
+        version,
+    );
+    let got = t.roundtrip(vec![DapMeasurement::U64(1337)]).await;
+    assert_eq!(got, DapAggregateResult::U128Vec(vec![0, 0, 1, 0]));
 }
 
-#[test]
-fn prepare_sum_vec() {
-    test_prepare(
-        &Prio3Config::SumVec { bits: 23, len: 1 },
-        DapMeasurement::U128Vec(vec![(1 << 23) - 1]),
-        DapAggregateResult::U128Vec(vec![(1 << 23) - 1]),
-    )
-    .unwrap();
+async_test_versions! { roundtrip_histogram }
 
-    test_prepare(
-        &Prio3Config::SumVec { bits: 23, len: 3 },
-        DapMeasurement::U128Vec(vec![1, 0, 42]),
-        DapAggregateResult::U128Vec(vec![1, 0, 42]),
-    )
-    .unwrap();
+async fn roundtrip_sum_vec(version: DapVersion) {
+    let mut t = Test::new(
+        &VdafConfig::Prio3(Prio3Config::SumVec { bits: 23, len: 1 }),
+        version,
+    );
+    let got = t
+        .roundtrip(vec![DapMeasurement::U128Vec(vec![(1 << 23) - 1])])
+        .await;
+    assert_eq!(got, DapAggregateResult::U128Vec(vec![(1 << 23) - 1]),);
+
+    let mut t = Test::new(
+        &VdafConfig::Prio3(Prio3Config::SumVec { bits: 23, len: 3 }),
+        version,
+    );
+    let got = t
+        .roundtrip(vec![DapMeasurement::U128Vec(vec![1, 0, 42])])
+        .await;
+    assert_eq!(got, DapAggregateResult::U128Vec(vec![1, 0, 42]));
 }
 
-fn test_prepare(
-    config: &Prio3Config,
-    measurement: DapMeasurement,
-    expected_result: DapAggregateResult,
-) -> Result<(), VdafError> {
-    let mut rng = thread_rng();
-    let verify_key = rng.gen();
-    let nonce = [0; 16];
-
-    // Shard
-    let (encoded_public_share, encoded_input_shares) =
-        prio3_shard(config, measurement, &nonce).unwrap();
-    assert_eq!(encoded_input_shares.len(), 2);
-
-    // Prepare
-    let (leader_state, leader_share) = prio3_prepare_init(
-        config,
-        &verify_key,
-        0,
-        &nonce,
-        &encoded_public_share,
-        &encoded_input_shares[0],
-    )?;
-
-    let (helper_state, helper_share) = prio3_prepare_init(
-        config,
-        &verify_key,
-        1,
-        &nonce,
-        &encoded_public_share,
-        &encoded_input_shares[1],
-    )?;
-
-    let helper_share_data = prio3_encode_prepare_message(&helper_share);
-
-    let (leader_out_share, leader_message_data) =
-        prio3_leader_prepare_finish(config, leader_state, leader_share, &helper_share_data)?;
-
-    let helper_out_share = prio3_helper_prepare_finish(config, helper_state, &leader_message_data)?;
-
-    // Unshard
-    let agg_res = prio3_unshard(
-        config,
-        1,
-        [
-            leader_out_share.get_encoded(),
-            helper_out_share.get_encoded(),
-        ],
-    )
-    .unwrap();
-    assert_eq!(agg_res, expected_result);
-
-    Ok(())
-}
+async_test_versions! { roundtrip_sum_vec }

--- a/daphne/src/vdaf/prio3_test.rs
+++ b/daphne/src/vdaf/prio3_test.rs
@@ -46,6 +46,23 @@ fn prepare_histogram() {
     .unwrap();
 }
 
+#[test]
+fn prepare_sum_vec() {
+    test_prepare(
+        &Prio3Config::SumVec { bits: 23, len: 1 },
+        DapMeasurement::U128Vec(vec![(1 << 23) - 1]),
+        DapAggregateResult::U128Vec(vec![(1 << 23) - 1]),
+    )
+    .unwrap();
+
+    test_prepare(
+        &Prio3Config::SumVec { bits: 23, len: 3 },
+        DapMeasurement::U128Vec(vec![1, 0, 42]),
+        DapAggregateResult::U128Vec(vec![1, 0, 42]),
+    )
+    .unwrap();
+}
+
 fn test_prepare(
     config: &Prio3Config,
     measurement: DapMeasurement,

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,30 +18,30 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.68"
-base64 = "0.21.2"
+async-trait.workspace = true
+base64.workspace = true
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
-futures = "0.3.28"
-getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
-hex = { version = "0.4.3", features = ["serde"] }
-matchit = "0.7.0"
-paste = "1.0.12"
-prio = "0.12.2"
-prometheus = "0.13.3"
-rand = "0.8.5"
-reqwest-wasm = { version = "0.11.16", features = ["json"] }
-ring = "0.16.20"
-serde = { version = "1.0.163", features = ["derive"] }
-thiserror = "1.0.40"
-tracing = "0.1.37"
-tracing-core = "0.1.31"
-tracing-subscriber = {version = "0.3.17", features = ["env-filter", "json"]}
-url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.96"
-serde-wasm-bindgen = "0.5.0"
-worker = "0.0.16"
+futures.workspace = true
+getrandom.workspace = true
+hex.workspace = true
+matchit.workspace = true
 once_cell = "1.17.2"
+paste.workspace = true
+prio.workspace = true
+prometheus.workspace = true
+rand.workspace = true
+reqwest-wasm = { version = "0.11.16", features = ["json"] }
+ring.workspace = true
+serde.workspace = true
+serde-wasm-bindgen = "0.5.0"
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-core = "0.1.31"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"]}
+url.workspace = true
+worker.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -19,29 +19,29 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1.68"
-base64 = "0.21.0"
-chrono = { version = "0.4.24", default-features = false, features = ["clock", "wasmbind"] }
+base64 = "0.21.2"
+chrono = { version = "0.4.26", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
 futures = "0.3.28"
 getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 matchit = "0.7.0"
 paste = "1.0.12"
-prio = "0.12.1"
+prio = "0.12.2"
 prometheus = "0.13.3"
 rand = "0.8.5"
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"
-serde = { version = "1.0.162", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
 thiserror = "1.0.40"
 tracing = "0.1.37"
-tracing-core = "0.1.30"
+tracing-core = "0.1.31"
 tracing-subscriber = {version = "0.3.17", features = ["env-filter", "json"]}
 url = { version = "2.3.1", features = ["serde"] }
 serde_json = "1.0.96"
 serde-wasm-bindgen = "0.5.0"
 worker = "0.0.16"
-once_cell = "1.17.1"
+once_cell = "1.17.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -27,18 +27,18 @@ getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 matchit = "0.7.0"
 paste = "1.0.12"
-prio = "0.12.0"
+prio = "0.12.1"
 prometheus = "0.13.3"
 rand = "0.8.5"
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
 ring = "0.16.20"
-serde = { version = "1.0.160", features = ["derive"] }
+serde = { version = "1.0.162", features = ["derive"] }
 thiserror = "1.0.40"
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-subscriber = {version = "0.3.16", features = ["env-filter", "json"]}
+tracing-subscriber = {version = "0.3.17", features = ["env-filter", "json"]}
 url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.95"
+serde_json = "1.0.96"
 serde-wasm-bindgen = "0.5.0"
 worker = "0.0.16"
 once_cell = "1.17.1"

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -19,29 +19,23 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
 futures.workspace = true
-getrandom.workspace = true
 hex.workspace = true
 matchit.workspace = true
 once_cell = "1.17.2"
-paste.workspace = true
 prio.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
-ring.workspace = true
-serde.workspace = true
 serde-wasm-bindgen = "0.5.0"
+serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"]}
-url.workspace = true
+tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
-assert_matches.workspace = true
+paste.workspace = true

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use daphne::{
     aborts::DapAbort,
+    audit_log::AuditLog,
     auth::BearerToken,
     constants::DapMediaType,
     hpke::HpkeReceiverConfig,
@@ -415,6 +416,9 @@ pub(crate) struct DaphneWorkerRequestState<'srv> {
 
     /// Error reporting for Daphne internal errors.
     pub(crate) error_reporter: &'srv dyn ErrorReporter,
+
+    /// Audit logging
+    pub(crate) audit_log: &'srv dyn AuditLog,
 }
 
 impl<'srv> DaphneWorkerRequestState<'srv> {
@@ -422,6 +426,7 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
         isolate_state: &'srv DaphneWorkerIsolateState,
         req: &Request,
         error_reporter: &'srv dyn ErrorReporter,
+        audit_log: &'srv dyn AuditLog,
     ) -> Result<Self> {
         let prometheus_registry = Registry::new();
         let metrics = DaphneWorkerMetrics::register(&prometheus_registry, None)
@@ -438,6 +443,7 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
             metrics,
             host,
             error_reporter,
+            audit_log,
         })
     }
 

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -652,7 +652,7 @@ impl<'srv> DaphneWorker<'srv> {
     pub(crate) async fn get_leader_bearer_token<'a>(
         &'a self,
         task_id: &'a TaskId,
-    ) -> Result<Option<BearerTokenKvPair>> {
+    ) -> Result<Option<BearerTokenKvPair<'a>>> {
         self.kv_get_cached(
             &self.isolate_state().leader_bearer_tokens,
             KV_KEY_PREFIX_BEARER_TOKEN_LEADER,
@@ -686,12 +686,9 @@ impl<'srv> DaphneWorker<'srv> {
 
     /// Retrieve from KV the configuration for the given task.
     pub(crate) async fn get_task_config<'req>(
-        &'srv self,
+        &self,
         task_id: Cow<'req, TaskId>,
-    ) -> Result<Option<DapTaskConfigKvPair<'req>>>
-    where
-        'srv: 'req,
-    {
+    ) -> Result<Option<DapTaskConfigKvPair<'req>>> {
         self.kv_get_cached(
             &self.isolate_state().tasks,
             KV_KEY_PREFIX_TASK_CONFIG,

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -999,7 +999,7 @@ impl<'srv> DaphneWorker<'srv> {
                 let mut r = Cursor::new(payload.as_ref());
                 (TaskId::decode(&mut r).ok(), DapResource::Undefined)
             }
-            DapVersion::Draft04 => {
+            DapVersion::Draft05 => {
                 let task_id = ctx.param("task_id").and_then(TaskId::try_from_base64url);
                 let resource = match media_type {
                     DapMediaType::AggregationJobInitReq

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -19,10 +19,10 @@ use crate::{
     InternalTestAddTask, InternalTestEndpointForTask, InternalTestRole,
 };
 use daphne::{
-    aborts::DapAbort,
     audit_log::AuditLog,
     auth::BearerToken,
     constants::DapMediaType,
+    error::DapAbort,
     fatal_error,
     hpke::HpkeReceiverConfig,
     messages::{

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -1024,11 +1024,10 @@ where
         let res: Option<String> = self
             .durable()
             .with_retry()
-            .post(
+            .get(
                 BINDING_DAP_HELPER_STATE_STORE,
                 DURABLE_HELPER_STATE_GET,
                 durable_helper_state_name(&task_config.as_ref().version, task_id, agg_job_id),
-                (),
             )
             .await
             .map_err(dap_err)?;

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use daphne::{
+    audit_log::AuditLog,
     auth::{BearerToken, BearerTokenProvider},
     constants::DapMediaType,
     hpke::HpkeDecrypter,
@@ -696,6 +697,10 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
 
     fn metrics(&self) -> &DaphneMetrics {
         &self.state.metrics.daphne
+    }
+
+    fn audit_log(&self) -> &dyn AuditLog {
+        self.state.audit_log
     }
 }
 

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -916,7 +916,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
 
         let url = task_config.as_ref().leader_url.clone();
 
-        // Note that we always return the draft02 URI, but draft04 and later ignore it.
+        // Note that we always return the draft02 URI, but draft05 and later ignore it.
         let collect_uri = url
             .join(&format!(
                 "collect/task/{}/req/{}",

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -62,7 +62,9 @@ impl DurableObject for HelperStateStore {
         match (req.path().as_ref(), req.method()) {
             // Store the Helper's state.
             //
+            // Idempotent
             // Input: `helper_state_hex: String` (hex-encoded state)
+            // Output: `()`
             (DURABLE_HELPER_STATE_PUT, Method::Post) => {
                 // The state is handled as an opaque hex string.
                 let mut helper_state_hex: Option<String> =
@@ -82,6 +84,7 @@ impl DurableObject for HelperStateStore {
 
             // Drain the Helper's state.
             //
+            // Non-idempotent (do not retry)
             // Output: `String` (hex-encoded state)
             (DURABLE_HELPER_STATE_GET, Method::Post) => {
                 let helper_state: Option<String> = state_get(&self.state, "helper_state").await?;

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -68,7 +68,7 @@ impl DurableObject for HelperStateStore {
         match (req.path().as_ref(), req.method()) {
             // Store the Helper's state.
             //
-            // Idempotent
+            // Non-idempotent
             // Input: `helper_state_hex: String` (hex-encoded state)
             // Output: `bool`
             (DURABLE_HELPER_STATE_PUT_IF_NOT_EXISTS, Method::Post) => {
@@ -80,15 +80,12 @@ impl DurableObject for HelperStateStore {
                 Response::from_json(&success)
             }
 
-            // Drain the Helper's state.
+            // Get the Helper's state.
             //
-            // Non-idempotent (do not retry)
+            // Idempotent
             // Output: `String` (hex-encoded state)
-            (DURABLE_HELPER_STATE_GET, Method::Post) => {
+            (DURABLE_HELPER_STATE_GET, Method::Get) => {
                 let helper_state: Option<String> = state_get(&self.state, "helper_state").await?;
-                if helper_state.is_some() {
-                    self.state.storage().delete("helper_state").await?;
-                }
                 Response::from_json(&helper_state)
             }
 

--- a/daphne_worker/src/durable/mod_test.rs
+++ b/daphne_worker/src/durable/mod_test.rs
@@ -6,7 +6,7 @@ use crate::durable::{
     reports_pending::PendingReport,
 };
 use daphne::{
-    messages::{BatchId, Report, ReportId, ReportMetadata, TaskId},
+    messages::{BatchId, HpkeCiphertext, Report, ReportId, ReportMetadata, TaskId},
     test_version, test_versions, DapBatchBucket, DapVersion,
 };
 use paste::paste;
@@ -52,7 +52,18 @@ fn parse_report_id_hex_from_report(version: DapVersion) {
             extensions: Vec::default(),
         },
         public_share: Vec::default(),
-        encrypted_input_shares: Vec::default(),
+        encrypted_input_shares: vec![
+            HpkeCiphertext {
+                config_id: rng.gen(),
+                enc: b"encapsulated key".to_vec(),
+                payload: b"ciphertext".to_vec(),
+            },
+            HpkeCiphertext {
+                config_id: rng.gen(),
+                enc: b"encapsulated key".to_vec(),
+                payload: b"ciphertext".to_vec(),
+            },
+        ],
     };
 
     let pending_report = PendingReport {

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -46,7 +46,7 @@ impl PendingReport {
     pub(crate) fn report_id_hex(&self) -> Option<&str> {
         match self.version {
             DapVersion::Draft02 if self.report_hex.len() >= 96 => Some(&self.report_hex[64..96]),
-            DapVersion::Draft04 if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
+            DapVersion::Draft05 if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
             DapVersion::Unknown => unreachable!("unhandled version {:?}", self.version),
             _ => None,
         }

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -80,6 +80,7 @@ impl DurableObject for ReportsProcessed {
             // Mark a set of reports as aggregated. Return the set of report IDs that already
             // exist.
             //
+            // Non-idempotent (do not retry)
             // Input: `report_id_hex_set: Vec<String>` (hex-encoded report IDs)
             // Output: `Vec<String>` (subset of the inputs that already exist).
             (DURABLE_REPORTS_PROCESSED_MARK_AGGREGATED, Method::Post) => {

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -80,7 +80,7 @@ impl DurableObject for ReportsProcessed {
             // Mark a set of reports as aggregated. Return the set of report IDs that already
             // exist.
             //
-            // Non-idempotent (do not retry)
+            // Non-idempotent
             // Input: `report_id_hex_set: Vec<String>` (hex-encoded report IDs)
             // Output: `Vec<String>` (subset of the inputs that already exist).
             (DURABLE_REPORTS_PROCESSED_MARK_AGGREGATED, Method::Post) => {

--- a/daphne_worker/src/error_reporting.rs
+++ b/daphne_worker/src/error_reporting.rs
@@ -3,7 +3,7 @@
 
 //! Daphne-Worker error reporting trait and default implementation.
 
-use daphne::aborts::DapAbort;
+use daphne::error::DapAbort;
 
 /// Interface for error reporting in Daphne
 /// Refer to NoopErrorReporter for implementation example.

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -698,6 +698,8 @@ pub(crate) struct InternalTestVdaf {
     typ: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     bits: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    length: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -677,17 +677,6 @@ pub(crate) fn int_err<S: ToString>(s: S) -> Error {
     Error::RustError("internalError".to_string())
 }
 
-/// Convert a [`worker::Error`] into a [`daphne::DapError`].
-///
-/// NOTE Alternatively, we could implement `From<worker::Error>` for `daphne::DapError` in the
-/// `daphne` crate. This requires synchronizing the version of the `worker` crate used here and by
-/// `daphne`. However, The `worker` crate is still under active development, and we often need
-/// changes that are on the main branch but not yet released. Thus, synchronizing this dependency
-/// between both crates is not currently feasible.
-pub(crate) fn dap_err(e: Error) -> DapError {
-    DapError::Fatal(format!("worker: {e}"))
-}
-
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum InternalTestRole {

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -159,10 +159,10 @@ use crate::{
     dap::dap_response_to_worker,
 };
 use daphne::{
-    aborts::DapAbort,
     audit_log::{AuditLog, NoopAuditLog},
     auth::BearerToken,
     constants::DapMediaType,
+    error::DapAbort,
     messages::{CollectionJobId, Duration, TaskId, Time},
     roles::{DapAggregator, DapHelper, DapLeader},
     DapCollectJob, DapError, DapRequest, DapResponse, DapVersion,

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -630,7 +630,7 @@ async fn handle_agg_job(
 
         info_span!(
             "aggregate",
-            job_id = task_id,
+            "dap.task_id" = task_id,
             version = req.version.to_string()
         )
     };
@@ -657,7 +657,7 @@ async fn handle_agg_share_req(
 
         info_span!(
             "aggregate_share",
-            job_id = task_id,
+            "dap.task_id" = task_id,
             version = req.version.to_string()
         )
     };

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -278,7 +278,7 @@ impl DaphneWorkerRouter<'_> {
 
                 let span = info_span_from_dap_request!("hpke_config", req);
 
-                match daph.http_get_hpke_config(&req).instrument(span).await {
+                match daph.handle_hpke_config_req(&req).instrument(span).await {
                     Ok(req) => dap_response_to_worker(req),
                     Err(e) => daph.state.dap_abort_to_worker_response(e),
                 }
@@ -316,7 +316,7 @@ impl DaphneWorkerRouter<'_> {
 
                         let span = info_span_from_dap_request!("collect", req);
 
-                        match daph.http_post_collect(&req).instrument(span).await {
+                        match daph.handle_collect_job_req(&req).instrument(span).await {
                             Ok(collect_uri) => {
                                 let mut headers = Headers::new();
                                 headers.set("Location", collect_uri.as_str())?;
@@ -390,7 +390,7 @@ impl DaphneWorkerRouter<'_> {
 
                             let span = info_span_from_dap_request!("collect (PUT)", req);
 
-                            match daph.http_post_collect(&req).instrument(span).await {
+                            match daph.handle_collect_job_req(&req).instrument(span).await {
                                 Ok(_) => Ok(Response::empty().unwrap().with_status(201)),
                                 Err(e) => daph.state.dap_abort_to_worker_response(e),
                             }
@@ -632,7 +632,7 @@ async fn put_report_into_task(
 
     let span = info_span_from_dap_request!("upload", req);
 
-    match daph.http_post_upload(&req).instrument(span).await {
+    match daph.handle_upload_req(&req).instrument(span).await {
         Ok(()) => Response::empty(),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }
@@ -647,7 +647,7 @@ async fn handle_agg_job(
 
     let span = info_span_from_dap_request!("aggregate", req);
 
-    match daph.http_post_aggregate(&req).instrument(span).await {
+    match daph.handle_agg_job_req(&req).instrument(span).await {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }
@@ -662,7 +662,7 @@ async fn handle_agg_share_req(
 
     let span = info_span_from_dap_request!("aggregate_share", req);
 
-    match daph.http_post_aggregate_share(&req).instrument(span).await {
+    match daph.handle_agg_share_req(&req).instrument(span).await {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![warn(unused_crate_dependencies)]
+
 //! Daphne-Worker implements a [Workers](https://developers.cloudflare.com/workers/) backend for
 //! Daphne.
 //!

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -66,7 +66,7 @@
 //! [Fixed-size tasks]    <version>/task/<task_id>/batch/<batch_id>
 //! ```
 //!
-//! where <version> is the DAP version, `<task_id>` is the task ID, `<window>` is a batch window,
+//! where `<version>` is the DAP version, `<task_id>` is the task ID, `<window>` is a batch window,
 //! and `<batch_id>` is a batch ID. A batch window is a UNIX timestamp (in seconds) truncated by
 //! the time precision for the task. (See the `time_precision` paramaeter of
 //! [`DapTaskConfig`](daphne::DapTaskConfig).)
@@ -100,7 +100,7 @@
 //!
 //! A "collection job ID" is computed for each job and incorporated into the collect URI for the
 //! Collector to poll later on. The job ID Is derived by applying a keyed hash to the serialized
-//! [`CollectReq`](daphne::messages::CollectReq) message. (The key is `DAP_COLLECT_ID_KEY`.)
+//! [`CollectionReq`](daphne::messages::CollectionReq) message. (The key is `DAP_COLLECT_ID_KEY`.)
 //!
 //! They are driven by the Leader's main processing loop. After all aggregation jobs are complete,
 //! the entire queue is fetched from `LeaderCollectionJobQueue`. In the order in which they were

--- a/daphne_worker/src/metrics.rs
+++ b/daphne_worker/src/metrics.rs
@@ -4,7 +4,7 @@
 //! Daphne-Worker metrics.
 
 use crate::DapError;
-use daphne::metrics::DaphneMetrics;
+use daphne::{fatal_error, metrics::DaphneMetrics};
 use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
 
 pub(crate) struct DaphneWorkerMetrics {
@@ -31,14 +31,16 @@ impl DaphneWorkerMetrics {
             "HTTP response status code.",
             &["host", "code"],
             registry
-        )?;
+        )
+        .map_err(|e| fatal_error!(err = e, "failed to register http_status_code"))?;
 
         let dap_abort_counter = register_int_counter_vec_with_registry!(
             format!("{front}dap_abort"),
             "DAP aborts.",
             &["host", "type"],
             registry
-        )?;
+        )
+        .map_err(|e| fatal_error!(err = e, "failed to register dap_abort"))?;
 
         let daphne = DaphneMetrics::register(registry, prefix)?;
 

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,23 +25,23 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-tracing = "0.1.37"
-worker = "0.0.16"
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+worker.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-base64 = "0.21.2"
+assert_matches.workspace = true
+base64.workspace = true
 daphne = { path = "../daphne" }
-futures = "0.3.28"
-hex = { version = "0.4.3", features = ["serde"] }
-hpke-rs = "0.1.0"
-lazy_static = "1.4.0"
-paste = "1.0.12"
-prio = "0.12.2"
-rand = "0.8.5"
-reqwest = { version = "0.11.18", features = ["json"] }
-ring = "0.16.20"
-tokio = { version = "1.28.2", features = ["full"] }
-url = { version = "2.3.1", features = ["serde"] }
+futures.workspace = true
+hex.workspace = true
+hpke-rs.workspace = true
+lazy_static.workspace = true
+paste.workspace = true
+prio.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+ring.workspace = true
+tokio = { workspace = true, features = ["full"] }
+url.workspace = true

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,8 +25,8 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version = "1.0.162", features = ["derive"] }
+serde_json = "1.0.96"
 tracing = "0.1.37"
 worker = "0.0.16"
 
@@ -39,9 +39,9 @@ hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
 lazy_static = "1.4.0"
 paste = "1.0.12"
-prio = "0.12.0"
+prio = "0.12.1"
 rand = "0.8.5"
-reqwest = { version = "0.11.16", features = ["json"] }
+reqwest = { version = "0.11.17", features = ["json"] }
 ring = "0.16.20"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.28.0", features = ["full"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,23 +25,23 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.162", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 tracing = "0.1.37"
 worker = "0.0.16"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-base64 = "0.21.0"
+base64 = "0.21.2"
 daphne = { path = "../daphne" }
 futures = "0.3.28"
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
 lazy_static = "1.4.0"
 paste = "1.0.12"
-prio = "0.12.1"
+prio = "0.12.2"
 rand = "0.8.5"
-reqwest = { version = "0.11.17", features = ["json"] }
+reqwest = { version = "0.11.18", features = ["json"] }
 ring = "0.16.20"
-tokio = { version = "1.28.0", features = ["full"] }
+tokio = { version = "1.28.2", features = ["full"] }
 url = { version = "2.3.1", features = ["serde"] }

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,23 +25,20 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde.workspace = true
-serde_json.workspace = true
 tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-base64.workspace = true
 daphne = { path = "../daphne" }
-futures.workspace = true
 hex.workspace = true
 hpke-rs.workspace = true
-lazy_static.workspace = true
 paste.workspace = true
 prio.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 url.workspace = true

--- a/daphne_worker_test/docker/runtests.Dockerfile
+++ b/daphne_worker_test/docker/runtests.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63-bullseye
+FROM rust:1.69-bullseye
 
 WORKDIR /tmp/dap_test
 
@@ -15,8 +15,6 @@ COPY daphne_worker ./daphne_worker
 COPY daphne ./daphne
 COPY daphne_worker_test/docker/test.sh /
 RUN chmod +x /test.sh
-
-RUN cargo test --no-run --features=test_e2e -p daphne-worker-test
 
 ENV PATH="${PATH}:/root/.cargo/bin"
 CMD ["/test.sh"]

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -26,7 +26,6 @@ use serde::Deserialize;
 use serde_json::json;
 use std::cmp::{max, min};
 use test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
-use url::Url;
 
 // Redefine async_test_version locally because we want a
 // cfg_attr as well.
@@ -1529,7 +1528,8 @@ async fn e2e_helper_admin_add_task(version: DapVersion) {
         "vdaf_verify_key": "y4e6alnJMQ0MZTvdJRJx5Q"
     });
 
-    let url = Url::parse("http://127.0.0.1:8788/task").unwrap();
+    let mut url = t.helper_url.clone();
+    url.set_path("task");
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         reqwest::header::HeaderName::from_lowercase(b"x-daphne-worker-admin-bearer-token").unwrap(),
@@ -1545,8 +1545,7 @@ async fn e2e_helper_admin_add_task(version: DapVersion) {
         .expect("request failed");
     if resp.status() != 200 {
         panic!(
-            "request to {} failed: {}: {}",
-            url,
+            "request to {url} failed: {}: {}",
             resp.status(),
             resp.text().await.unwrap()
         );

--- a/daphne_worker_test/tests/e2e.rs
+++ b/daphne_worker_test/tests/e2e.rs
@@ -90,7 +90,7 @@ async fn e2e_leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let expected = if want_prefix {
         format!("/{}/", version.as_ref())
     } else {
-        String::from("/v04/") // Must match DAP_DEFAULT_VERSION
+        String::from("/v05/") // Must match DAP_DEFAULT_VERSION
     };
     assert_eq!(res.endpoint.unwrap(), expected);
 }
@@ -131,7 +131,7 @@ async fn e2e_helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let expected = if want_prefix {
         format!("/{}/", version.as_ref())
     } else {
-        String::from("/v04/") // Must match DAP_DEFAULT_VERSION
+        String::from("/v05/") // Must match DAP_DEFAULT_VERSION
     };
     assert_eq!(res.endpoint.unwrap(), expected);
 }
@@ -317,7 +317,7 @@ async fn e2e_leader_upload(version: DapVersion) {
     );
     let builder = match t.version {
         DapVersion::Draft02 => client.post(url.as_str()),
-        DapVersion::Draft04 => client.put(url.as_str()),
+        DapVersion::Draft05 => client.put(url.as_str()),
         _ => unreachable!("unhandled version {}", t.version),
     };
     let resp = builder
@@ -1154,7 +1154,7 @@ async fn e2e_fixed_size(version: DapVersion, use_current: bool) {
     if version == DapVersion::Draft02 && use_current {
         // The "current batch" isn't a feature in Draft02, but we allow it
         // and immediately return for testing flexibility, as this allows us
-        // to not have a test coverage regression if we add a Draft04 in
+        // to not have a test coverage regression if we add a Draft05 in
         // the future.
         return;
     }

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -86,7 +86,7 @@ impl TestRunner {
         // aggregator URL with 127.0.0.1.
         let version_path = match version {
             DapVersion::Draft02 => "v02",
-            DapVersion::Draft04 => "v04",
+            DapVersion::Draft05 => "v05",
             _ => panic!("unimplemented DapVersion"),
         };
         let mut leader_url = Url::parse(&format!("http://leader:8787/{}/", version_path)).unwrap();
@@ -568,7 +568,7 @@ impl TestRunner {
         client: &reqwest::Client,
         report_sel: &DaphneWorkerReportSelector,
     ) -> DapLeaderProcessTelemetry {
-        // Replace path "/v04" with "/internal/process".
+        // Replace path "/v05" with "/internal/process".
         let mut url = self.leader_url.clone();
         url.set_path("internal/process");
 
@@ -599,7 +599,7 @@ impl TestRunner {
         } else {
             self.helper_url.clone()
         };
-        url.set_path(path); // Overwrites the version path (i.e., "/v04")
+        url.set_path(path); // Overwrites the version path (i.e., "/v05")
         let resp = client
             .post(url.clone())
             .json(data)
@@ -662,7 +662,7 @@ impl TestRunner {
     pub fn upload_path_for_task(&self, id: &TaskId) -> String {
         match self.version {
             DapVersion::Draft02 => "upload".to_string(),
-            DapVersion::Draft04 => format!("tasks/{}/reports", id.to_base64url()),
+            DapVersion::Draft05 => format!("tasks/{}/reports", id.to_base64url()),
             _ => unreachable!("unknown version"),
         }
     }
@@ -763,7 +763,7 @@ async fn post_internal_delete_all(
     base_url: &Url,
     batch_interval: &Interval,
 ) {
-    // Replace path "/v04" with "/internal/delete_all".
+    // Replace path "/v05" with "/internal/delete_all".
     let mut url = base_url.clone();
     url.set_path("internal/delete_all");
 

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -54,7 +54,7 @@ DAP_TASKPROV_LEADER_AUTH = """{
 DAP_TASKPROV_COLLECTOR_AUTH = """{
   "bearer_token": "I am the collector!"
 }""" # SECRET
-DAP_DEFAULT_VERSION = "v04"
+DAP_DEFAULT_VERSION = "v05"
 DAP_TRACING = "debug"
 
 [env.leader.durable_objects]
@@ -131,7 +131,7 @@ DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d
 DAP_TASKPROV_LEADER_AUTH = """{
   "bearer_token": "I am the leader!"
 }""" # SECRET
-DAP_DEFAULT_VERSION = "v04"
+DAP_DEFAULT_VERSION = "v05"
 DAP_TRACING = "debug"
 
 [env.helper.durable_objects]

--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -32,8 +32,8 @@ ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "
 
 FROM test AS helper
 
-ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", "", "-p", "8080", "--wrangler-env=helper"]
+ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", "", "--wrangler-env=helper"]
 
 FROM test AS leader
 
-ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", "", "-p", "8080", "--wrangler-env=leader"]
+ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", "", "--wrangler-env=leader"]

--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update \
     npm \
     openssl-dev \
     wasm-pack
-RUN npm install -g wrangler@2.12.2
+RUN npm install -g wrangler@2.19.0
 
 # Pre-install worker-build and Rust's wasm32 target to speed up our custom build command
 RUN cargo install --git https://github.com/cloudflare/workers-rs
@@ -23,7 +23,7 @@ RUN wrangler publish --dry-run
 
 FROM alpine:3.16 AS test
 RUN apk add --update npm bash
-RUN npm install -g miniflare@2.12.2
+RUN npm install -g miniflare@2.14.0
 COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
 COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
 EXPOSE 8080

--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68-alpine AS builder
+FROM rust:1.69-alpine AS builder
 WORKDIR /tmp/dap_test
 RUN apk add --update \
     bash \

--- a/docker/wrangler.toml
+++ b/docker/wrangler.toml
@@ -54,7 +54,7 @@ DAP_TASKPROV_LEADER_AUTH = """{
 DAP_TASKPROV_COLLECTOR_AUTH = """{
   "bearer_token": "I am the collector!"
 }""" # SECRET
-DAP_DEFAULT_VERSION = "v04"
+DAP_DEFAULT_VERSION = "v05"
 DAP_TRACING = "debug"
 
 [env.leader.durable_objects]
@@ -131,7 +131,7 @@ DAP_TASKPROV_VDAF_VERIFY_KEY_INIT = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d
 DAP_TASKPROV_LEADER_AUTH = """{
   "bearer_token": "I am the leader!"
 }""" # SECRET
-DAP_DEFAULT_VERSION = "v04"
+DAP_DEFAULT_VERSION = "v05"
 DAP_TRACING = "debug"
 
 [env.helper.durable_objects]


### PR DESCRIPTION
THIS PR IS NOT READY FOR REVIEW. It's based on a PR for the DAP spec that hasn't yet been merged.

Implement the new aggregation flow as of DAP spec PR https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/393.

This PR introduces the following changes:

* In the current "leader-as-broadcast-channel" flow, the Leader gathers each round of prep shares from the Helpers, computes the prep message, and broadcasts it to the Helpers in the next round. In the new flow, we assume there is exactly one Helper, and each Aggregator runs the prep process as far as it it can until it needs input from its peer. This results in a significant reduction in the number of HTTP requests sent.

* The `Report` serialization has changed in light of specializing the protocol for two Aggregators.

* A new `PrepareStepState` variant is defined for signaling commitment to the share and transmitting the prep message.


TODOs
- [ ] List the code changs that were needed. We've tried to maintain test coverage, however some tests are no longer relevant since (a) we only support 1-round VDAFs and (b) draft04 requires one request to complete aggregation instead of two.
- [x] Don't check for existing Helper state in draft04, since we don't need to store it anymore.
- [x] Implement `Report` encoding change
- [ ] Pick a codepoint (and name!) for the new `PrepareStepState` variant.

