### PR TITLE
Implement the aggregation flow as in draft07

### DIFF
--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -26,7 +26,6 @@ async-trait.workspace = true
 assert_matches = { workspace = true, optional = true }
 base64.workspace = true
 deepsize = { version = "0.2.0", optional = true }
-futures.workspace = true
 hex.workspace = true
 hpke-rs = { workspace = true, features = ["hazmat", "serialization"] }
 hpke-rs-crypto.workspace = true
@@ -44,6 +43,7 @@ url.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 criterion.workspace = true
+futures.workspace = true
 matchit.workspace = true
 paste.workspace = true
 regex = "1.10.0"

--- a/daphne/benches/aggregation.rs
+++ b/daphne/benches/aggregation.rs
@@ -3,8 +3,8 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use daphne::{
-    hpke::HpkeKemId, testing::AggregationJobTest, DapLeaderTransition, DapMeasurement, DapVersion,
-    Prio3Config, VdafConfig,
+    hpke::HpkeKemId, testing::AggregationJobTest, DapLeaderAggregationJobTransition,
+    DapMeasurement, DapVersion, Prio3Config, VdafConfig,
 };
 
 fn handle_agg_job_init_req(c: &mut Criterion) {
@@ -38,7 +38,7 @@ fn handle_agg_job_init_req(c: &mut Criterion) {
 
         let agg_job_init_req = rt.block_on(async {
             let reports = agg_job_test.produce_reports(vec![measurement; batch_size]);
-            let DapLeaderTransition::Continue(_leader_state, agg_job_init_req) =
+            let DapLeaderAggregationJobTransition::Continued(_leader_state, agg_job_init_req) =
                 agg_job_test.produce_agg_job_init_req(reports).await
             else {
                 panic!("unexpected transition");
@@ -46,7 +46,7 @@ fn handle_agg_job_init_req(c: &mut Criterion) {
             agg_job_init_req
         });
 
-        c.bench_function(&format!("handle_agg_job_init_req {vdaf:?}"), |b| {
+        c.bench_function(&format!("handle_agg_job_init_req {vdaf}"), |b| {
             b.to_async(&rt).iter(|| async {
                 black_box(agg_job_test.handle_agg_job_init_req(&agg_job_init_req)).await
             })


### PR DESCRIPTION
Stacked on #412.
Partially addresses #350.

In draft07, the Leader sends its prep share in the
AggregationJobInitReq; the Helper computes its prep share, computes the
prep message, and commits. For 1-round VDAFs, the flow is complete after
one request.

The main goal of this change is to implement this new control flow.
Other changes:

* Clean up and unify data structures for aggregation job state.

* Rename the `aggregation_job_continue_repeats_due_to_replays` metric
  (we need to do an analogous thing during AggregationJobInitReq
  processing).

* Regression: Remove the `handle_agg_job_req_init_expired_task` tests.
  Ideally we'd like to keep these, but it's difficult to do so without
  major refactoring.

Work-in-progress: The code is not yet wire-compatible with draft07.