### PR TITLE
Clean up bearer token resolution logic

### DIFF
--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -49,7 +49,11 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
     /// If the return value is `None`, then the request is authorized. If the return value is
     /// `Some(reason)`, then the request is denied and `reason` conveys details about how the
     /// decision was reached.
-    async fn unauthorized_reason(&self, req: &DapRequest<S>) -> Result<Option<String>, DapError>;
+    async fn unauthorized_reason(
+        &self,
+        task_config: &DapTaskConfig,
+        req: &DapRequest<S>,
+    ) -> Result<Option<String>, DapError>;
 
     /// Look up the DAP global configuration.
     fn get_global_config(&self) -> &DapGlobalConfig;

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -1283,6 +1283,15 @@ impl<K: Clone + Eq + std::hash::Hash, V> KvPair<'_, K, V> {
 
 pub(crate) type BearerTokenKvPair<'a> = KvPair<'a, TaskId, BearerToken>;
 
+impl<'a> BearerTokenKvPair<'a> {
+    pub(crate) fn new(task_id: &'a TaskId, bearer_token: &BearerToken) -> Self {
+        Self {
+            key: Cow::Borrowed(task_id),
+            value: bearer_token.clone(),
+        }
+    }
+}
+
 impl AsRef<BearerToken> for BearerTokenKvPair<'_> {
     fn as_ref(&self) -> &BearerToken {
         self.value()


### PR DESCRIPTION
Decouple taskprov from the `BearerTokenProvider` by getting rid of the
`is_taskprov_*token()` calls and forcing the `get_*token()` calls to
resolve the taskprov tokens.

Accordingly, pass the `DapTaskConfig` so that the implementer knows if
the task was configured via taskprov. This requires resolving the
`DapTaskConfig` before authorizing the request, so re-order the logic in
`DapLeader` and `DapHelper` accordingly.

While at it, pick up an efficiency improvement for DaphneWorker: if
taskprov is enabled for the task, then we use the token from the global
taskprov config and avoid a KV lookup.