### PR TITLE
Prepare for offloading VDAF preparation

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -70,6 +70,7 @@ use std::{
     fmt::{Debug, Display},
 };
 use url::Url;
+use vdaf::VdafPrepInput;
 
 /// DAP version used for a task.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -425,9 +426,7 @@ impl DapTaskConfig {
     pub fn prep_init(
         &self,
         is_leader: bool,
-        report_id: &ReportId,
-        public_share: &[u8],
-        input_share: &[u8],
+        prep_input: &VdafPrepInput,
     ) -> Result<(VdafPrepState, VdafPrepMessage), DapError> {
         let agg_id = usize::from(!is_leader);
         match (&self.vdaf, &self.vdaf_verify_key) {
@@ -436,9 +435,9 @@ impl DapTaskConfig {
                     prio3_config,
                     verify_key,
                     agg_id,
-                    &report_id.0,
-                    public_share,
-                    input_share,
+                    &prep_input.metadata.id.0,
+                    &prep_input.public_share,
+                    &prep_input.input_share,
                 )?)
             }
             (VdafConfig::Prio2 { dimension }, VdafVerifyKey::Prio2(ref verify_key)) => {
@@ -446,9 +445,9 @@ impl DapTaskConfig {
                     *dimension,
                     verify_key,
                     agg_id,
-                    &report_id.0,
-                    public_share,
-                    input_share,
+                    &prep_input.metadata.id.0,
+                    &prep_input.public_share,
+                    &prep_input.input_share,
                 )?)
             }
             _ => Err(fatal_error!(err = "VDAF verify key does not match config")),

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -46,10 +46,7 @@ use crate::{
         ReportMetadata, TaskId, Time,
     },
     taskprov::TaskprovVersion,
-    vdaf::{
-        prio2::prio2_prepare_init, prio3::prio3_prepare_init, VdafAggregateShare, VdafPrepMessage,
-        VdafPrepState, VdafVerifyKey,
-    },
+    vdaf::{VdafAggregateShare, VdafPrepMessage, VdafPrepState, VdafVerifyKey},
 };
 use constants::DapMediaType;
 #[cfg(test)]
@@ -69,7 +66,6 @@ use std::{
     fmt::{Debug, Display},
 };
 use url::Url;
-use vdaf::VdafPrepInput;
 
 /// DAP version used for a task.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -419,38 +415,6 @@ impl DapTaskConfig {
         };
 
         Ok(report_count >= self.min_batch_size)
-    }
-
-    /// Initialize VDAF preparation of a report share.
-    pub fn prep_init(
-        &self,
-        is_leader: bool,
-        prep_input: &VdafPrepInput,
-    ) -> Result<(VdafPrepState, VdafPrepMessage), DapError> {
-        let agg_id = usize::from(!is_leader);
-        match (&self.vdaf, &self.vdaf_verify_key) {
-            (VdafConfig::Prio3(ref prio3_config), VdafVerifyKey::Prio3(ref verify_key)) => {
-                Ok(prio3_prepare_init(
-                    prio3_config,
-                    verify_key,
-                    agg_id,
-                    &prep_input.metadata.id.0,
-                    &prep_input.public_share,
-                    &prep_input.input_share,
-                )?)
-            }
-            (VdafConfig::Prio2 { dimension }, VdafVerifyKey::Prio2(ref verify_key)) => {
-                Ok(prio2_prepare_init(
-                    *dimension,
-                    verify_key,
-                    agg_id,
-                    &prep_input.metadata.id.0,
-                    &prep_input.public_share,
-                    &prep_input.input_share,
-                )?)
-            }
-            _ => Err(fatal_error!(err = "VDAF verify key does not match config")),
-        }
     }
 }
 

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use assert_matches::assert_matches;
 use async_trait::async_trait;
+use prio::codec::Encode;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1396,13 +1397,8 @@ impl AggregationJobTest {
             .await else {
                 panic!("unexpected transition");
         };
-        let got = DapHelperState::get_decoded(
-            &self.task_config.vdaf,
-            &helper_state
-                .get_encoded(&self.task_config.vdaf)
-                .expect("failed to encode helper state"),
-        )
-        .expect("failed to decode helper state");
+        let got = DapHelperState::get_decoded(&self.task_config.vdaf, &helper_state.get_encoded())
+            .expect("failed to decode helper state");
         assert_eq!(got, helper_state);
 
         let DapLeaderTransition::Uncommitted(uncommitted, agg_cont) = self

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -14,7 +14,7 @@ use crate::{
     testing::AggregationJobTest,
     DapAggregateResult, DapAggregateShare, DapError, DapHelperState, DapHelperTransition,
     DapLeaderState, DapLeaderTransition, DapLeaderUncommitted, DapMeasurement, DapOutputShare,
-    DapVersion, Prio3Config, VdafAggregateShare, VdafConfig, VdafMessage, VdafState,
+    DapVersion, Prio3Config, VdafAggregateShare, VdafConfig, VdafPrepMessage, VdafPrepState,
 };
 use assert_matches::assert_matches;
 use hpke_rs::HpkePublicKey;
@@ -114,10 +114,10 @@ async fn roundtrip_report(version: DapVersion) {
 
     match (leader_step, helper_step, leader_share, helper_share) {
         (
-            VdafState::Prio3Field64(leader_step),
-            VdafState::Prio3Field64(helper_step),
-            VdafMessage::Prio3ShareField64(leader_share),
-            VdafMessage::Prio3ShareField64(helper_share),
+            VdafPrepState::Prio3Field64(leader_step),
+            VdafPrepState::Prio3Field64(helper_step),
+            VdafPrepMessage::Prio3ShareField64(leader_share),
+            VdafPrepMessage::Prio3ShareField64(helper_share),
         ) => {
             let vdaf = Prio3::new_count(2).unwrap();
             let message = vdaf

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -20,6 +20,7 @@ use assert_matches::assert_matches;
 use hpke_rs::HpkePublicKey;
 use paste::paste;
 use prio::{
+    codec::Encode,
     field::Field64,
     vdaf::{
         prio3::Prio3, Aggregatable, AggregateShare, Aggregator as VdafAggregator,
@@ -718,8 +719,7 @@ async fn helper_state_serialization(version: DapVersion) {
         .await
         .unwrap_continue();
 
-    let got =
-        DapHelperState::get_decoded(TEST_VDAF, &want.get_encoded(TEST_VDAF).unwrap()).unwrap();
+    let got = DapHelperState::get_decoded(TEST_VDAF, &want.get_encoded()).unwrap();
     assert_eq!(got, want);
 
     assert!(DapHelperState::get_decoded(TEST_VDAF, b"invalid helper state").is_err())

--- a/daphne/src/vdaf/prio2.rs
+++ b/daphne/src/vdaf/prio2.rs
@@ -119,14 +119,6 @@ pub(crate) fn prio2_decode_prepare_state(
     )?))
 }
 
-/// Encode `message` as a byte string.
-pub(crate) fn prio2_encode_prepare_message(message: &VdafPrepMessage) -> Vec<u8> {
-    match message {
-        VdafPrepMessage::Prio2Share(message) => message.get_encoded(),
-        _ => panic!("prio2_encode_prepare_message: unexpected message type"),
-    }
-}
-
 /// Interpret `encoded_agg_shares` as a sequence of encoded aggregate shares and unshard them.
 pub(crate) fn prio2_unshard<M: IntoIterator<Item = Vec<u8>>>(
     dimension: usize,

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -302,26 +302,6 @@ pub(crate) fn prio3_helper_prepare_finish(
     Ok(agg_share)
 }
 
-/// Interpret `step` as a prepare message for prio3 and append it to `bytes`. Returns an error if
-/// the `step` is not compatible with `param`.
-pub(crate) fn prio3_append_prepare_state(
-    bytes: &mut Vec<u8>,
-    config: &Prio3Config,
-    state: &VdafPrepState,
-) -> Result<(), VdafError> {
-    match (&config, state) {
-        (Prio3Config::Count, VdafPrepState::Prio3Field64(state)) => {
-            state.encode(bytes);
-        }
-        (Prio3Config::Histogram { buckets: _ }, VdafPrepState::Prio3Field128(state))
-        | (Prio3Config::Sum { bits: _ }, VdafPrepState::Prio3Field128(state)) => {
-            state.encode(bytes);
-        }
-        _ => panic!("prio3_append_prepare_state: {ERR_FIELD_TYPE}"),
-    }
-    Ok(())
-}
-
 /// Parse a prio3 prepare message from the front of `reader` whose type is compatible with `param`.
 pub(crate) fn prio3_decode_prepare_state(
     config: &Prio3Config,
@@ -353,15 +333,6 @@ pub(crate) fn prio3_decode_prepare_state(
                 Prio3PrepareState::decode_with_param(&(&vdaf, agg_id), bytes)?,
             ))
         }
-    }
-}
-
-/// Encode `message` as a byte string.
-pub(crate) fn prio3_encode_prepare_message(message: &VdafPrepMessage) -> Vec<u8> {
-    match message {
-        VdafPrepMessage::Prio3ShareField64(message) => message.get_encoded(),
-        VdafPrepMessage::Prio3ShareField128(message) => message.get_encoded(),
-        _ => panic!("prio3_encode_prepare_message: unexpected message type"),
     }
 }
 

--- a/daphne/src/vdaf/prio3_test.rs
+++ b/daphne/src/vdaf/prio3_test.rs
@@ -4,8 +4,8 @@
 use crate::{
     vdaf::{
         prio3::{
-            prio3_encode_prepare_message, prio3_helper_prepare_finish, prio3_leader_prepare_finish,
-            prio3_prepare_init, prio3_shard, prio3_unshard,
+            prio3_helper_prepare_finish, prio3_leader_prepare_finish, prio3_prepare_init,
+            prio3_shard, prio3_unshard,
         },
         VdafError,
     },
@@ -96,10 +96,12 @@ fn test_prepare(
         &encoded_input_shares[1],
     )?;
 
-    let helper_share_data = prio3_encode_prepare_message(&helper_share);
-
-    let (leader_out_share, leader_message_data) =
-        prio3_leader_prepare_finish(config, leader_state, leader_share, &helper_share_data)?;
+    let (leader_out_share, leader_message_data) = prio3_leader_prepare_finish(
+        config,
+        leader_state,
+        leader_share,
+        &helper_share.get_encoded(),
+    )?;
 
     let helper_out_share = prio3_helper_prepare_finish(config, helper_state, &leader_message_data)?;
 

--- a/daphne_worker/src/dap.rs
+++ b/daphne_worker/src/dap.rs
@@ -954,7 +954,7 @@ impl<'srv> DapHelper<DaphneWorkerAuth> for DaphneWorker<'srv> {
         helper_state: &DapHelperState,
     ) -> std::result::Result<bool, DapError> {
         let task_config = self.try_get_task_config(task_id).await?;
-        let helper_state_hex = hex::encode(helper_state.get_encoded(&task_config.as_ref().vdaf)?);
+        let helper_state_hex = hex::encode(helper_state.get_encoded());
         Ok(self
             .durable()
             .with_retry()


### PR DESCRIPTION
We want to be able to offload VDAF preparation to durable objects. This PR refactors the code to make this easier and resolves some prerequisites. Details in the commit messages, but at a high level:
* Split `consume_report_share()` into two steps and wrap the state after each step with a state object.
* Implement codec traits on VdafPrepState and VdafPrepMessage, which will be required for serializing the input and output to DO.
* Fix a bug that triggers abort if a reports plaintext input share is malformed. (We should just reject instead.)