### PR TITLE
Propagate tracing fields to DOs

### DIFF
--- a/daphne_worker/src/tracing_utils/fields_recording_layer.rs
+++ b/daphne_worker/src/tracing_utils/fields_recording_layer.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::collections::HashMap;
+
+use tracing::{span::Attributes, Id, Subscriber};
+use tracing_subscriber::{layer::Context as LayerContext, registry, Layer};
+
+use super::{JsonFields, JsonVisitor};
+
+/// Tracing subscriber layer that records the fields of the created spans.
+///
+/// Fields from spans are flattened into the JSON, duplicates are prioritized by their closeness to
+/// the leaf (e.g. leaf field overrides root field).
+///
+/// Timestamps are derived from calling `Date.now()`. In the Workers runtime, time only progresses
+/// when IO occurs.
+pub(super) struct SpanFieldsRecorderLayer;
+
+impl<S> Layer<S> for SpanFieldsRecorderLayer
+where
+    S: Subscriber + for<'a> registry::LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: LayerContext<'_, S>) {
+        let span = ctx.span(id).expect("span should exist");
+        let mut fields = HashMap::new();
+        let mut visitor = JsonVisitor(&mut fields);
+        attrs.record(&mut visitor);
+
+        let mut extensions = span.extensions_mut();
+        if extensions.get_mut::<JsonFields>().is_none() {
+            extensions.insert(fields);
+        }
+    }
+}

--- a/daphne_worker/src/tracing_utils/workers_json_layer.rs
+++ b/daphne_worker/src/tracing_utils/workers_json_layer.rs
@@ -124,7 +124,12 @@ where
 
         let metadata = event.metadata();
         if let (Some(file), Some(line)) = (metadata.file(), metadata.line()) {
-            fields.insert("at".to_owned(), format!("{}:{}", file, line).into());
+            // we need to keep log lines as short as possible otherwise logpush will truncate them.
+            let file_parts = shorten_paths(file.trim_start_matches("daphne_").split('/'));
+            fields.insert(
+                "at".to_owned(),
+                format!("{}:{}", file_parts.display(), line).into(),
+            );
         }
 
         // If there is no `message`, repurpose the error meessage is there is one or the


### PR DESCRIPTION
The first commit is not related to this PR and I apologize for that, but it's
small and the code is reused later in the PR, so I included it to reduce churn.

This PR can be reviewed in 3 parts, one for each commit.

- Shorten file location to reduce logpush truncation chance. Instead of having `daphne_worker/src/durable/mod.rs:333` we instead have `wo/sr/du/mod.rs:333`, it's enough to know where the logline is, but takes up less space in the logline.

- Split the tracing JsonLayer into 2 layers (see commit message description for why this is needed)

- Pass tracing fields as headers
