### PR TITLE
Fix clippy redundant guard warning

### DIFF
--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -142,11 +142,10 @@ impl DapReportInitializer for DaphneWorker<'_> {
                 if let Some(initialized_report) = initialized_reports.get_mut(&metadata.id) {
                     let processed = match initialized_report {
                         EarlyReportStateInitialized::Ready { .. } => false,
-                        EarlyReportStateInitialized::Rejected { failure, .. }
-                            if matches!(failure, TransitionFailure::ReportReplayed) =>
-                        {
-                            true
-                        }
+                        EarlyReportStateInitialized::Rejected {
+                            failure: TransitionFailure::ReportReplayed,
+                            ..
+                        } => true,
                         EarlyReportStateInitialized::Rejected { .. } => {
                             continue;
                         }


### PR DESCRIPTION
Rust 1.73 added a "redundant guard" warning that causes CI to fail now
