### PR TITLE
Removed unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,14 +492,11 @@ name = "dapf"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "assert_matches",
- "base64 0.21.2",
  "clap",
  "daphne",
  "prio",
  "rand",
  "reqwest",
- "serde",
  "serde_json",
  "tokio",
  "url",
@@ -512,12 +509,10 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.21.2",
- "getrandom",
  "hex",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
- "lazy_static",
  "matchit 0.7.0",
  "paste",
  "prio",
@@ -537,15 +532,12 @@ name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
- "base64 0.21.2",
  "cfg-if",
  "console_error_panic_hook",
  "daphne",
  "daphne_worker",
- "futures",
  "hex",
  "hpke-rs",
- "lazy_static",
  "paste",
  "prio",
  "rand",
@@ -563,13 +555,10 @@ dependencies = [
 name = "daphne_worker"
 version = "0.3.0"
 dependencies = [
- "assert_matches",
  "async-trait",
- "base64 0.21.2",
  "chrono",
  "daphne",
  "futures",
- "getrandom",
  "hex",
  "matchit 0.7.0",
  "once_cell",
@@ -578,15 +567,12 @@ dependencies = [
  "prometheus",
  "rand",
  "reqwest-wasm",
- "ring",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "thiserror",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "url",
  "worker",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,10 @@ opt-level = "s"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 async-trait = "0.1.68"
-base64 = "0.21.2"
 futures = "0.3.28"
 getrandom = { version = "0.2.9", features = ["js"] } # Required for prio
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.1.0"
-lazy_static = "1.4.0"
 matchit = "0.7.0"
 paste = "1.0.12"
 prio = "0.12.2"

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -20,15 +20,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 assert_matches.workspace = true
 async-trait.workspace = true
-base64.workspace = true
-getrandom.workspace = true
+base64 = "0.21.2"
 hex.workspace = true
 hpke-rs = { workspace = true , features = ["hazmat", "serialization"] }
 hpke-rs-crypto = { version = "0.1.1" }
 hpke-rs-rust-crypto = { version = "0.1.1"}
-lazy_static.workspace = true
-matchit.workspace = true
-paste.workspace = true
 prio = { workspace = true, features = ["prio2"] }
 prometheus.workspace = true
 rand.workspace = true
@@ -40,4 +36,6 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+matchit.workspace = true
+paste.workspace = true
 tokio.workspace = true

--- a/daphne/dapf/Cargo.toml
+++ b/daphne/dapf/Cargo.toml
@@ -12,14 +12,11 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.71"
-assert_matches.workspace = true
-base64.workspace = true
 clap = { version = "4.3.0", features = ["derive"] }
 daphne = { path = ".." }
 prio.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
-serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 url.workspace = true

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![warn(unused_crate_dependencies)]
+
 //! This crate implements the core protocol logic for the Distributed Aggregation Protocol
 //! ([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard under development in the
 //! PPM working group of the IETF. See [`VdafConfig`] for a listing of supported

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -19,29 +19,23 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne" }
 futures.workspace = true
-getrandom.workspace = true
 hex.workspace = true
 matchit.workspace = true
 once_cell = "1.17.2"
-paste.workspace = true
 prio.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest-wasm = { version = "0.11.16", features = ["json"] }
-ring.workspace = true
-serde.workspace = true
 serde-wasm-bindgen = "0.5.0"
+serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"]}
-url.workspace = true
+tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
-assert_matches.workspace = true
+paste.workspace = true

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![warn(unused_crate_dependencies)]
+
 //! Daphne-Worker implements a [Workers](https://developers.cloudflare.com/workers/) backend for
 //! Daphne.
 //!

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -25,23 +25,20 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker" }
-serde.workspace = true
-serde_json.workspace = true
 tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-base64.workspace = true
 daphne = { path = "../daphne" }
-futures.workspace = true
 hex.workspace = true
 hpke-rs.workspace = true
-lazy_static.workspace = true
 paste.workspace = true
 prio.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 url.workspace = true


### PR DESCRIPTION
Remove unused dependencies and setup a lint to catch when this happens.

This lint is not perfect, in slightly more complex build configurations it
signals a lot of false positives (which is the case for the `daphne_worker_test`
crate).

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies

> This lint is "allow" by default because it can provide false positives
> depending on how the build system is configured. For example, when using
> Cargo, a "package" consists of multiple crates (such as a library and a
> binary), but the dependencies are defined for the package as a whole. If there
> is a dependency that is only used in the binary, but not the library, then the
> lint will be incorrectly issued in the library.
