### PR TITLE
Simplify trait lifetimes with GATs

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -418,11 +418,11 @@ impl DapTaskConfig {
     }
 
     /// Return the batch span of a set of reports with the given metadata.
-    pub fn batch_span_for_meta<'a>(
+    pub fn batch_span_for_meta<'sel, 'rep>(
         &self,
-        part_batch_sel: &'a PartialBatchSelector,
-        report_meta: impl Iterator<Item = &'a ReportMetadata>,
-    ) -> Result<HashMap<DapBatchBucket<'a>, Vec<&'a ReportMetadata>>, DapError> {
+        part_batch_sel: &'sel PartialBatchSelector,
+        report_meta: impl Iterator<Item = &'rep ReportMetadata>,
+    ) -> Result<HashMap<DapBatchBucket<'sel>, Vec<&'rep ReportMetadata>>, DapError> {
         if !self.query.is_valid_part_batch_sel(part_batch_sel) {
             return Err(DapError::fatal(
                 "partial batch selector not compatible with task",

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -340,7 +340,7 @@ impl VdafConfig {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn consume_report_share(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         is_leader: bool,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
@@ -420,7 +420,7 @@ impl VdafConfig {
     #[allow(clippy::too_many_arguments)]
     pub async fn produce_agg_job_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_id: &MetaAggregationJobId<'_>,
@@ -519,7 +519,7 @@ impl VdafConfig {
     /// * `version` is the DapVersion to use.
     pub(crate) async fn handle_agg_job_init_req(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_init_req: &AggregationJobInitReq,
@@ -885,7 +885,7 @@ impl VdafConfig {
     // TODO spec: Allow the collector to have multiple HPKE public keys (the way Aggregators do).
     pub async fn consume_encrypted_agg_shares(
         &self,
-        decrypter: &impl HpkeDecrypter<'_>,
+        decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,
         batch_sel: &BatchSelector,
         report_count: u64,

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -652,7 +652,7 @@ impl<'srv> DaphneWorker<'srv> {
     pub(crate) async fn get_leader_bearer_token<'a>(
         &'a self,
         task_id: &'a TaskId,
-    ) -> Result<Option<BearerTokenKvPair>> {
+    ) -> Result<Option<BearerTokenKvPair<'a>>> {
         self.kv_get_cached(
             &self.isolate_state().leader_bearer_tokens,
             KV_KEY_PREFIX_BEARER_TOKEN_LEADER,
@@ -686,12 +686,9 @@ impl<'srv> DaphneWorker<'srv> {
 
     /// Retrieve from KV the configuration for the given task.
     pub(crate) async fn get_task_config<'req>(
-        &'srv self,
+        &self,
         task_id: Cow<'req, TaskId>,
-    ) -> Result<Option<DapTaskConfigKvPair<'req>>>
-    where
-        'srv: 'req,
-    {
+    ) -> Result<Option<DapTaskConfigKvPair<'req>>> {
         self.kv_get_cached(
             &self.isolate_state().tasks,
             KV_KEY_PREFIX_TASK_CONFIG,


### PR DESCRIPTION
The main traits of the protocol were overly complex in terms of lifetimes. Rust
recently added GATs which are perfect for expressing what we need here.
