### PR TITLE
taskprov: Don't store config if advertised by request from Leader

### DIFF
--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -24,7 +24,7 @@ const MEDIA_TYPE_HPKE_CONFIG_LIST: &str = "application/dap-hpke-config-list";
 const MEDIA_TYPE_REPORT: &str = "application/dap-report";
 
 /// Media type for each DAP request. This is included in the "content-type" HTTP header.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum DapMediaType {
     AggregationJobInitReq,
     AggregationJobResp,
@@ -41,6 +41,7 @@ pub enum DapMediaType {
     /// The content-type does not match a known media type.
     Invalid(String),
     /// No content-type header found.
+    #[default]
     Missing,
 }
 

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -123,7 +123,7 @@ impl From<VdafError> for DapError {
 }
 
 /// DAP version used for a task.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum DapVersion {
     #[serde(rename = "v02")]
     Draft02,
@@ -133,6 +133,7 @@ pub enum DapVersion {
 
     #[serde(other)]
     #[serde(rename = "unknown_version")]
+    #[default]
     Unknown,
 }
 
@@ -737,7 +738,7 @@ pub enum DapSender {
 }
 
 /// Types of resources associated with DAP tasks.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum DapResource {
     /// Aggregation job resource.
     AggregationJob(AggregationJobId),
@@ -758,6 +759,7 @@ pub enum DapResource {
     ///
     /// draft02 compatibility: In draft02, the resource of a DAP request is undetermined until the
     /// request payload is parsed. Defer detrmination of the resource until then.
+    #[default]
     Undefined,
 }
 
@@ -785,6 +787,24 @@ pub struct DapRequest<S> {
 
     /// Sender authorization, e.g., a bearer token.
     pub sender_auth: Option<S>,
+
+    /// taskprov: The task advertisement, sent in the "dap-taskprov" header.
+    pub taskprov: Option<String>,
+}
+
+impl<S> Default for DapRequest<S> {
+    fn default() -> Self {
+        Self {
+            version: Default::default(),
+            media_type: Default::default(),
+            task_id: Default::default(),
+            resource: Default::default(),
+            payload: Default::default(),
+            url: Url::parse("http://example.com").unwrap(),
+            sender_auth: Default::default(),
+            taskprov: Default::default(),
+        }
+    }
 }
 
 impl<S> DapRequest<S> {

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -792,6 +792,7 @@ pub struct DapRequest<S> {
     pub taskprov: Option<String>,
 }
 
+#[cfg(test)]
 impl<S> Default for DapRequest<S> {
     fn default() -> Self {
         Self {

--- a/daphne/src/roles.rs
+++ b/daphne/src/roles.rs
@@ -240,6 +240,7 @@ macro_rules! leader_post {
                     .authorize(&$task_id, &$req_media_type, &$req_data)
                     .await?,
             ),
+            taskprov: None,
         };
 
         let resp = if $is_put {

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -217,7 +217,7 @@ impl Test {
             resource: DapResource::Undefined,
             payload: report.get_encoded_with_param(&version),
             url: task_config.leader_url.join("upload").unwrap(),
-            sender_auth: None,
+            ..Default::default()
         }
     }
 
@@ -448,6 +448,7 @@ impl Test {
             payload,
             url,
             sender_auth,
+            ..Default::default()
         }
     }
 
@@ -475,6 +476,7 @@ impl Test {
             payload,
             url,
             sender_auth,
+            ..Default::default()
         }
     }
 
@@ -500,6 +502,7 @@ impl Test {
             payload: msg.get_encoded_with_param(&version),
             url,
             sender_auth: Some(self.collector_token.clone()),
+            ..Default::default()
         }
     }
 }
@@ -684,7 +687,7 @@ async fn http_get_hpke_config_unrecognized_task(version: DapVersion) {
             task_id.to_base64url()
         ))
         .unwrap(),
-        sender_auth: None,
+        ..Default::default()
     };
 
     assert_matches!(
@@ -704,7 +707,7 @@ async fn http_get_hpke_config_missing_task_id(version: DapVersion) {
         resource: DapResource::Undefined,
         payload: Vec::new(),
         url: Url::parse("http://aggregator.biz/v02/hpke_config").unwrap(),
-        sender_auth: None,
+        ..Default::default()
     };
 
     // An Aggregator is permitted to abort an HPKE config request if the task ID is missing. Note
@@ -858,7 +861,7 @@ async fn http_post_collect_unauthorized_request(version: DapVersion) {
         }
         .get_encoded_with_param(&task_config.version),
         url: task_config.leader_url.join(&url_path).unwrap(),
-        sender_auth: None, // Unauthorized request.
+        ..Default::default() // Unauthorized request.
     };
 
     // Expect failure due to missing bearer token.
@@ -1106,7 +1109,7 @@ async fn http_post_upload_fail_send_invalid_report(version: DapVersion) {
         resource: DapResource::Undefined,
         payload: report_invalid_task_id.get_encoded_with_param(&task_config.version),
         url: task_config.leader_url.join("upload").unwrap(),
-        sender_auth: None,
+        ..Default::default()
     };
 
     // Expect failure due to invalid task ID in report.
@@ -1144,7 +1147,7 @@ async fn http_post_upload_task_expired(version: DapVersion) {
         resource: DapResource::Undefined,
         payload: report.get_encoded_with_param(&version),
         url: task_config.leader_url.join("upload").unwrap(),
-        sender_auth: None,
+        ..Default::default()
     };
 
     assert_matches!(
@@ -1689,7 +1692,7 @@ async fn e2e_taskprov(version: DapVersion) {
         resource: DapResource::Undefined,
         payload: report.get_encoded_with_param(&version),
         url: Url::parse("https://leader.com/upload").unwrap(),
-        sender_auth: None,
+        ..Default::default()
     };
     t.leader.http_post_upload(&req).await.unwrap();
 

--- a/daphne/src/taskprov_test.rs
+++ b/daphne/src/taskprov_test.rs
@@ -1,11 +1,18 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+use prio::codec::ParameterizedEncode;
+
 use crate::{
-    messages::taskprov::VdafType,
-    messages::TaskId,
-    taskprov::{compute_vdaf_verify_key, TaskprovVersion},
+    auth::BearerToken,
+    hpke::HpkeReceiverConfig,
+    messages::{encode_base64url, taskprov::*, Extension, ReportId, ReportMetadata, TaskId},
+    messages::{taskprov::VdafType, HpkeKemId},
+    taskprov::{
+        compute_task_id, compute_vdaf_verify_key, resolve_advertised_task_config, TaskprovVersion,
+    },
     vdaf::VdafVerifyKey,
+    DapRequest,
 };
 
 #[test]
@@ -34,4 +41,111 @@ fn check_vdaf_key_computation() {
         VdafVerifyKey::Prio3(bytes) => assert_eq!(*bytes, expected),
         _ => unreachable!(),
     }
+}
+
+// Ensure that the task config is computed the same way whether it was advertised in the request
+// header or the report metadata.
+#[test]
+fn test_resolve_advertised_task_config() {
+    let taskprov_version = TaskprovVersion::Draft02;
+    let taskprov_task_config = TaskConfig {
+        task_info: "Hi".as_bytes().to_vec(),
+        aggregator_endpoints: vec![
+            UrlBytes {
+                bytes: "https://leader.com".as_bytes().to_vec(),
+            },
+            UrlBytes {
+                bytes: "https://helper.com".as_bytes().to_vec(),
+            },
+        ],
+        query_config: QueryConfig {
+            time_precision: 0x01,
+            max_batch_query_count: 128,
+            min_batch_size: 1024,
+            var: QueryConfigVar::FixedSize {
+                max_batch_size: 2048,
+            },
+        },
+        task_expiration: 0x6352f9a5,
+        vdaf_config: VdafConfig {
+            dp_config: DpConfig::None,
+            var: VdafTypeVar::Prio3Aes128Histogram {
+                buckets: vec![1, 2, 3],
+            },
+        },
+    };
+
+    let taskprov_task_config_data = taskprov_task_config.get_encoded_with_param(&taskprov_version);
+    let taskprov_task_config_base64url = encode_base64url(&taskprov_task_config_data);
+    let task_id = compute_task_id(taskprov_version, &taskprov_task_config_data).unwrap();
+    let collector_hpke_config = HpkeReceiverConfig::gen(1, HpkeKemId::X25519HkdfSha256)
+        .unwrap()
+        .config;
+
+    let from_request_header = resolve_advertised_task_config(
+        &DapRequest::<BearerToken> {
+            task_id: Some(task_id.clone()),
+            taskprov: Some(taskprov_task_config_base64url),
+            ..Default::default()
+        },
+        taskprov_version,
+        &[0; 32],
+        &collector_hpke_config,
+        &task_id,
+        None,
+    )
+    .unwrap()
+    .unwrap();
+
+    let from_report_metadata = resolve_advertised_task_config(
+        &DapRequest::<BearerToken> {
+            task_id: Some(task_id.clone()),
+            ..Default::default()
+        },
+        taskprov_version,
+        &[0; 32],
+        &collector_hpke_config,
+        &task_id,
+        Some(&ReportMetadata {
+            id: ReportId([0; 16]),
+            time: 0,
+            extensions: vec![Extension::Taskprov {
+                payload: taskprov_task_config_data,
+            }],
+        }),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(from_request_header.version, from_report_metadata.version);
+    assert_eq!(
+        from_request_header.leader_url,
+        from_report_metadata.leader_url
+    );
+    assert_eq!(
+        from_request_header.helper_url,
+        from_report_metadata.helper_url
+    );
+    assert_eq!(
+        from_request_header.time_precision,
+        from_report_metadata.time_precision
+    );
+    assert_eq!(
+        from_request_header.expiration,
+        from_report_metadata.expiration
+    );
+    assert_eq!(
+        from_request_header.min_batch_size,
+        from_report_metadata.min_batch_size
+    );
+    assert_eq!(from_request_header.query, from_report_metadata.query);
+    assert_eq!(from_request_header.vdaf, from_report_metadata.vdaf);
+    assert_eq!(
+        from_request_header.vdaf_verify_key.as_ref(),
+        from_report_metadata.vdaf_verify_key.as_ref()
+    );
+    assert_eq!(
+        from_request_header.collector_hpke_config,
+        from_report_metadata.collector_hpke_config
+    );
 }

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -366,20 +366,14 @@ where
             && metadata.is_some()
             && metadata.unwrap().is_taskprov(taskprov_version, &task_id)
         {
-            if let Some(taskprov_task_config) = taskprov::get_taskprov_task_config(
+            if let Some(task_config) = taskprov::resolve_advertised_task_config(
+                version,
                 taskprov_version,
+                &self.taskprov_vdaf_verify_key_init,
+                &self.collector_hpke_config,
                 task_id.as_ref(),
-                metadata.unwrap(),
+                metadata,
             )? {
-                let task_config = DapTaskConfig::try_from_taskprov(
-                    version,
-                    self.global_config.taskprov_version,
-                    task_id.as_ref(),
-                    taskprov_task_config,
-                    &self.taskprov_vdaf_verify_key_init,
-                    &self.collector_hpke_config,
-                )?;
-
                 let mut tasks = self.tasks.lock().expect("tasks: lock failed");
                 if tasks.get(task_id.as_ref()).is_none() {
                     // Decide whether to opt-in to the task.

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -369,7 +369,7 @@ where
                 .is_taskprov(taskprov_version, task_id)
         {
             if let Some(task_config) = taskprov::resolve_advertised_task_config(
-                req.version,
+                req,
                 taskprov_version,
                 &self.taskprov_vdaf_verify_key_init,
                 &self.collector_hpke_config,

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -86,7 +86,7 @@ struct MetricsPushConfig {
 /// Daphne-Worker configuration, including long-lived parameters used across DAP tasks.
 pub(crate) struct DaphneWorkerConfig {
     /// Indicates if DaphneWorker is used as the Leader.
-    is_leader: bool,
+    pub(crate) is_leader: bool,
 
     /// Global DAP configuration.
     pub(crate) global: DapGlobalConfig,
@@ -371,13 +371,13 @@ pub(crate) struct DaphneWorkerIsolateState {
     hpke_receiver_configs: Arc<RwLock<HashMap<HpkeReceiverKvKey, HpkeReceiverConfig>>>,
 
     /// Laeder bearer token per task.
-    leader_bearer_tokens: Arc<RwLock<HashMap<TaskId, BearerToken>>>,
+    pub(crate) leader_bearer_tokens: Arc<RwLock<HashMap<TaskId, BearerToken>>>,
 
     /// Collector bearer token per task.
     collector_bearer_tokens: Arc<RwLock<HashMap<TaskId, BearerToken>>>,
 
     /// Task list.
-    tasks: Arc<RwLock<HashMap<TaskId, DapTaskConfig>>>,
+    pub(crate) tasks: Arc<RwLock<HashMap<TaskId, DapTaskConfig>>>,
 }
 
 impl DaphneWorkerIsolateState {

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -1004,6 +1004,7 @@ impl<'srv> DaphneWorker<'srv> {
             url: req.url()?,
             media_type,
             sender_auth,
+            taskprov: req.headers().get("dap-taskprov")?,
         })
     }
 

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -396,7 +396,7 @@ where
             .ok_or_else(|| DapError::fatal("taskprov configuration not found"))?;
 
         let Some(task_config) = taskprov::resolve_advertised_task_config(
-            req.version,
+            req,
             global_config.taskprov_version,
             &taskprov.vdaf_verify_key_init,
             &taskprov.hpke_collector_config,


### PR DESCRIPTION
Closes #257.

Modifies the behavior of Daphne-Worker: If the Leader sends a serialized `TaskConfig` in the HTTP "dap-taskprov" Header, then expect it to always send this header for requests pertaining to the same task. In this case, the Helper skips  writing the task config through to KV.

**Reviewer note**: It's probably easiest to review this change commit-by-commit. The commits are:
* daphne_worker: Don't write through task config when advertised in header
* taskprov: Parse advertisement from `DapRequest.taskprov` if available
* Only build `Default` for `DapRequest` for tests
* Ensure taskprov is resolved at the top of each request handler
* Decouple task config fetching from taskprov resolution
* taskprov: Encapsulate some shared logic into one method
* daphne_worker: Read the "dap-taskprov" header into DapRequest