### PR TITLE
Adds new AuditLog trait to daphne

### DIFF
--- a/daphne/src/audit_log.rs
+++ b/daphne/src/audit_log.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{messages::TaskId, DapTaskConfig};
+
+pub enum AggregationJobAuditAction {
+    Init,
+    Continue,
+}
+
+pub trait AuditLog {
+    fn on_aggregation_job(
+        &self,
+        host: &str,
+        task_id: &TaskId,
+        task_config: &DapTaskConfig,
+        report_count: u64,
+        action: AggregationJobAuditAction,
+    );
+}
+
+/// Default implementation of the trait, which is a no-op.
+pub struct NoopAuditLog;
+
+impl AuditLog for NoopAuditLog {
+    fn on_aggregation_job(
+        &self,
+        _host: &str,
+        _task_id: &TaskId,
+        _task_config: &DapTaskConfig,
+        _report_count: u64,
+        _action: AggregationJobAuditAction,
+    ) {
+    }
+}

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -62,7 +62,7 @@ use std::{
     borrow::Cow,
     cmp::{max, min},
     collections::{HashMap, HashSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
 };
 use url::Url;
 
@@ -702,7 +702,7 @@ pub enum DapHelperTransition<M: Debug> {
     Finish(Vec<DapOutputShare>, M),
 }
 
-/// Specificaiton of a concrete VDAF.
+/// Specification of a concrete VDAF.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VdafConfig {
@@ -715,6 +715,15 @@ impl std::str::FromStr for VdafConfig {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         serde_json::from_str(s)
+    }
+}
+
+impl Display for VdafConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VdafConfig::Prio3(prio3_config) => write!(f, "Prio3({prio3_config})"),
+            VdafConfig::Prio2 { dimension } => write!(f, "Prio2({dimension})"),
+        }
     }
 }
 
@@ -737,6 +746,19 @@ pub enum Prio3Config {
     /// The element-wise sum of vectors. Each vector has `len` elements.
     /// Each element is a 64-bit unsigned integer in range `[0,2^bits)`.
     SumVec { bits: usize, len: usize },
+}
+
+impl Display for Prio3Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Prio3Config::Count => write!(f, "Count"),
+            Prio3Config::Histogram { buckets } => {
+                write!(f, "Histogram({})", buckets.len())
+            }
+            Prio3Config::Sum { bits } => write!(f, "Sum({bits})"),
+            Prio3Config::SumVec { bits, len } => write!(f, "SumVec({bits},{len})"),
+        }
+    }
 }
 
 /// DAP sender role.
@@ -951,6 +973,7 @@ impl MetaAggregationJobId<'_> {
 }
 
 pub mod aborts;
+pub mod audit_log;
 pub mod auth;
 pub mod constants;
 #[cfg(test)]

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use daphne::{
     aborts::DapAbort,
+    audit_log::AuditLog,
     auth::BearerToken,
     constants::DapMediaType,
     hpke::HpkeReceiverConfig,
@@ -415,6 +416,9 @@ pub(crate) struct DaphneWorkerRequestState<'srv> {
 
     /// Error reporting for Daphne internal errors.
     pub(crate) error_reporter: &'srv dyn ErrorReporter,
+
+    /// Audit logging
+    pub(crate) audit_log: &'srv dyn AuditLog,
 }
 
 impl<'srv> DaphneWorkerRequestState<'srv> {
@@ -422,6 +426,7 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
         isolate_state: &'srv DaphneWorkerIsolateState,
         req: &Request,
         error_reporter: &'srv dyn ErrorReporter,
+        audit_log: &'srv dyn AuditLog,
     ) -> Result<Self> {
         let prometheus_registry = Registry::new();
         let metrics = DaphneWorkerMetrics::register(&prometheus_registry, None)
@@ -438,6 +443,7 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
             metrics,
             host,
             error_reporter,
+            audit_log,
         })
     }
 

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use daphne::{
+    audit_log::AuditLog,
     auth::{BearerToken, BearerTokenProvider},
     constants::DapMediaType,
     hpke::HpkeDecrypter,
@@ -696,6 +697,10 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
 
     fn metrics(&self) -> &DaphneMetrics {
         &self.state.metrics.daphne
+    }
+
+    fn audit_log(&self) -> &dyn AuditLog {
+        self.state.audit_log
     }
 }
 


### PR DESCRIPTION
Enables implementations backed by services like: https://developers.cloudflare.com/analytics/analytics-engine/

* For now, there is just a basic handler for successful aggregation job requests.
* Adds a `Display` to `VdafConfig` for a reasonably succinct string repr, useful for event logging.
* Adds some assertions on the handler being invoked