### PR TITLE
Remove `DapVersion::Unknown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,6 @@ dependencies = [
  "daphne",
  "futures",
  "hex",
- "matchit 0.7.3",
  "once_cell",
  "paste",
  "prio",

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -134,7 +134,6 @@ impl DapMediaType {
             }
             (_, Self::Invalid(ref content_type)) => Some(content_type),
             (_, Self::Missing) => None,
-            (DapVersion::Unknown, _) => unreachable!("unhandled version {version:?}"),
         }
     }
 
@@ -144,7 +143,6 @@ impl DapMediaType {
         match version {
             DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
             DapVersion::Draft07 => Self::AggregationJobResp,
-            _ => unreachable!("unhandled version {version:?}"),
         }
     }
 }

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -109,7 +109,6 @@ impl TaskId {
         match version {
             DapVersion::Draft02 => Some(self.clone()),
             DapVersion::Draft07 => None,
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         }
     }
 }
@@ -441,7 +440,6 @@ impl ParameterizedDecode<DapVersion> for PrepareInit {
         let draft07_payload = match version {
             DapVersion::Draft02 => None,
             DapVersion::Draft07 => Some(decode_u32_bytes(bytes)?),
-            _ => unreachable!("unhandled version {version:?}"),
         };
 
         Ok(Self {
@@ -476,7 +474,6 @@ impl ParameterizedEncode<DapVersion> for AggregationJobInitReq {
                 encode_u16_bytes(bytes, &self.agg_param);
             }
             DapVersion::Draft07 => encode_u32_bytes(bytes, &self.agg_param),
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         self.part_batch_sel.encode(bytes);
         encode_u32_items(bytes, version, &self.prep_inits);
@@ -495,7 +492,6 @@ impl ParameterizedDecode<DapVersion> for AggregationJobInitReq {
                 decode_u16_bytes(bytes)?,
             ),
             DapVersion::Draft07 => (None, None, decode_u32_bytes(bytes)?),
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
 
         Ok(Self {
@@ -536,7 +532,6 @@ impl ParameterizedEncode<DapVersion> for AggregationJobContinueReq {
                     .expect("draft07: missing round")
                     .encode(bytes);
             }
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         encode_u32_items(bytes, &(), &self.transitions);
     }
@@ -554,7 +549,6 @@ impl ParameterizedDecode<DapVersion> for AggregationJobContinueReq {
                 None,
             ),
             DapVersion::Draft07 => (None, None, Some(u16::decode(bytes)?)),
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         Ok(Self {
             draft02_task_id,
@@ -842,13 +836,11 @@ impl ParameterizedEncode<DapVersion> for CollectionReq {
                     .encode(bytes);
             }
             DapVersion::Draft07 => {}
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         }
         self.query.encode_with_param(version, bytes);
         match version {
             DapVersion::Draft02 => encode_u16_bytes(bytes, &self.agg_param),
             DapVersion::Draft07 => encode_u32_bytes(bytes, &self.agg_param),
-            _ => panic!("unimplemented DapVersion"),
         };
     }
 }
@@ -861,7 +853,6 @@ impl ParameterizedDecode<DapVersion> for CollectionReq {
         let draft02_task_id = match version {
             DapVersion::Draft02 => Some(TaskId::decode(bytes)?),
             DapVersion::Draft07 => None,
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         Ok(Self {
             draft02_task_id,
@@ -869,7 +860,6 @@ impl ParameterizedDecode<DapVersion> for CollectionReq {
             agg_param: match version {
                 DapVersion::Draft02 => decode_u16_bytes(bytes)?,
                 DapVersion::Draft07 => decode_u32_bytes(bytes)?,
-                _ => panic!("unimplemented DapVersion"),
             },
         })
     }
@@ -899,7 +889,6 @@ impl ParameterizedEncode<DapVersion> for Collection {
                     .expect("draft07: missing interval")
                     .encode(bytes);
             }
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         encode_u32_items(bytes, &(), &self.encrypted_agg_shares);
     }
@@ -916,7 +905,6 @@ impl ParameterizedDecode<DapVersion> for Collection {
             interval: match version {
                 DapVersion::Draft02 => None,
                 DapVersion::Draft07 => Some(Interval::decode(bytes)?),
-                _ => panic!("unimplemented DapVersion"),
             },
             encrypted_agg_shares: decode_u32_items(&(), bytes)?,
         })
@@ -950,7 +938,6 @@ impl ParameterizedEncode<DapVersion> for AggregateShareReq {
                 self.batch_sel.encode_with_param(version, bytes);
                 encode_u32_bytes(bytes, &self.agg_param);
             }
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         self.report_count.encode(bytes);
         bytes.extend_from_slice(&self.checksum);
@@ -973,7 +960,6 @@ impl ParameterizedDecode<DapVersion> for AggregateShareReq {
                 BatchSelector::decode_with_param(version, bytes)?,
                 decode_u32_bytes(bytes)?,
             ),
-            DapVersion::Unknown => unreachable!("unhandled version {version:?}"),
         };
         Ok(Self {
             draft02_task_id,

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -141,11 +141,6 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
 
     /// Handle request for the Aggregator's HPKE configuration.
     async fn handle_hpke_config_req(&self, req: &DapRequest<S>) -> Result<DapResponse, DapAbort> {
-        // Check whether the DAP version indicated by the sender is supported.
-        if req.version == DapVersion::Unknown {
-            return Err(DapAbort::version_unknown());
-        }
-
         let metrics = self.metrics();
 
         // Parse the task ID from the query string, ensuring that it is the only query parameter.
@@ -187,9 +182,6 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
                 };
                 hpke_config_list.get_encoded()
             }
-            // This is just to keep the compiler happy as we excluded DapVersion::Unknown by
-            // aborting at the top of the function.
-            _ => unreachable!("unhandled version {:?}", req.version),
         };
 
         metrics.inbound_req_inc(DaphneRequestType::HpkeConfig);

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -186,7 +186,6 @@ pub trait DapHelper<S>: DapAggregator<S> {
                 metrics.agg_job_completed_inc();
                 agg_job_resp
             }
-            v => unreachable!("unhandled version {v:?}"),
         };
 
         self.audit_log().on_aggregation_job(
@@ -295,11 +294,6 @@ pub trait DapHelper<S>: DapAggregator<S> {
         let metrics = self.metrics();
         let task_id = req.task_id()?;
 
-        // Check whether the DAP version indicated by the sender is supported.
-        if req.version == DapVersion::Unknown {
-            return Err(DapAbort::version_unknown());
-        }
-
         match req.media_type {
             DapMediaType::AggregationJobInitReq => {
                 self.handle_agg_job_init_req(req, metrics, task_id).await
@@ -318,11 +312,6 @@ pub trait DapHelper<S>: DapAggregator<S> {
         let now = self.get_current_time();
         let metrics = self.metrics();
         let task_id = req.task_id()?;
-
-        // Check whether the DAP version indicated by the sender is supported.
-        if req.version == DapVersion::Unknown {
-            return Err(DapAbort::version_unknown());
-        }
 
         check_request_content_type(req, DapMediaType::AggregateShareReq)?;
 

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -151,11 +151,6 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         let task_id = req.task_id()?;
         debug!("upload for task {task_id}");
 
-        // Check whether the DAP version indicated by the sender is supported.
-        if req.version == DapVersion::Unknown {
-            return Err(DapAbort::version_unknown());
-        }
-
         check_request_content_type(req, DapMediaType::Report)?;
 
         let report = Report::get_decoded_with_param(&req.version, req.payload.as_ref())
@@ -229,11 +224,6 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         let metrics = self.metrics();
         let task_id = req.task_id()?;
         debug!("collect for task {task_id}");
-
-        // Check whether the DAP version indicated by the sender is supported.
-        if req.version == DapVersion::Unknown {
-            return Err(DapAbort::version_unknown());
-        }
 
         check_request_content_type(req, DapMediaType::CollectReq)?;
 
@@ -552,7 +542,6 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
                     },
                 })
             }
-            _ => unreachable!("unhandled version {}", task_config.version),
         };
 
         // Complete the collect job.

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -1688,24 +1688,6 @@ mod test {
 
     async_test_versions! { handle_collect_job_req_invalid_query }
 
-    // Test HTTP POST requests with a wrong DAP version.
-    async fn http_post_fail_unknown_version(version: DapVersion) {
-        let t = Test::new(version);
-        let task_id = &t.time_interval_task_id;
-        let task_config = t.leader.unchecked_get_task_config(task_id).await;
-
-        // Send a request with the wrong DAP version.
-        let report = t.gen_test_report(task_id).await;
-        let mut req = t.gen_test_upload_req(report, task_id).await;
-        req.version = DapVersion::Unknown;
-        req.url = task_config.leader_url.join("upload").unwrap();
-
-        let err = t.leader.handle_upload_req(&req).await.unwrap_err();
-        assert_matches!(err, DapAbort::BadRequest(details) => assert_eq!(details, "DAP version of request is not recognized"));
-    }
-
-    async_test_versions! { http_post_fail_unknown_version }
-
     async fn handle_upload_req(version: DapVersion) {
         let t = Test::new(version);
         let task_id = &t.time_interval_task_id;
@@ -1742,7 +1724,6 @@ mod test {
         let agg_job_req_count = match version {
             DapVersion::Draft02 => 2,
             DapVersion::Draft07 => 1,
-            _ => panic!("unhandled version {version:?}"),
         };
 
         assert_metrics_include!(t.helper_registry, {
@@ -1784,7 +1765,6 @@ mod test {
         let agg_job_req_count = match version {
             DapVersion::Draft02 => 2,
             DapVersion::Draft07 => 1,
-            _ => panic!("unhandled version {version:?}"),
         };
 
         assert_metrics_include!(t.helper_registry, {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -135,7 +135,6 @@ impl<'req> EarlyReportStateConsumed<'req> {
         let input_share_text = match task_config.version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
             DapVersion::Draft07 => CTX_INPUT_SHARE_DRAFT07,
-            _ => return Err(unimplemented_version()),
         };
         let n: usize = input_share_text.len();
         let mut info = Vec::new();
@@ -180,7 +179,6 @@ impl<'req> EarlyReportStateConsumed<'req> {
                     })
                 }
             },
-            _ => return Err(unimplemented_version()),
         };
 
         Ok(Self::Ready {
@@ -497,14 +495,6 @@ impl Encode for VdafAggregateShare {
     }
 }
 
-fn unimplemented_version_abort() -> DapAbort {
-    DapAbort::BadRequest("unimplemented version".to_string())
-}
-
-fn unimplemented_version() -> DapError {
-    DapError::Abort(unimplemented_version_abort())
-}
-
 impl VdafConfig {
     /// Parse a verification key from raw bytes.
     pub fn get_decoded_verify_key(&self, bytes: &[u8]) -> Result<VdafVerifyKey, DapError> {
@@ -624,7 +614,6 @@ impl VdafConfig {
         let input_share_text = match version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
             DapVersion::Draft07 => CTX_INPUT_SHARE_DRAFT07,
-            _ => return Err(unimplemented_version()),
         };
         let n: usize = input_share_text.len();
         let mut info = Vec::new();
@@ -789,7 +778,6 @@ impl VdafConfig {
                             None,
                             Some(message.get_encoded_with_param(&task_config.version)),
                         ),
-                        v => unreachable!("unhandled version {v:?}"),
                     };
 
                     states.push(AggregationJobReportState {
@@ -914,7 +902,6 @@ impl VdafConfig {
                 agg_job_init_req,
                 metrics,
             ),
-            v => unreachable!("unhandled version {v:?}"),
         }
     }
 
@@ -1091,7 +1078,6 @@ impl VdafConfig {
             DapVersion::Draft07 => {
                 self.draft07_handle_agg_job_resp(task_id, task_config, state, agg_job_resp, metrics)
             }
-            v => unreachable!("unhandled version {v:?}"),
         }
     }
 
@@ -1552,7 +1538,6 @@ impl VdafConfig {
         let agg_share_text = match version {
             DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
             DapVersion::Draft07 => CTX_AGG_SHARE_DRAFT07,
-            _ => return Err(unimplemented_version()),
         };
         let n: usize = agg_share_text.len();
         let mut info = Vec::new();
@@ -1614,7 +1599,6 @@ fn produce_encrypted_agg_share(
     let agg_share_text = match version {
         DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
         DapVersion::Draft07 => CTX_AGG_SHARE_DRAFT07,
-        _ => return Err(unimplemented_version_abort()),
     };
     let n: usize = agg_share_text.len();
     let mut info = Vec::new();

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -24,7 +24,6 @@ chrono = { version = "0.4.31", default-features = false, features = ["clock", "w
 daphne = { path = "../daphne" }
 futures.workspace = true
 hex.workspace = true
-matchit.workspace = true
 once_cell = "1.18.0"
 prio.workspace = true
 prometheus.workspace = true

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -49,7 +49,6 @@ impl PendingReport {
         match self.version {
             DapVersion::Draft02 if self.report_hex.len() >= 96 => Some(&self.report_hex[64..96]),
             DapVersion::Draft07 if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
-            DapVersion::Unknown => unreachable!("unhandled version {:?}", self.version),
             _ => None,
         }
     }

--- a/daphne_worker/src/router/aggregator.rs
+++ b/daphne_worker/src/router/aggregator.rs
@@ -8,7 +8,10 @@ use super::{dap_response_to_worker, DapRouter};
 pub(super) fn add_aggregator_routes(router: DapRouter<'_>) -> DapRouter<'_> {
     router.get_async("/:version/hpke_config", |req, ctx| async move {
         let daph = ctx.data.handler(&ctx.env);
-        let req = daph.worker_request_to_dap(req, &ctx).await?;
+        let req = match daph.worker_request_to_dap(req, &ctx).await {
+            Ok(req) => req,
+            Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+        };
 
         let span = info_span_from_dap_request!("hpke_config", req);
 

--- a/daphne_worker/src/router/helper.rs
+++ b/daphne_worker/src/router/helper.rs
@@ -33,7 +33,10 @@ async fn handle_agg_job(
     ctx: RouteContext<&DaphneWorkerRequestState<'_>>,
 ) -> Result<Response> {
     let daph = ctx.data.handler(&ctx.env);
-    let req = daph.worker_request_to_dap(req, &ctx).await?;
+    let req = match daph.worker_request_to_dap(req, &ctx).await {
+        Ok(req) => req,
+        Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+    };
 
     let span = match req.media_type {
         DapMediaType::AggregationJobInitReq => {
@@ -56,7 +59,10 @@ async fn handle_agg_share_req(
     ctx: RouteContext<&DaphneWorkerRequestState<'_>>,
 ) -> Result<Response> {
     let daph = ctx.data.handler(&ctx.env);
-    let req = daph.worker_request_to_dap(req, &ctx).await?;
+    let req = match daph.worker_request_to_dap(req, &ctx).await {
+        Ok(req) => req,
+        Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+    };
 
     let span = info_span_from_dap_request!(MeasuredSpanName::AggregateShares.as_str(), req);
 

--- a/daphne_worker/src/router/leader.rs
+++ b/daphne_worker/src/router/leader.rs
@@ -6,23 +6,47 @@ use daphne::{
     error::DapAbort,
     messages::{CollectionJobId, TaskId},
     roles::DapLeader,
-    DapCollectJob, DapResponse, DapVersion,
+    DapCollectJob, DapRequest, DapResponse, DapVersion,
 };
 use prio::codec::ParameterizedEncode;
 use tracing::{info_span, Instrument};
-use worker::{Headers, Request, Response, Result, RouteContext};
+use worker::{Headers, Response, Result};
 
-use crate::{config::DaphneWorkerRequestState, info_span_from_dap_request};
+use crate::{auth::DaphneWorkerAuth, config::DaphneWorker, info_span_from_dap_request};
 
 use super::{dap_response_to_worker, DapRouter};
 
 pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
     router
-        .post_async("/v02/upload", put_report_into_task) // draft02
-        .put_async("/:version/tasks/:task_id/reports", put_report_into_task)
-        .post_async("/v02/collect", |req, ctx| async move {
+        .post_async("/:version/upload", |req, ctx| async move {
             let daph = ctx.data.handler(&ctx.env);
-            let req = daph.worker_request_to_dap(req, &ctx).await?;
+            let req = match daph.worker_request_to_dap(req, &ctx).await {
+                Ok(req) => req,
+                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+            };
+            if req.version != DapVersion::Draft02 {
+                return Response::error("not implemented", 404);
+            }
+            put_report_into_task(req, daph).await
+        }) // draft02
+        .put_async("/:version/tasks/:task_id/reports", |req, ctx| async move {
+            let daph = ctx.data.handler(&ctx.env);
+            let req = match daph.worker_request_to_dap(req, &ctx).await {
+                Ok(req) => req,
+                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+            };
+            put_report_into_task(req, daph).await
+        })
+        .post_async("/:version/collect", |req, ctx| async move {
+            let daph = ctx.data.handler(&ctx.env);
+            let req = match daph.worker_request_to_dap(req, &ctx).await {
+                Ok(req) => req,
+                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+            };
+
+            if req.version != DapVersion::Draft02 {
+                return Response::error("not implemented", 404);
+            }
 
             let span = info_span_from_dap_request!("collect", req);
 
@@ -39,8 +63,13 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             }
         }) // draft02
         .get_async(
-            "/v02/collect/task/:task_id/req/:collect_id",
-            |req, ctx| async move {
+            "/:version/collect/task/:task_id/req/:collect_id",
+            |_, ctx| async move {
+                let version = DaphneWorker::parse_version_param(&ctx)
+                    .map_err(|e| worker::Error::RustError(e.to_string()))?;
+                if version != DapVersion::Draft02 {
+                    return Response::error("not implemented", 404);
+                }
                 let task_id = match ctx.param("task_id").and_then(TaskId::try_from_base64url) {
                     Some(id) => id,
                     None => {
@@ -61,7 +90,6 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                     }
                 };
                 let daph = ctx.data.handler(&ctx.env);
-                let version = daph.extract_version_parameter(&req)?;
                 match daph
                     .poll_collect_job(&task_id, &collect_id)
                     .instrument(info_span!("poll_collect_job (draft02)"))
@@ -88,7 +116,10 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             "/:version/tasks/:task_id/collection_jobs/:collect_job_id",
             |req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
-                let req = daph.worker_request_to_dap(req, &ctx).await?;
+                let req = match daph.worker_request_to_dap(req, &ctx).await {
+                    Ok(req) => req,
+                    Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                };
 
                 let span = info_span_from_dap_request!("collect (PUT)", req);
 
@@ -102,7 +133,10 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             "/:version/tasks/:task_id/collection_jobs/:collect_job_id",
             |req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
-                let req = daph.worker_request_to_dap(req, &ctx).await?;
+                let req = match daph.worker_request_to_dap(req, &ctx).await {
+                    Ok(req) => req,
+                    Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                };
                 let task_id = match req.task_id() {
                     Ok(id) => id,
                     Err(e) => return daph.state.dap_abort_to_worker_response(e),
@@ -155,12 +189,9 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
 }
 
 async fn put_report_into_task(
-    req: Request,
-    ctx: RouteContext<&DaphneWorkerRequestState<'_>>,
+    req: DapRequest<DaphneWorkerAuth>,
+    daph: DaphneWorker<'_>,
 ) -> Result<Response> {
-    let daph = ctx.data.handler(&ctx.env);
-    let req = daph.worker_request_to_dap(req, &ctx).await?;
-
     let span = info_span_from_dap_request!("upload", req);
 
     match daph.handle_upload_req(&req).instrument(span).await {

--- a/daphne_worker/src/router/test_routes.rs
+++ b/daphne_worker/src/router/test_routes.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use tracing::{debug, info_span, Instrument};
 use worker::{Response, Url};
 
-use crate::DaphneWorkerReportSelector;
+use crate::{config::DaphneWorker, DaphneWorkerReportSelector};
 
 use super::{DapRouter, Role};
 
@@ -94,7 +94,8 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
             |mut req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
                 let cmd: InternalTestEndpointForTask = req.json().await?;
-                let version = daph.extract_version_parameter(&req)?;
+                let version = DaphneWorker::parse_version_param(&ctx)
+                    .map_err(|e| worker::Error::RustError(e.to_string()))?;
                 daph.internal_endpoint_for_task(version, cmd)
                     .instrument(info_span!("endpoint_for_task"))
                     .await
@@ -115,7 +116,8 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
             |mut req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
                 let cmd: InternalTestAddTask = req.json().await?;
-                let version = daph.extract_version_parameter(&req)?;
+                let version = DaphneWorker::parse_version_param(&ctx)
+                    .map_err(|e| worker::Error::RustError(e.to_string()))?;
                 daph.internal_add_task(version, cmd)
                     .instrument(info_span!("add_task"))
                     .await?;
@@ -129,7 +131,8 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
             |mut req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
                 let hpke: HpkeReceiverConfig = req.json().await?;
-                let version = daph.extract_version_parameter(&req)?;
+                let version = DaphneWorker::parse_version_param(&ctx)
+                    .map_err(|e| worker::Error::RustError(e.to_string()))?;
                 daph.internal_add_hpke_config(version, hpke)
                     .instrument(info_span!("add_hpke_config"))
                     .await?;

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -300,7 +300,6 @@ async fn leader_upload(version: DapVersion) {
     let builder = match t.version {
         DapVersion::Draft02 => client.post(url.as_str()),
         DapVersion::Draft07 => client.put(url.as_str()),
-        _ => unreachable!("unhandled version {}", t.version),
     };
     let resp = builder
         .body(

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -80,7 +80,6 @@ impl TestRunner {
         let version_path = match version {
             DapVersion::Draft02 => "v02",
             DapVersion::Draft07 => "v07",
-            _ => panic!("unimplemented DapVersion"),
         };
         let mut leader_url = Url::parse(&format!("http://leader:8787/{}/", version_path)).unwrap();
         let mut helper_url = Url::parse(&format!("http://helper:8788/{}/", version_path)).unwrap();
@@ -680,7 +679,6 @@ impl TestRunner {
         match self.version {
             DapVersion::Draft02 => "upload".to_string(),
             DapVersion::Draft07 => format!("tasks/{}/reports", id.to_base64url()),
-            _ => unreachable!("unknown version"),
         }
     }
 


### PR DESCRIPTION
The code is littered with `unrecheable` and `panic` because it assumes one has checked the dap version before but we can just avoid this bug altogether if we don't have `DapVersion::Unknown`!

Also I think our error types might need a bit of a redesign but I'm not sure yet what that could be, but I found our current error types very annoying to work with, specially in the third commit of this PR.