### PR TITLE
Wait to mark reports as aggregated until just before committing

### DIFF
--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -392,7 +392,13 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
                 .vdaf
                 .handle_final_agg_job_resp(uncommited, agg_job_resp, &metrics)?;
         let out_shares_count = out_shares.len() as u64;
-        self.put_out_shares(task_id, part_batch_sel, out_shares)
+
+        // At this point we're committed to aggregating the reports: if we do detect a report was
+        // replayed at this stage, then we may end up with a batch mismatch. However, this should
+        // only happen if there are multiple aggregation jobs in-flight that include the same
+        // report.
+        let _ = self
+            .put_out_shares(task_id, task_config, part_batch_sel, out_shares)
             .await?;
 
         metrics.report_inc_by("aggregated", out_shares_count);

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -913,6 +913,7 @@ impl VdafConfig {
 
                     states.push((
                         DapOutputShare {
+                            report_id: leader_report_id.clone(),
                             time: leader_time,
                             checksum: checksum.as_ref().try_into().unwrap(),
                             data,
@@ -1063,6 +1064,7 @@ impl VdafConfig {
                         );
 
                         out_shares.push(DapOutputShare {
+                            report_id: helper_report_id.clone(),
                             time: helper_time,
                             checksum: checksum.as_ref().try_into().unwrap(),
                             data,


### PR DESCRIPTION
Loads that require a lot of CPU time can trigger the Workers runtime to reset itself, causing a 500 error. This is most likely to happen when processing the AggregationJobInitReq, as this involves the expensive, VDAF prep initialization step. Some reports may still get marked as aggregated; if the peer retries the request, those reports will get rejected.

This problem is so common that we need to make this request idempotent. As a first step, wait to mark the reports as aggregated until just before we have committed to aggregating them. In particular, instead of doing this in `DapReportInitializer::initialize_reports()`, wait until `DapAggregator::put_out_shares()`.