### PR TITLE
taskprov: Miscellaneous improvements

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -320,6 +320,10 @@ pub struct DapTaskConfig {
 
     /// The Collector's HPKE configuration for this task.
     pub collector_hpke_config: HpkeConfig,
+
+    /// If true, then the taskprov extension was used to configure this task.
+    #[serde(default)]
+    pub taskprov: bool,
 }
 
 impl DapTaskConfig {

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -107,6 +107,7 @@ impl Test {
                 query: DapQueryConfig::TimeInterval,
                 vdaf: vdaf_config.clone(),
                 vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                taskprov: false,
             },
         );
         tasks.insert(
@@ -122,6 +123,7 @@ impl Test {
                 query: DapQueryConfig::FixedSize { max_batch_size: 2 },
                 vdaf: vdaf_config.clone(),
                 vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                taskprov: false,
             },
         );
         tasks.insert(
@@ -137,6 +139,7 @@ impl Test {
                 query: DapQueryConfig::TimeInterval,
                 vdaf: vdaf_config,
                 vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                taskprov: false,
             },
         );
 

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -288,6 +288,7 @@ impl DapTaskConfig {
                 vdaf_type,
             ),
             collector_hpke_config: collector_hpke_config.clone(),
+            taskprov: true,
         })
     }
 }

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -773,6 +773,7 @@ impl Test {
                 vdaf: vdaf.clone(),
                 vdaf_verify_key,
                 collector_hpke_config,
+                taskprov: false,
             },
             prometheus_registry,
             leader_metrics,

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -895,6 +895,7 @@ impl<'srv> DaphneWorker<'srv> {
                     vdaf,
                     vdaf_verify_key,
                     collector_hpke_config,
+                    taskprov: false,
                 },
             )
             .await?

--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -115,6 +115,7 @@ impl TestRunner {
             vdaf: VDAF_CONFIG.clone(),
             vdaf_verify_key: VDAF_CONFIG.gen_verify_key(),
             collector_hpke_config: collector_hpke_receiver.config.clone(),
+            taskprov: false,
         };
 
         // This block needs to be kept in-sync with daphne_worker_test/wrangler.toml.


### PR DESCRIPTION
Based on #317 (merge that first).

Just some minor things I noticed after some recent refactoring:

*    tasprov: Dedup some shared logic

    Both `MockAggregator` and `DaphneWorker` need to parse need to do the
    following:

    1. Resolve advertisement
    2. Decide to opt-in
    3. Store the task

    Step (1.) is backend-agnostic; steps (2.) and (3.) can be handled as
    callbacks. Refactor the code so that they are.

*    daphne: Add field to `DapTaskConfig` indicating if taskprov was used

    For backwards compatibility, JSON deserialization defaults to `false`.
    This means that any tasks configured via taskprov will be treated as
    non-taskprov. However this is currently a noop, since no protocol logic
    uses this flag.