### PR TITLE
Reorganize e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "cfg-if",
  "console_error_panic_hook",
  "daphne",
@@ -703,6 +704,7 @@ dependencies = [
  "hpke-rs",
  "paste",
  "prio",
+ "prometheus",
  "rand",
  "reqwest",
  "ring",
@@ -1224,6 +1226,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1976,6 +1992,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1985,16 +2002,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2096,6 +2117,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2176,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -2502,6 +2564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,6 +2885,25 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ members = [
 opt-level = "s"
 
 [workspace.dependencies]
+anyhow = "1.0.71"
 assert_matches = "1.5.0"
 async-trait = "0.1.71"
+base64 = "0.21.2"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 futures = "0.3.28"
 getrandom = { version = "0.2.10", features = ["js"] } # Required for prio

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 [dependencies]
 assert_matches.workspace = true
 async-trait.workspace = true
-base64 = "0.21.2"
+base64.workspace = true
 futures.workspace = true
 hex.workspace = true
 hpke-rs = { workspace = true, features = ["hazmat", "serialization"] }

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook"]
 test_e2e = []
+test_acceptance = []
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -29,14 +30,16 @@ tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 assert_matches.workspace = true
 daphne = { path = "../daphne" }
 hex.workspace = true
 hpke-rs.workspace = true
 paste.workspace = true
 prio.workspace = true
+prometheus.workspace = true
 rand.workspace = true
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/daphne_worker_test/docker/test.sh
+++ b/daphne_worker_test/docker/test.sh
@@ -10,7 +10,8 @@ env RUST_BACKTRACE=1 cargo test \
     --features=test_e2e \
     -- \
     --nocapture \
-    --test-threads 1
+    --test-threads 1 \
+    e2e
 
 echo "Running clippy."
 cargo clippy -- -Dwarnings

--- a/daphne_worker_test/docker/test.sh
+++ b/daphne_worker_test/docker/test.sh
@@ -5,8 +5,12 @@
 
 set -e
 
-echo "Running tests."
-env RUST_BACKTRACE=1 cargo test --features=test_e2e -p daphne-worker-test -- --nocapture --test-threads 1
+echo "Running e2e tests."
+env RUST_BACKTRACE=1 cargo test \
+    --features=test_e2e \
+    -- \
+    --nocapture \
+    --test-threads 1
 
 echo "Running clippy."
 cargo clippy -- -Dwarnings

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! End-to-end tests for daphne.
-
-mod test_runner;
-
 use daphne::{
     async_test_versions,
     constants::DapMediaType,
@@ -25,7 +22,7 @@ use rand::prelude::*;
 use serde::Deserialize;
 use serde_json::json;
 use std::cmp::{max, min};
-use test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
+use super::test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
 
 // Redefine async_test_version locally because we want a
 // cfg_attr as well.

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 //! End-to-end tests for daphne.
+use super::test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
 use daphne::{
     async_test_versions,
     constants::DapMediaType,
@@ -22,7 +23,6 @@ use rand::prelude::*;
 use serde::Deserialize;
 use serde_json::json;
 use std::cmp::{max, min};
-use super::test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
 
 // Redefine async_test_version locally because we want a
 // cfg_attr as well.
@@ -47,23 +47,23 @@ struct InternalTestEndpointForTaskResult {
     endpoint: Option<String>,
 }
 
-async fn e2e_helper_ready(version: DapVersion) {
+async fn helper_ready(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     t.helper_post_internal::<_, ()>("/internal/test/ready", &())
         .await;
 }
 
-async_test_versions! { e2e_helper_ready }
+async_test_versions! { helper_ready }
 
-async fn e2e_leader_ready(version: DapVersion) {
+async fn leader_ready(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     t.leader_post_internal::<_, ()>("/internal/test/ready", &())
         .await;
 }
 
-async_test_versions! { e2e_leader_ready }
+async_test_versions! { leader_ready }
 
-async fn e2e_leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
+async fn leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let prefix = if want_prefix {
         format!("/{}", version.as_ref())
     } else {
@@ -92,19 +92,19 @@ async fn e2e_leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     assert_eq!(res.endpoint.unwrap(), expected);
 }
 
-async fn e2e_leader_endpoint_for_task_unprefixed(version: DapVersion) {
-    e2e_leader_endpoint_for_task(version, false).await
+async fn leader_endpoint_for_task_unprefixed(version: DapVersion) {
+    leader_endpoint_for_task(version, false).await
 }
 
-async_test_versions! { e2e_leader_endpoint_for_task_unprefixed }
+async_test_versions! { leader_endpoint_for_task_unprefixed }
 
-async fn e2e_leader_endpoint_for_task_prefixed(version: DapVersion) {
-    e2e_leader_endpoint_for_task(version, true).await
+async fn leader_endpoint_for_task_prefixed(version: DapVersion) {
+    leader_endpoint_for_task(version, true).await
 }
 
-async_test_versions! { e2e_leader_endpoint_for_task_prefixed }
+async_test_versions! { leader_endpoint_for_task_prefixed }
 
-async fn e2e_helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
+async fn helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let prefix = if want_prefix {
         format!("/{}", version.as_ref())
     } else {
@@ -133,35 +133,35 @@ async fn e2e_helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     assert_eq!(res.endpoint.unwrap(), expected);
 }
 
-async fn e2e_helper_endpoint_for_task_unprefixed(version: DapVersion) {
-    e2e_helper_endpoint_for_task(version, false).await
+async fn helper_endpoint_for_task_unprefixed(version: DapVersion) {
+    helper_endpoint_for_task(version, false).await
 }
 
-async_test_versions! { e2e_helper_endpoint_for_task_unprefixed }
+async_test_versions! { helper_endpoint_for_task_unprefixed }
 
-async fn e2e_helper_endpoint_for_task_prefixed(version: DapVersion) {
-    e2e_helper_endpoint_for_task(version, true).await
+async fn helper_endpoint_for_task_prefixed(version: DapVersion) {
+    helper_endpoint_for_task(version, true).await
 }
 
-async_test_versions! { e2e_helper_endpoint_for_task_prefixed }
+async_test_versions! { helper_endpoint_for_task_prefixed }
 
-async fn e2e_leader_hpke_config(version: DapVersion) {
+async fn leader_hpke_config(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     t.leader_get_raw_hpke_config(&client).await;
 }
 
-async_test_versions! { e2e_leader_hpke_config }
+async_test_versions! { leader_hpke_config }
 
-async fn e2e_helper_hpke_config(version: DapVersion) {
+async fn helper_hpke_config(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     t.helper_get_raw_hpke_config(&client).await;
 }
 
-async_test_versions! { e2e_helper_hpke_config }
+async_test_versions! { helper_hpke_config }
 
-async fn e2e_hpke_configs_are_cached(version: DapVersion) {
+async fn hpke_configs_are_cached(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     // Get a set of HPKE configs from leader and helper.
@@ -175,9 +175,9 @@ async fn e2e_hpke_configs_are_cached(version: DapVersion) {
     assert_eq!(hpke_config_list_0[1], hpke_config_list_1[1]);
 }
 
-async_test_versions! { e2e_hpke_configs_are_cached }
+async_test_versions! { hpke_configs_are_cached }
 
-async fn e2e_leader_upload(version: DapVersion) {
+async fn leader_upload(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let mut rng = thread_rng();
     let client = t.http_client();
@@ -354,11 +354,11 @@ async fn e2e_leader_upload(version: DapVersion) {
     );
 }
 
-async_test_versions! { e2e_leader_upload }
+async_test_versions! { leader_upload }
 
 #[tokio::test]
 #[cfg_attr(not(feature = "test_e2e"), ignore)]
-async fn e2e_leader_upload_taskprov() {
+async fn leader_upload_taskprov() {
     let version = DapVersion::Draft02;
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
@@ -527,7 +527,7 @@ async fn e2e_leader_upload_taskprov() {
     .await;
 }
 
-async fn e2e_internal_leader_process(version: DapVersion) {
+async fn internal_leader_process(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let path = t.upload_path();
 
@@ -584,10 +584,10 @@ async fn e2e_internal_leader_process(version: DapVersion) {
     assert_eq!(agg_telem.reports_collected, 0, "reports collected");
 }
 
-async_test_versions! { e2e_internal_leader_process }
+async_test_versions! { internal_leader_process }
 
 // Test that all reports eventually get drained at minimum aggregation rate.
-async fn e2e_leader_process_min_agg_rate(version: DapVersion) {
+async fn leader_process_min_agg_rate(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     let batch_interval = t.batch_interval();
@@ -633,9 +633,9 @@ async fn e2e_leader_process_min_agg_rate(version: DapVersion) {
     assert_eq!(agg_telem.reports_processed, 0, "reports processed");
 }
 
-async_test_versions! { e2e_leader_process_min_agg_rate }
+async_test_versions! { leader_process_min_agg_rate }
 
-async fn e2e_leader_collect_ok(version: DapVersion) {
+async fn leader_collect_ok(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
 
@@ -776,11 +776,11 @@ async fn e2e_leader_collect_ok(version: DapVersion) {
     //  .await;
 }
 
-async_test_versions! { e2e_leader_collect_ok }
+async_test_versions! { leader_collect_ok }
 
 // Test that collect jobs complete even if the request is issued after all reports for the task
 // have been processed.
-async fn e2e_leader_collect_ok_interleaved(version: DapVersion) {
+async fn leader_collect_ok_interleaved(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     let batch_interval = t.batch_interval();
@@ -842,9 +842,9 @@ async fn e2e_leader_collect_ok_interleaved(version: DapVersion) {
     );
 }
 
-async_test_versions! { e2e_leader_collect_ok_interleaved }
+async_test_versions! { leader_collect_ok_interleaved }
 
-async fn e2e_leader_collect_not_ready_min_batch_size(version: DapVersion) {
+async fn leader_collect_not_ready_min_batch_size(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
     let client = t.http_client();
@@ -912,9 +912,9 @@ async fn e2e_leader_collect_not_ready_min_batch_size(version: DapVersion) {
     assert_eq!(resp.status(), 202);
 }
 
-async_test_versions! { e2e_leader_collect_not_ready_min_batch_size }
+async_test_versions! { leader_collect_not_ready_min_batch_size }
 
-async fn e2e_leader_collect_abort_unknown_request(version: DapVersion) {
+async fn leader_collect_abort_unknown_request(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
 
@@ -936,9 +936,9 @@ async fn e2e_leader_collect_abort_unknown_request(version: DapVersion) {
     assert_eq!(resp.status(), expected_status);
 }
 
-async_test_versions! { e2e_leader_collect_abort_unknown_request }
+async_test_versions! { leader_collect_abort_unknown_request }
 
-async fn e2e_leader_collect_accept_global_config_max_batch_duration(version: DapVersion) {
+async fn leader_collect_accept_global_config_max_batch_duration(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     let batch_interval = Interval {
@@ -958,9 +958,9 @@ async fn e2e_leader_collect_accept_global_config_max_batch_duration(version: Dap
         .await;
 }
 
-async_test_versions! { e2e_leader_collect_accept_global_config_max_batch_duration }
+async_test_versions! { leader_collect_accept_global_config_max_batch_duration }
 
-async fn e2e_leader_collect_abort_invalid_batch_interval(version: DapVersion) {
+async fn leader_collect_abort_invalid_batch_interval(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let client = t.http_client();
     let batch_interval = t.batch_interval();
@@ -1037,9 +1037,9 @@ async fn e2e_leader_collect_abort_invalid_batch_interval(version: DapVersion) {
     }
 }
 
-async_test_versions! { e2e_leader_collect_abort_invalid_batch_interval }
+async_test_versions! { leader_collect_abort_invalid_batch_interval }
 
-async fn e2e_leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
+async fn leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
     let client = t.http_client();
@@ -1145,9 +1145,9 @@ async fn e2e_leader_collect_abort_overlapping_batch_interval(version: DapVersion
     }
 }
 
-async_test_versions! { e2e_leader_collect_abort_overlapping_batch_interval }
+async_test_versions! { leader_collect_abort_overlapping_batch_interval }
 
-async fn e2e_fixed_size(version: DapVersion, use_current: bool) {
+async fn fixed_size(version: DapVersion, use_current: bool) {
     if version == DapVersion::Draft02 && use_current {
         // The "current batch" isn't a feature in Draft02, but we allow it
         // and immediately return for testing flexibility, as this allows us
@@ -1342,19 +1342,19 @@ async fn e2e_fixed_size(version: DapVersion, use_current: bool) {
     }
 }
 
-async fn e2e_fixed_size_no_current(version: DapVersion) {
-    e2e_fixed_size(version, true).await;
+async fn fixed_size_no_current(version: DapVersion) {
+    fixed_size(version, true).await;
 }
 
-async_test_versions! { e2e_fixed_size_no_current }
+async_test_versions! { fixed_size_no_current }
 
-async fn e2e_fixed_size_current(version: DapVersion) {
-    e2e_fixed_size(version, true).await;
+async fn fixed_size_current(version: DapVersion) {
+    fixed_size(version, true).await;
 }
 
-async_test_versions! { e2e_fixed_size_current }
+async_test_versions! { fixed_size_current }
 
-async fn e2e_leader_collect_taskprov_ok(version: DapVersion) {
+async fn leader_collect_taskprov_ok(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
 
@@ -1502,9 +1502,9 @@ async fn e2e_leader_collect_taskprov_ok(version: DapVersion) {
     );
 }
 
-async_test_version! { e2e_leader_collect_taskprov_ok, Draft02 }
+async_test_version! { leader_collect_taskprov_ok, Draft02 }
 
-async fn e2e_helper_admin_add_task(version: DapVersion) {
+async fn helper_admin_add_task(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
 
     let add_task_cmd = serde_json::json!({
@@ -1549,4 +1549,4 @@ async fn e2e_helper_admin_add_task(version: DapVersion) {
     }
 }
 
-async_test_versions! { e2e_helper_admin_add_task }
+async_test_versions! { helper_admin_add_task }

--- a/daphne_worker_test/tests/e2e/main.rs
+++ b/daphne_worker_test/tests/e2e/main.rs
@@ -1,0 +1,2 @@
+mod e2e;
+mod test_runner;

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -36,7 +36,6 @@ struct InternalTestCommandResult {
     error: Option<String>,
 }
 
-#[allow(dead_code)]
 pub struct TestRunner {
     pub global_config: DapGlobalConfig,
     pub task_id: TaskId,
@@ -52,14 +51,9 @@ pub struct TestRunner {
     pub version: DapVersion,
 }
 
-#[allow(dead_code)]
 impl TestRunner {
     pub async fn default_with_version(version: DapVersion) -> Self {
         Self::with(version, &DapQueryConfig::TimeInterval).await
-    }
-
-    pub async fn default() -> Self {
-        Self::default_with_version(DapVersion::Draft02).await
     }
 
     pub async fn fixed_size(version: DapVersion) -> Self {
@@ -591,7 +585,6 @@ impl TestRunner {
             .await
     }
 
-    #[allow(dead_code)]
     pub async fn internal_process(
         &self,
         client: &reqwest::Client,
@@ -641,7 +634,6 @@ impl TestRunner {
         resp.json().await.expect("failed to parse result")
     }
 
-    #[allow(dead_code)]
     pub async fn leader_post_internal<I: Serialize, O: for<'a> Deserialize<'a>>(
         &self,
         path: &str,
@@ -650,7 +642,6 @@ impl TestRunner {
         self.post_internal(true /* is_leader */, path, data).await
     }
 
-    #[allow(dead_code)]
     pub async fn helper_post_internal<I: Serialize, O: for<'a> Deserialize<'a>>(
         &self,
         path: &str,
@@ -659,14 +650,12 @@ impl TestRunner {
         self.post_internal(false /* is_leader */, path, data).await
     }
 
-    #[allow(dead_code)]
     pub async fn internal_delete_all(&self, batch_interval: &Interval) {
         let client = self.http_client();
         post_internal_delete_all(&client, &self.leader_url, batch_interval).await;
         post_internal_delete_all(&client, &self.helper_url, batch_interval).await;
     }
 
-    #[allow(dead_code)]
     pub async fn internal_current_batch(&self, task_id: &TaskId) -> BatchId {
         let client = self.http_client();
         let mut url = self.leader_url.clone();
@@ -746,7 +735,6 @@ impl TestRunner {
     }
 }
 
-#[allow(dead_code)]
 async fn get_raw_hpke_config(
     client: &reqwest::Client,
     task_id: &[u8],
@@ -786,7 +774,6 @@ async fn get_raw_hpke_config(
     panic!("{} at {} is down.", svc, url)
 }
 
-#[allow(dead_code)]
 async fn post_internal_delete_all(
     client: &reqwest::Client,
     base_url: &Url,


### PR DESCRIPTION
This organization let's us remove the `allow(dead_code)` directives and also
lets us remove the `e2e_` prefix from the tests since the test name will get
that from the module name.
