### PR TITLE
Rename the `try_put_agg_share_span()` retry metric

### DIFF
--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -24,7 +24,7 @@ pub struct DaphneMetrics {
     aggregation_job_batch_size_histogram: Histogram,
 
     /// Helper: Number of times replays caused the aggregation to be retried.
-    aggregation_job_continue_repeats_due_to_replays: IntCounter,
+    aggregation_job_put_span_retry_counter: IntCounter,
 }
 
 impl DaphneMetrics {
@@ -65,20 +65,20 @@ impl DaphneMetrics {
         )
         .map_err(|e| fatal_error!(err = ?e, "failed to register aggregation_job_counter"))?;
 
-        let aggregation_job_continue_repeats_due_to_replays =
+        let aggregation_job_put_span_retry_counter =
             register_int_counter_with_registry!(
-                "aggregation_continuation_repeats_due_to_replays",
+                format!("aggregation_job_put_span_retry_counter"),
                 "Total number of times the aggregation continuation was restarted due to replayed reports",
                 registry
             )
-            .map_err(|e| fatal_error!(err = ?e, "failed to register aggregation_continuation_repeats_due_to_replays"))?;
+            .map_err(|e| fatal_error!(err = ?e, "failed to register aggregation_job_put_span_retry_counter"))?;
 
         Ok(Self {
             inbound_request_counter,
             report_counter,
             aggregation_job_counter,
             aggregation_job_batch_size_histogram,
-            aggregation_job_continue_repeats_due_to_replays,
+            aggregation_job_put_span_retry_counter,
         })
     }
 
@@ -116,8 +116,8 @@ impl DaphneMetrics {
             .inc();
     }
 
-    pub fn agg_job_cont_restarted_inc(&self) {
-        self.aggregation_job_continue_repeats_due_to_replays.inc();
+    pub fn agg_job_put_span_retry_inc(&self) {
+        self.aggregation_job_put_span_retry_counter.inc();
     }
 }
 

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -472,7 +472,7 @@ async fn run_vdaf_cont_round_and_aggregate<S>(
                             ReportProcessedStatus::Rejected(TransitionFailure::ReportReplayed),
                         )
                     }));
-                    inc_restart_metric.call_once(|| metrics.agg_job_cont_restarted_inc());
+                    inc_restart_metric.call_once(|| metrics.agg_job_put_span_retry_inc());
                 }
                 // If this happens, the leader and helper can possibly have inconsistent state.
                 // The leader will still think all of the reports in this job have yet to be


### PR DESCRIPTION
Partially addresses #350.

In DAP-07 it won't be specific to `AggregationJobContinueReq`.