### PR TITLE
Reduce version specification duplication by using workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,27 @@ members = [
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+[workspace.dependencies]
+assert_matches = "1.5.0"
+async-trait = "0.1.68"
+base64 = "0.21.2"
+futures = "0.3.28"
+getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
+hex = { version = "0.4.3", features = ["serde"] }
+hpke-rs = "0.1.0"
+lazy_static = "1.4.0"
+matchit = "0.7.0"
+paste = "1.0.12"
+prio = "0.12.2"
+prometheus = "0.13.3"
+rand = "0.8.5"
+reqwest = "0.11.18"
+ring = "0.16.20"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+thiserror = "1.0.40"
+tokio = { version = "1.28.2", features = ["macros", "rt"] }
+tracing = "0.1.37"
+url = { version = "2.3.1", features = ["serde"] }
+worker = "0.0.16"

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -18,26 +18,26 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-assert_matches = "1.5.0"
-async-trait = "0.1.68"
-base64 = "0.21.2"
-getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
-hex = { version = "0.4.3", features = ["serde"] }
-hpke-rs = { version = "0.1.0" , features = ["hazmat", "serialization"] }
+assert_matches.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+getrandom.workspace = true
+hex.workspace = true
+hpke-rs = { workspace = true , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
-lazy_static = "1.4.0"
-matchit = "0.7.0"
-paste = "1.0.12"
-prio = { version = "0.12.2", features = ["prio2"] }
-prometheus = "0.13.3"
-rand = "0.8.5"
-ring = "0.16.20"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-thiserror = "1.0.40"
-tracing = "0.1.37"
-url = { version = "2.3.1", features = ["serde"] }
+lazy_static.workspace = true
+matchit.workspace = true
+paste.workspace = true
+prio = { workspace = true, features = ["prio2"] }
+prometheus.workspace = true
+rand.workspace = true
+ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1.28.2", features = ["rt", "macros"] }
+tokio.workspace = true

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -11,15 +11,15 @@ edition = "2021"
 license = "BSD-3-Clause"
 
 [dependencies]
-daphne = { path = ".." }
-assert_matches = "1.5.0"
-base64 = "0.21.2"
-prio = "0.12.2"
-rand = "0.8.5"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-url = { version = "2.3.1", features = ["serde"] }
-clap = { version = "4.3.0", features = ["derive"] }
-reqwest = { version = "0.11.18", features = ["blocking"] }
 anyhow = "1.0.71"
-tokio = { version = "1.28.2", features = ["macros", "rt"] }
+assert_matches.workspace = true
+base64.workspace = true
+clap = { version = "4.3.0", features = ["derive"] }
+daphne = { path = ".." }
+prio.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+url.workspace = true

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -18,30 +18,30 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.68"
-base64 = "0.21.2"
+async-trait.workspace = true
+base64.workspace = true
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
-futures = "0.3.28"
-getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
-hex = { version = "0.4.3", features = ["serde"] }
-matchit = "0.7.0"
-paste = "1.0.12"
-prio = "0.12.2"
-prometheus = "0.13.3"
-rand = "0.8.5"
-reqwest-wasm = { version = "0.11.16", features = ["json"] }
-ring = "0.16.20"
-serde = { version = "1.0.163", features = ["derive"] }
-thiserror = "1.0.40"
-tracing = "0.1.37"
-tracing-core = "0.1.31"
-tracing-subscriber = {version = "0.3.17", features = ["env-filter", "json"]}
-url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.96"
-serde-wasm-bindgen = "0.5.0"
-worker = "0.0.16"
+futures.workspace = true
+getrandom.workspace = true
+hex.workspace = true
+matchit.workspace = true
 once_cell = "1.17.2"
+paste.workspace = true
+prio.workspace = true
+prometheus.workspace = true
+rand.workspace = true
+reqwest-wasm = { version = "0.11.16", features = ["json"] }
+ring.workspace = true
+serde.workspace = true
+serde-wasm-bindgen = "0.5.0"
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-core = "0.1.31"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"]}
+url.workspace = true
+worker.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,23 +25,23 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
-tracing = "0.1.37"
-worker = "0.0.16"
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+worker.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-base64 = "0.21.2"
+assert_matches.workspace = true
+base64.workspace = true
 daphne = { path = "../daphne" }
-futures = "0.3.28"
-hex = { version = "0.4.3", features = ["serde"] }
-hpke-rs = "0.1.0"
-lazy_static = "1.4.0"
-paste = "1.0.12"
-prio = "0.12.2"
-rand = "0.8.5"
-reqwest = { version = "0.11.18", features = ["json"] }
-ring = "0.16.20"
-tokio = { version = "1.28.2", features = ["full"] }
-url = { version = "2.3.1", features = ["serde"] }
+futures.workspace = true
+hex.workspace = true
+hpke-rs.workspace = true
+lazy_static.workspace = true
+paste.workspace = true
+prio.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+ring.workspace = true
+tokio = { workspace = true, features = ["full"] }
+url.workspace = true


### PR DESCRIPTION
Having the same version written two or three times is a binary size hazard and
just a tech debt pitfall in general. Using workspace inheritance we can specify
versions only once and reuse them.
