### PR TITLE
daphne: Improve naming of protocol-level methods

### DIFF
--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -870,7 +870,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                     .peer
                     .as_ref()
                     .expect("peer not configured")
-                    .http_post_aggregate(&req)
+                    .handle_agg_job_req(&req)
                     .await
                     .expect("peer aborted unexpectedly"))
             }
@@ -878,7 +878,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                 .peer
                 .as_ref()
                 .expect("peer not configured")
-                .http_post_aggregate_share(&req)
+                .handle_agg_share_req(&req)
                 .await
                 .expect("peer aborted unexpectedly")),
             _ => unreachable!("unhandled media type: {:?}", req.media_type),
@@ -891,7 +891,7 @@ impl DapLeader<BearerToken> for MockAggregator {
                 .peer
                 .as_ref()
                 .expect("peer not configured")
-                .http_post_aggregate(&req)
+                .handle_agg_job_req(&req)
                 .await
                 .expect("peer aborted unexpectedly"))
         } else {

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -278,7 +278,7 @@ impl DaphneWorkerRouter<'_> {
 
                 let span = info_span_from_dap_request!("hpke_config", req);
 
-                match daph.http_get_hpke_config(&req).instrument(span).await {
+                match daph.handle_hpke_config_req(&req).instrument(span).await {
                     Ok(req) => dap_response_to_worker(req),
                     Err(e) => daph.state.dap_abort_to_worker_response(e),
                 }
@@ -316,7 +316,7 @@ impl DaphneWorkerRouter<'_> {
 
                         let span = info_span_from_dap_request!("collect", req);
 
-                        match daph.http_post_collect(&req).instrument(span).await {
+                        match daph.handle_collect_job_req(&req).instrument(span).await {
                             Ok(collect_uri) => {
                                 let mut headers = Headers::new();
                                 headers.set("Location", collect_uri.as_str())?;
@@ -390,7 +390,7 @@ impl DaphneWorkerRouter<'_> {
 
                             let span = info_span_from_dap_request!("collect (PUT)", req);
 
-                            match daph.http_post_collect(&req).instrument(span).await {
+                            match daph.handle_collect_job_req(&req).instrument(span).await {
                                 Ok(_) => Ok(Response::empty().unwrap().with_status(201)),
                                 Err(e) => daph.state.dap_abort_to_worker_response(e),
                             }
@@ -632,7 +632,7 @@ async fn put_report_into_task(
 
     let span = info_span_from_dap_request!("upload", req);
 
-    match daph.http_post_upload(&req).instrument(span).await {
+    match daph.handle_upload_req(&req).instrument(span).await {
         Ok(()) => Response::empty(),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }
@@ -647,7 +647,7 @@ async fn handle_agg_job(
 
     let span = info_span_from_dap_request!("aggregate", req);
 
-    match daph.http_post_aggregate(&req).instrument(span).await {
+    match daph.handle_agg_job_req(&req).instrument(span).await {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }
@@ -662,7 +662,7 @@ async fn handle_agg_share_req(
 
     let span = info_span_from_dap_request!("aggregate_share", req);
 
-    match daph.http_post_aggregate_share(&req).instrument(span).await {
+    match daph.handle_agg_share_req(&req).instrument(span).await {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }


### PR DESCRIPTION
Closes #255.

The name `http_post_aggregate()` is misleading because it is not necessarily used to handle an HTTP POST. In fact, in DAP-04, the initial request is a PUT. Also, the name of the endpoints themselves have changed in s way that is inconsistent across the two supported versions (DAP-02 and -04). Similarly for other high-level API calls in `roles.rs`.

This change updates the API and documentation to reflect the semantics of the methods rather than the details of the HTTP request.