### PR TITLE
Add `.wrangler` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 wasm-pack.log
 build/
 dist
+.wrangler


### PR DESCRIPTION
This directory is created by `wrangler dev` as of version 3.0.1.