### PR TITLE
daphne_worker: Enusre HPKE config preference is respected

### DIFF
--- a/daphne_worker_test/tests/test_runner.rs
+++ b/daphne_worker_test/tests/test_runner.rs
@@ -237,7 +237,7 @@ impl TestRunner {
         );
 
         let gen_config = || {
-            HpkeReceiverConfig::gen(random(), HpkeKemId::X25519HkdfSha256)
+            HpkeReceiverConfig::gen(0, HpkeKemId::X25519HkdfSha256)
                 .expect("failed to generate receiver config")
         };
         let res: InternalTestCommandResult = t


### PR DESCRIPTION
The current schema for the set of HPKE receiver configs stored in KV is `HashMap<u8, HpkeReceiverConfig>`, e.g.:
```
{
    42 : {
        "config": {
            ...
        }
        "secret_key": ...
    },
    13: {
        "config" : {
            ...
        }
        "secret_key": ...
    }
}
```
When a Client asks for the HPKE config we currently return the "first" element in this set. But since the set is unordered, there is no way for the Aggregator to enforce a preference. For instance, it may prefer P256 for the KEM.

In addition, once key rotation is implemented, the set will contain stale configs that we are willing to use but don't want to advertise.

In order to ensure the value stored in KV reflects the servers preference, replace the `HpkeReceiverConfigSet` type with `HpkeReceiverConfigList`.