### PR TITLE
make failures to report metrics non fatal

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -482,9 +482,6 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
             let status = reqwest_resp.status();
             if status != 200 {
                 error!("unexpected response from metrics server: {reqwest_resp:?}");
-                return Err(Error::RustError(format!(
-                    "metrics push failed with response status {status}",
-                )));
             }
         }
         Ok(())


### PR DESCRIPTION
Sometimes our metrics endpoint is returning an error and propagating the error to the eyeball.

Since metrics aren't cleared, we can retry the next time. This change makes the metrics failure non fatal and makes it invisible to the eyeball.