### PR TITLE
Add support for Prio3SumVec

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -483,6 +483,7 @@ impl AsRef<DapTaskConfig> for DapTaskConfig {
 pub enum DapMeasurement {
     U64(u64),
     U32Vec(Vec<u32>),
+    U128Vec(Vec<u128>),
 }
 
 /// The aggregate result computed by the Collector.
@@ -730,6 +731,10 @@ pub enum Prio3Config {
     /// The sum of 64-bit, unsigned integers. Each measurement is an integer in range `[0,
     /// 2^bits)`.
     Sum { bits: usize },
+
+    /// The element-wise sum of vectors. Each vector has `len` elements.
+    /// Each element is a 64-bit unsigned integer in range `[0,2^bits)`.
+    SumVec { bits: usize, len: usize },
 }
 
 /// DAP sender role.

--- a/daphne/src/vdaf/prio3_test.rs
+++ b/daphne/src/vdaf/prio3_test.rs
@@ -46,6 +46,23 @@ fn prepare_histogram() {
     .unwrap();
 }
 
+#[test]
+fn prepare_sum_vec() {
+    test_prepare(
+        &Prio3Config::SumVec { bits: 23, len: 1 },
+        DapMeasurement::U128Vec(vec![(1 << 23) - 1]),
+        DapAggregateResult::U128Vec(vec![(1 << 23) - 1]),
+    )
+    .unwrap();
+
+    test_prepare(
+        &Prio3Config::SumVec { bits: 23, len: 3 },
+        DapMeasurement::U128Vec(vec![1, 0, 42]),
+        DapAggregateResult::U128Vec(vec![1, 0, 42]),
+    )
+    .unwrap();
+}
+
 fn test_prepare(
     config: &Prio3Config,
     measurement: DapMeasurement,

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -698,6 +698,8 @@ pub(crate) struct InternalTestVdaf {
     typ: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     bits: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    length: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This PR should solve https://github.com/cloudflare/daphne/issues/267 by adding support for Prio3SumVec. I added a test vector to check that the shares are prepared properly.

@cjpatton I left a couple of comments with `TODO(tholop)` with my questions, I'm still exploring the codebase so I might be misunderstanding some things