### PR TITLE
Add problem details to UnrecognizedMessage abort

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -850,7 +850,10 @@ impl<S> DapRequest<S> {
             // draft02: Handle missing task ID as decoding failure. Normally the task ID would be
             // encoded by the message payload; it may be missing becvause parsing failed earlier on
             // in the request.
-            Err(DapAbort::UnrecognizedMessage)
+            Err(DapAbort::UnrecognizedMessage {
+                detail: "missing or malformed task ID".into(),
+                task_id: None,
+            })
         } else {
             // Handle missing task ID as a bad request. The task ID is normally conveyed by the
             // request path; if missing at this point, it is because it was missing or couldn't be

--- a/daphne/src/roles_test.rs
+++ b/daphne/src/roles_test.rs
@@ -690,7 +690,7 @@ async fn handle_agg_job_req_zero_round(version: DapVersion) {
         .await;
     assert_matches!(
         t.helper.handle_agg_job_req(&req).await,
-        Err(DapAbort::UnrecognizedMessage)
+        Err(DapAbort::UnrecognizedMessage { .. })
     );
 
     // AggregationJobContinueReq fails
@@ -1164,7 +1164,7 @@ async fn handle_upload_req_fail_send_invalid_report(version: DapVersion) {
     // Expect failure due to incorrect number of input shares
     assert_matches!(
         t.leader.handle_upload_req(&req).await,
-        Err(DapAbort::UnrecognizedMessage)
+        Err(DapAbort::UnrecognizedMessage { .. })
     );
 }
 

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -386,7 +386,7 @@ async fn agg_job_resp_abort_transition_out_of_order(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -408,7 +408,7 @@ async fn agg_job_resp_abort_report_id_repeated(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -433,7 +433,7 @@ async fn agg_job_resp_abort_unrecognized_report_id(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -454,7 +454,7 @@ async fn agg_job_resp_abort_invalid_transition(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_resp_expect_err(leader_state, agg_job_resp),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -590,7 +590,7 @@ async fn agg_cont_abort_unrecognized_report_id(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -616,7 +616,7 @@ async fn agg_job_cont_req_abort_transition_out_of_order(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 
@@ -641,7 +641,7 @@ async fn agg_job_cont_req_abort_report_id_repeated(version: DapVersion) {
 
     assert_matches!(
         t.handle_agg_job_cont_req_expect_err(helper_state, &agg_job_cont_req),
-        DapAbort::UnrecognizedMessage
+        DapAbort::UnrecognizedMessage { .. }
     );
 }
 


### PR DESCRIPTION
As described in https://github.com/cloudflare/daphne/issues/326, the `UnrecognizedMessage` abort type was too generic. This PR adds a `detail` field that contains more information, depending on where the error was raised. I looked for conditions raising the `UnrecognizedMessage` abort, and translated them into hopefully helpful strings. I also added a `task_id` field that optionally contains the task ID, when available.