### PR TITLE
daphne_worker: Retry requests to HelperStateStore

### DIFF
--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -1000,6 +1000,7 @@ where
         let task_config = self.try_get_task_config(task_id).await?;
         let helper_state_hex = hex::encode(helper_state.get_encoded(&task_config.as_ref().vdaf)?);
         self.durable()
+            .with_retry()
             .post(
                 BINDING_DAP_HELPER_STATE_STORE,
                 DURABLE_HELPER_STATE_PUT,
@@ -1019,6 +1020,7 @@ where
         let task_config = self.try_get_task_config(task_id).await?;
         let res: Option<String> = self
             .durable()
+            .with_retry()
             .post(
                 BINDING_DAP_HELPER_STATE_STORE,
                 DURABLE_HELPER_STATE_GET,


### PR DESCRIPTION
Add a method, `with_retry()` on `DurableConnector` that, when invoked, implements a simple linear-backoff retry mechanism. Further, retry requests to HelperStateStore.

This change is intended to address transient errors in the Workers platform that we noticed during load testing. In particular, we noticed a non-negligible number of failures of requests to HelperStateStore, of which there is a fresh instance per aggregation job.

Retries are safe for HelperStateStore because requests to this object are idempotent. In general, whether retry is safe depends on the nature of how the request changes the object's state.