### PR TITLE
Parallelize VDAF preparation initialization

### DIFF
--- a/daphne/benches/aggregation.rs
+++ b/daphne/benches/aggregation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use daphne::{
     hpke::HpkeKemId, testing::AggregationJobTest, DapLeaderTransition, DapMeasurement, DapVersion,
     Prio3Config, VdafConfig,
@@ -46,9 +46,7 @@ fn handle_agg_job_init_req(c: &mut Criterion) {
 
         c.bench_function(&format!("handle_agg_job_init_req {vdaf:?}"), |b| {
             b.to_async(&rt).iter(|| async {
-                agg_job_test
-                    .handle_agg_job_init_req(&agg_job_init_req)
-                    .await
+                black_box(agg_job_test.handle_agg_job_init_req(&agg_job_init_req)).await
             })
         });
     }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         TransitionVar,
     },
     metrics::ContextualizedDaphneMetrics,
+    roles::DapReportInitializer,
     vdaf::{
         prio2::{
             prio2_helper_prepare_finish, prio2_leader_prepare_finish, prio2_prepare_init,
@@ -38,7 +39,7 @@ use prio::{
     },
 };
 use rand::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::{borrow::Cow, collections::HashSet, convert::TryInto};
 
 use self::{prio2::prio2_decode_prepare_state, prio3::prio3_decode_prepare_state};
@@ -77,16 +78,28 @@ impl AsRef<[u8]> for VdafVerifyKey {
     }
 }
 
+/// Report state during aggregation initialization.
+pub trait EarlyReportState {
+    fn metadata(&self) -> &ReportMetadata;
+    fn is_ready(&self) -> bool;
+}
+
 /// Report state during aggregation initialization after consuming the report share. This involves
 /// decryption as well a few validation steps.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EarlyReportStateConsumed<'req> {
     Ready {
         metadata: Cow<'req, ReportMetadata>,
+        #[serde(with = "serialize_bytes")]
         public_share: Cow<'req, [u8]>,
+        #[serde(with = "serialize_bytes")]
         input_share: Vec<u8>,
     },
-    Rejected(TransitionFailure),
+    Rejected {
+        metadata: Cow<'req, ReportMetadata>,
+        failure: TransitionFailure,
+    },
 }
 
 impl<'req> EarlyReportStateConsumed<'req> {
@@ -96,12 +109,15 @@ impl<'req> EarlyReportStateConsumed<'req> {
         is_leader: bool,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
-        metadata: &'req ReportMetadata,
-        public_share: &'req [u8],
+        metadata: Cow<'req, ReportMetadata>,
+        public_share: Cow<'req, [u8]>,
         encrypted_input_share: &HpkeCiphertext,
     ) -> Result<EarlyReportStateConsumed<'req>, DapError> {
         if metadata.time >= task_config.expiration {
-            return Ok(Self::Rejected(TransitionFailure::TaskExpired));
+            return Ok(Self::Rejected {
+                metadata,
+                failure: TransitionFailure::TaskExpired,
+            });
         }
 
         let input_share_text = match task_config.version {
@@ -124,14 +140,14 @@ impl<'req> EarlyReportStateConsumed<'req> {
         task_id.encode(&mut aad);
         metadata.encode_with_param(&task_config.version, &mut aad);
         // TODO spec: Consider folding the public share into a field called "header".
-        encode_u32_bytes(&mut aad, public_share);
+        encode_u32_bytes(&mut aad, public_share.as_ref());
 
         let encoded_input_share = match decrypter
             .hpke_decrypt(task_id, &info, &aad, encrypted_input_share)
             .await
         {
             Ok(encoded_input_share) => encoded_input_share,
-            Err(DapError::Transition(failure)) => return Ok(Self::Rejected(failure)),
+            Err(DapError::Transition(failure)) => return Ok(Self::Rejected { metadata, failure }),
             Err(e) => return Err(e),
         };
 
@@ -145,33 +161,93 @@ impl<'req> EarlyReportStateConsumed<'req> {
             },
             DapVersion::Draft04 => match PlaintextInputShare::get_decoded(&encoded_input_share) {
                 Ok(input_share) => input_share,
-                Err(..) => return Ok(Self::Rejected(TransitionFailure::UnrecognizedMessage)),
+                Err(..) => {
+                    return Ok(Self::Rejected {
+                        metadata,
+                        failure: TransitionFailure::UnrecognizedMessage,
+                    })
+                }
             },
             _ => return Err(unimplemented_version()),
         };
 
         Ok(Self::Ready {
-            metadata: Cow::Borrowed(metadata),
-            public_share: Cow::Borrowed(public_share),
+            metadata,
+            public_share,
             input_share: input_share.payload,
         })
     }
 }
 
-/// Report state during aggregation initialization after the VDAF preparation step.
-pub enum EarlyReportStateInitialized {
-    Ready {
-        state: VdafPrepState,
-        message: VdafPrepMessage,
-    },
-    Rejected(TransitionFailure),
+impl EarlyReportState for EarlyReportStateConsumed<'_> {
+    fn metadata(&self) -> &ReportMetadata {
+        match self {
+            Self::Ready { metadata, .. } => metadata,
+            Self::Rejected { metadata, .. } => metadata,
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
+    }
 }
 
-impl EarlyReportStateInitialized {
-    pub(crate) fn initialize(
+/// Report state during aggregation initialization after the VDAF preparation step.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EarlyReportStateInitialized<'req> {
+    Ready {
+        metadata: Cow<'req, ReportMetadata>,
+        #[serde(with = "serialize_bytes")]
+        public_share: Cow<'req, [u8]>,
+        #[serde(serialize_with = "serialize_encodable")]
+        state: VdafPrepState,
+        #[serde(serialize_with = "serialize_encodable")]
+        message: VdafPrepMessage,
+    },
+    Rejected {
+        metadata: Cow<'req, ReportMetadata>,
+        failure: TransitionFailure,
+    },
+}
+
+mod serialize_bytes {
+    use serde::{de, Deserializer, Serializer};
+    pub(super) fn serialize<S, T>(x: &T, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: AsRef<[u8]>,
+    {
+        s.serialize_str(&hex::encode(x.as_ref()))
+    }
+
+    pub(super) fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: TryFrom<Vec<u8>>,
+        <T as TryFrom<Vec<u8>>>::Error: std::fmt::Display,
+    {
+        hex::deserialize::<_, Vec<u8>>(deserializer)
+            .and_then(|bytes| bytes.try_into().map_err(de::Error::custom))
+    }
+}
+
+fn serialize_encodable<S, T>(x: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Encode,
+{
+    s.serialize_str(&hex::encode(x.get_encoded()))
+}
+
+impl<'req> EarlyReportStateInitialized<'req> {
+    /// Initialize VDAF preparation for a report. This method is meant to be called by
+    /// [`DapReportInitializer`].
+    pub fn initialize(
         is_leader: bool,
-        task_config: &DapTaskConfig,
-        early_report_state_consumed: EarlyReportStateConsumed,
+        vdaf_verify_key: &VdafVerifyKey,
+        vdaf_config: &VdafConfig,
+        early_report_state_consumed: EarlyReportStateConsumed<'req>,
     ) -> Result<Self, DapError> {
         let (metadata, public_share, input_share) = match early_report_state_consumed {
             EarlyReportStateConsumed::Ready {
@@ -179,11 +255,13 @@ impl EarlyReportStateInitialized {
                 public_share,
                 input_share,
             } => (metadata, public_share, input_share),
-            EarlyReportStateConsumed::Rejected(failure) => return Ok(Self::Rejected(failure)),
+            EarlyReportStateConsumed::Rejected { metadata, failure } => {
+                return Ok(Self::Rejected { metadata, failure })
+            }
         };
 
         let agg_id = usize::from(!is_leader);
-        let res = match (&task_config.vdaf, &task_config.vdaf_verify_key) {
+        let res = match (vdaf_config, vdaf_verify_key) {
             (VdafConfig::Prio3(ref prio3_config), VdafVerifyKey::Prio3(ref verify_key)) => {
                 prio3_prepare_init(
                     prio3_config,
@@ -208,10 +286,31 @@ impl EarlyReportStateInitialized {
         };
 
         let early_report_state_initialized = match res {
-            Ok((state, message)) => Self::Ready { state, message },
-            Err(..) => Self::Rejected(TransitionFailure::VdafPrepError),
+            Ok((state, message)) => Self::Ready {
+                metadata,
+                public_share,
+                state,
+                message,
+            },
+            Err(..) => Self::Rejected {
+                metadata,
+                failure: TransitionFailure::VdafPrepError,
+            },
         };
         Ok(early_report_state_initialized)
+    }
+}
+
+impl EarlyReportState for EarlyReportStateInitialized<'_> {
+    fn metadata(&self) -> &ReportMetadata {
+        match self {
+            Self::Ready { metadata, .. } => metadata,
+            Self::Rejected { metadata, .. } => metadata,
+        }
+    }
+
+    fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
     }
 }
 
@@ -233,18 +332,21 @@ impl Encode for VdafPrepState {
     }
 }
 
-impl ParameterizedDecode<VdafConfig> for VdafPrepState {
+impl<'a> ParameterizedDecode<(&'a VdafConfig, bool /* is_leader */)> for VdafPrepState {
     fn decode_with_param(
-        vdaf_config: &VdafConfig,
+        (vdaf_config, is_leader): &(&VdafConfig, bool),
         bytes: &mut std::io::Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
+        let agg_id = usize::from(!is_leader);
         match vdaf_config {
             VdafConfig::Prio3(ref prio3_config) => {
-                Ok(prio3_decode_prepare_state(prio3_config, 1, bytes)
+                Ok(prio3_decode_prepare_state(prio3_config, agg_id, bytes)
                     .map_err(|e| CodecError::Other(Box::new(e)))?)
             }
-            VdafConfig::Prio2 { dimension } => Ok(prio2_decode_prepare_state(*dimension, 1, bytes)
-                .map_err(|e| CodecError::Other(Box::new(e)))?),
+            VdafConfig::Prio2 { dimension } => {
+                Ok(prio2_decode_prepare_state(*dimension, agg_id, bytes)
+                    .map_err(|e| CodecError::Other(Box::new(e)))?)
+            }
         }
     }
 }
@@ -263,6 +365,25 @@ impl Encode for VdafPrepMessage {
             Self::Prio3ShareField64(share) => share.encode(bytes),
             Self::Prio3ShareField128(share) => share.encode(bytes),
             Self::Prio2Share(share) => share.encode(bytes),
+        }
+    }
+}
+
+impl ParameterizedDecode<VdafPrepState> for VdafPrepMessage {
+    fn decode_with_param(
+        state: &VdafPrepState,
+        bytes: &mut std::io::Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        match state {
+            VdafPrepState::Prio3Field64(state) => Ok(VdafPrepMessage::Prio3ShareField64(
+                Prio3PrepareShare::decode_with_param(state, bytes)?,
+            )),
+            VdafPrepState::Prio3Field128(state) => Ok(VdafPrepMessage::Prio3ShareField128(
+                Prio3PrepareShare::decode_with_param(state, bytes)?,
+            )),
+            VdafPrepState::Prio2(state) => Ok(VdafPrepMessage::Prio2Share(
+                Prio2PrepareShare::decode_with_param(state, bytes)?,
+            )),
         }
     }
 }
@@ -510,6 +631,7 @@ impl VdafConfig {
     pub async fn produce_agg_job_init_req(
         &self,
         decrypter: &impl HpkeDecrypter,
+        initializer: &impl DapReportInitializer,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_id: &MetaAggregationJobId<'_>,
@@ -520,6 +642,8 @@ impl VdafConfig {
         let mut processed = HashSet::with_capacity(reports.len());
         let mut states = Vec::with_capacity(reports.len());
         let mut seq = Vec::with_capacity(reports.len());
+        let mut consumed_reports = Vec::with_capacity(reports.len());
+        let mut helper_shares = Vec::with_capacity(reports.len());
         for report in reports.into_iter() {
             if processed.contains(&report.report_metadata.id) {
                 return Err(fatal_error!(
@@ -535,39 +659,46 @@ impl VdafConfig {
                 (it.next().unwrap(), it.next().unwrap())
             };
 
-            let early_report_state_consumed = EarlyReportStateConsumed::consume(
-                decrypter,
-                true,
-                task_id,
-                task_config,
-                &report.report_metadata,
-                &report.public_share,
-                &leader_share,
-            )
+            consumed_reports.push(
+                EarlyReportStateConsumed::consume(
+                    decrypter,
+                    true,
+                    task_id,
+                    task_config,
+                    Cow::Owned(report.report_metadata),
+                    Cow::Owned(report.public_share),
+                    &leader_share,
+                )
+                .await?,
+            );
+            helper_shares.push(helper_share);
+        }
+
+        let initialized_reports = initializer
+            .initialize_reports(true, task_id, task_config, part_batch_sel, consumed_reports)
             .await?;
 
-            let early_report_state_initialized = EarlyReportStateInitialized::initialize(
-                true,
-                task_config,
-                early_report_state_consumed,
-            )?;
-
-            match early_report_state_initialized {
-                EarlyReportStateInitialized::Ready { state, message } => {
-                    states.push((
-                        state,
-                        message,
-                        report.report_metadata.time,
-                        report.report_metadata.id.clone(),
-                    ));
+        assert_eq!(initialized_reports.len(), helper_shares.len());
+        for (initialized_report, helper_share) in initialized_reports
+            .into_iter()
+            .zip(helper_shares.into_iter())
+        {
+            match initialized_report {
+                EarlyReportStateInitialized::Ready {
+                    metadata,
+                    public_share,
+                    state,
+                    message,
+                } => {
+                    states.push((state, message, metadata.time, metadata.id.clone()));
                     seq.push(ReportShare {
-                        report_metadata: report.report_metadata,
-                        public_share: report.public_share,
+                        report_metadata: metadata.into_owned(),
+                        public_share: public_share.into_owned(),
                         encrypted_input_share: helper_share,
                     });
                 }
 
-                EarlyReportStateInitialized::Rejected(failure) => {
+                EarlyReportStateInitialized::Rejected { failure, .. } => {
                     // Skip report that can't be processed any further.
                     metrics.report_inc_by(&format!("rejected_{failure}"), 1);
                     continue;
@@ -615,6 +746,7 @@ impl VdafConfig {
     pub(crate) async fn handle_agg_job_init_req(
         &self,
         decrypter: &impl HpkeDecrypter,
+        initializer: &impl DapReportInitializer,
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         agg_job_init_req: &AggregationJobInitReq,
@@ -624,6 +756,7 @@ impl VdafConfig {
         let mut processed = HashSet::with_capacity(num_reports);
         let mut states = Vec::with_capacity(num_reports);
         let mut transitions = Vec::with_capacity(num_reports);
+        let mut consumed_reports = Vec::with_capacity(num_reports);
         for report_share in agg_job_init_req.report_shares.iter() {
             if processed.contains(&report_share.report_metadata.id) {
                 return Err(DapAbort::UnrecognizedMessage {
@@ -636,43 +769,55 @@ impl VdafConfig {
             }
             processed.insert(report_share.report_metadata.id.clone());
 
-            let early_report_state_consumed = EarlyReportStateConsumed::consume(
-                decrypter,
+            consumed_reports.push(
+                EarlyReportStateConsumed::consume(
+                    decrypter,
+                    false,
+                    task_id,
+                    task_config,
+                    Cow::Borrowed(&report_share.report_metadata),
+                    Cow::Borrowed(&report_share.public_share),
+                    &report_share.encrypted_input_share,
+                )
+                .await?,
+            );
+        }
+
+        let initialized_reports = initializer
+            .initialize_reports(
                 false,
                 task_id,
                 task_config,
-                &report_share.report_metadata,
-                &report_share.public_share,
-                &report_share.encrypted_input_share,
+                &agg_job_init_req.part_batch_sel,
+                consumed_reports,
             )
             .await?;
 
-            let early_report_state_initialized = EarlyReportStateInitialized::initialize(
-                false,
-                task_config,
-                early_report_state_consumed,
-            )?;
-
-            let var = match early_report_state_initialized {
-                EarlyReportStateInitialized::Ready { state, message } => {
-                    states.push((
-                        state,
-                        report_share.report_metadata.time,
-                        report_share.report_metadata.id.clone(),
-                    ));
-                    TransitionVar::Continued(message.get_encoded())
+        for initialized_report in initialized_reports.into_iter() {
+            let transition = match initialized_report {
+                EarlyReportStateInitialized::Ready {
+                    metadata,
+                    public_share: _,
+                    state,
+                    message,
+                } => {
+                    states.push((state, metadata.time, metadata.id.clone()));
+                    Transition {
+                        report_id: metadata.into_owned().id,
+                        var: TransitionVar::Continued(message.get_encoded()),
+                    }
                 }
 
-                EarlyReportStateInitialized::Rejected(failure) => {
+                EarlyReportStateInitialized::Rejected { metadata, failure } => {
                     metrics.report_inc_by(&format!("rejected_{failure}"), 1);
-                    TransitionVar::Failed(failure)
+                    Transition {
+                        report_id: metadata.into_owned().id,
+                        var: TransitionVar::Failed(failure),
+                    }
                 }
             };
 
-            transitions.push(Transition {
-                report_id: report_share.report_metadata.id.clone(),
-                var,
-            });
+            transitions.push(transition);
         }
 
         Ok(DapHelperTransition::Continue(

--- a/daphne/src/vdaf/mod_test.rs
+++ b/daphne/src/vdaf/mod_test.rs
@@ -28,7 +28,7 @@ use prio::{
     },
 };
 use rand::prelude::*;
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
 use super::{EarlyReportStateConsumed, EarlyReportStateInitialized};
 
@@ -94,14 +94,14 @@ async fn roundtrip_report(version: DapVersion) {
         true, // is_leader
         &t.task_id,
         &t.task_config,
-        &report.report_metadata,
-        &report.public_share,
+        Cow::Borrowed(&report.report_metadata),
+        Cow::Borrowed(&report.public_share),
         &report.encrypted_input_shares[0],
     )
     .await
     .unwrap();
-    let EarlyReportStateInitialized::Ready{ state: leader_step, message: leader_share } =
-        EarlyReportStateInitialized::initialize(true, &t.task_config, early_report_state_consumed).unwrap() else {
+    let EarlyReportStateInitialized::Ready{ state: leader_step, message: leader_share, .. } =
+        EarlyReportStateInitialized::initialize(true, &t.task_config.vdaf_verify_key, &t.task_config.vdaf, early_report_state_consumed).unwrap() else {
         panic!("rejected unexpectedly");
     };
 
@@ -110,14 +110,14 @@ async fn roundtrip_report(version: DapVersion) {
         false, // is_helper
         &t.task_id,
         &t.task_config,
-        &report.report_metadata,
-        &report.public_share,
+        Cow::Borrowed(&report.report_metadata),
+        Cow::Borrowed(&report.public_share),
         &report.encrypted_input_shares[1],
     )
     .await
     .unwrap();
-    let EarlyReportStateInitialized::Ready{ state: helper_step, message: helper_share } =
-        EarlyReportStateInitialized::initialize(false, &t.task_config, early_report_state_consumed).unwrap() else {
+    let EarlyReportStateInitialized::Ready{ state: helper_step, message: helper_share, .. } =
+        EarlyReportStateInitialized::initialize(false, &t.task_config.vdaf_verify_key, &t.task_config.vdaf, early_report_state_consumed).unwrap() else {
         panic!("rejected unexpectedly");
     };
 

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -6,13 +6,23 @@ use crate::{
     durable::{state_set_if_not_exists, BINDING_DAP_REPORTS_PROCESSED},
     initialize_tracing, int_err,
 };
+use daphne::{
+    messages::{ReportId, ReportMetadata, TransitionFailure},
+    vdaf::{
+        EarlyReportState, EarlyReportStateConsumed, EarlyReportStateInitialized, VdafPrepMessage,
+        VdafPrepState, VdafVerifyKey,
+    },
+    DapError, VdafConfig,
+};
 use futures::future::try_join_all;
-use std::time::Duration;
+use prio::codec::{CodecError, Decode, ParameterizedDecode};
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, collections::HashSet, time::Duration};
 use tracing::warn;
 use worker::*;
 
-pub(crate) const DURABLE_REPORTS_PROCESSED_MARK_AGGREGATED: &str =
-    "/internal/do/report_store/mark_aggregated";
+pub(crate) const DURABLE_REPORTS_PROCESSED_INITIALIZE: &str =
+    "/internal/do/reports_processed/initialize";
 
 /// Durable Object (DO) for tracking which reports have been processed.
 ///
@@ -77,22 +87,71 @@ impl DurableObject for ReportsProcessed {
         );
 
         match (req.path().as_ref(), req.method()) {
-            // Mark a set of reports as aggregated. Return the set of report IDs that already
-            // exist.
+            // Initialize a report:
+            //  * Ensure the report wasn't replayed
+            //  * Ensure the report won't be included in a batch that was already collected
+            //  * Initialize VDAF preparation.
             //
             // Non-idempotent
-            // Input: `report_id_hex_set: Vec<String>` (hex-encoded report IDs)
-            // Output: `Vec<String>` (subset of the inputs that already exist).
-            (DURABLE_REPORTS_PROCESSED_MARK_AGGREGATED, Method::Post) => {
-                let report_id_hex_set: Vec<String> = req.json().await?;
-                let mut requests = Vec::new();
-                for report_id_hex in report_id_hex_set.into_iter() {
-                    requests.push(self.to_checked(report_id_hex));
-                }
+            // Input: `ReportsProcessedReq`
+            // Output: `ReportsProcessedResp`
+            (DURABLE_REPORTS_PROCESSED_INITIALIZE, Method::Post) => {
+                let reports_processed_request: ReportsProcessedReq = req.json().await?;
+                let replayed_reports = try_join_all(
+                    reports_processed_request
+                        .consumed_reports
+                        .iter()
+                        .filter(|consumed_report| consumed_report.is_ready())
+                        .map(|consumed_report| {
+                            self.to_checked(consumed_report.metadata().id.to_hex())
+                        }),
+                )
+                .await?
+                .into_iter()
+                // The iterator here is on `Option<String>`. What we want to do is filter out
+                // values that are `None` and unwrap the `String`.
+                .flatten()
+                .map(|report_id_hex| {
+                    hex::decode(report_id_hex)
+                        .map_err(|e| format!("Failed to hex decode ReportId: {e}"))
+                        .and_then(|report_id_data| {
+                            ReportId::get_decoded(&report_id_data)
+                                .map_err(|e| format!("Failed to decode ReportId: {e}"))
+                        })
+                })
+                .collect::<std::result::Result<HashSet<ReportId>, String>>()
+                .map_err(|e| int_err(format!("ReportsProcessed: {e}")))?;
 
-                let responses: Vec<Option<String>> = try_join_all(requests).await?;
-                let res: Vec<String> = responses.into_iter().flatten().collect();
-                Response::from_json(&res)
+                let initialized_reports = reports_processed_request
+                    .consumed_reports
+                    .into_iter()
+                    .map(|consumed_report| {
+                        if replayed_reports.contains(&consumed_report.metadata().id) {
+                            Ok(EarlyReportStateInitialized::Rejected {
+                                metadata: Cow::Owned(consumed_report.metadata().clone()),
+                                failure: TransitionFailure::ReportReplayed,
+                            })
+                        } else {
+                            EarlyReportStateInitialized::initialize(
+                                reports_processed_request.is_leader,
+                                &reports_processed_request.vdaf_verify_key,
+                                &reports_processed_request.vdaf_config,
+                                consumed_report,
+                            )
+                        }
+                    })
+                    .collect::<std::result::Result<Vec<EarlyReportStateInitialized>, DapError>>()
+                    .map_err(|e| {
+                        int_err(format!(
+                            "ReportsProcessed: failed to initialize a report: {e}"
+                        ))
+                    })?;
+
+                Response::from_json(&ReportsProcessedResp {
+                    is_leader: reports_processed_request.is_leader,
+                    vdaf_config: reports_processed_request.vdaf_config,
+                    initialized_reports,
+                })
             }
 
             _ => Err(int_err(format!(
@@ -108,5 +167,91 @@ impl DurableObject for ReportsProcessed {
         self.alarmed = false;
         self.touched = false;
         Response::from_json(&())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ReportsProcessedReq<'req> {
+    pub(crate) is_leader: bool,
+    pub(crate) vdaf_verify_key: VdafVerifyKey,
+    pub(crate) vdaf_config: VdafConfig,
+    pub(crate) consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(try_from = "ShadowReportsProcessedResp")]
+pub(crate) struct ReportsProcessedResp<'req> {
+    pub(crate) is_leader: bool,
+    pub(crate) vdaf_config: VdafConfig,
+    pub(crate) initialized_reports: Vec<EarlyReportStateInitialized<'req>>,
+}
+
+// we need this custom deserializer because VdafPrepState and VdafPrepMessage don't implement
+// Decode, only ParameterizedDecode.
+#[derive(Deserialize)]
+struct ShadowReportsProcessedResp {
+    pub(crate) is_leader: bool,
+    pub(crate) vdaf_config: VdafConfig,
+    pub(crate) initialized_reports: Vec<EarlyReportStateInitializedOwned>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EarlyReportStateInitializedOwned {
+    Ready {
+        metadata: ReportMetadata,
+        #[serde(with = "hex")]
+        public_share: Vec<u8>,
+        #[serde(with = "hex")]
+        state: Vec<u8>,
+        #[serde(with = "hex")]
+        message: Vec<u8>,
+    },
+    Rejected {
+        metadata: ReportMetadata,
+        failure: TransitionFailure,
+    },
+}
+
+impl TryFrom<ShadowReportsProcessedResp> for ReportsProcessedResp<'_> {
+    type Error = CodecError;
+
+    fn try_from(other: ShadowReportsProcessedResp) -> std::result::Result<Self, CodecError> {
+        let initialized_reports = other
+            .initialized_reports
+            .into_iter()
+            .map(|initialized_report| match initialized_report {
+                EarlyReportStateInitializedOwned::Ready {
+                    metadata,
+                    public_share,
+                    state,
+                    message,
+                } => {
+                    let state = VdafPrepState::get_decoded_with_param(
+                        &(&other.vdaf_config, other.is_leader),
+                        &state,
+                    )?;
+                    let message = VdafPrepMessage::get_decoded_with_param(&state, &message)?;
+
+                    Ok(EarlyReportStateInitialized::Ready {
+                        metadata: Cow::Owned(metadata),
+                        public_share: Cow::Owned(public_share),
+                        state,
+                        message,
+                    })
+                }
+                EarlyReportStateInitializedOwned::Rejected { metadata, failure } => {
+                    Ok(EarlyReportStateInitialized::Rejected {
+                        metadata: Cow::Owned(metadata),
+                        failure,
+                    })
+                }
+            })
+            .collect::<std::result::Result<Vec<EarlyReportStateInitialized>, CodecError>>()?;
+        Ok(Self {
+            is_leader: other.is_leader,
+            vdaf_config: other.vdaf_config,
+            initialized_reports,
+        })
     }
 }


### PR DESCRIPTION
Define a trait `DapReportInitializer` that takes a sequence of reports
in the "consumed" state and transitions each report to the "initialized"
state. Implementers are expected to perform the early validation steps
(i.e., the protocol logic previously implemented by
`DapAggregator::check_early_reject()`) and initialize VDAF preparation.

The primary motivation for this change is to improve the performance of
`DaphneWorker`. VDAF preparation initialization is expensive, so we'd
like to parallelize the computation. Because the Workers runtime is
single-threaded, the best option is to offload VDAF preparation to
durable objects. In particular, `DaphneWorker`'s implementation of
`DapReportInitializer` piggy-backs this computation on the requests to
`ReportsProcessed`.