### PR TITLE
Reduce metrics error cardinality

### DIFF
--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -522,7 +522,7 @@ impl<'srv> DaphneWorkerRequestState<'srv> {
         };
         self.metrics
             .dap_abort_counter
-            .with_label_values(&[&self.host, &e.to_string()])
+            .with_label_values(&[&self.host])
             .inc();
         let problem_details = e.into_problem_details();
         error!(

--- a/daphne_worker/src/metrics.rs
+++ b/daphne_worker/src/metrics.rs
@@ -37,7 +37,7 @@ impl DaphneWorkerMetrics {
         let dap_abort_counter = register_int_counter_vec_with_registry!(
             format!("{front}dap_abort"),
             "DAP aborts.",
-            &["host", "type"],
+            &["host"],
             registry
         )
         .map_err(|e| fatal_error!(err = e, "failed to register dap_abort"))?;


### PR DESCRIPTION
Using display implementations for program behavior sensitive code is a bad
idea. Different parts of the code need different string representations.
