### PR TITLE
Remove unecessary Cow's from the codebase

### DIFF
--- a/daphne/src/error/aborts.rs
+++ b/daphne/src/error/aborts.rs
@@ -190,7 +190,7 @@ impl DapAbort {
                 "The batch indicated by the request: {}",
                 serde_json::to_string(batch_sel).expect("failed to JSON-encode the batch selector while constructing a \"batchOverlap\" abort"),
             ),
-            task_id: task_id.clone(),
+            task_id: *task_id,
         }
     }
 
@@ -202,7 +202,7 @@ impl DapAbort {
     ) -> Self {
         Self::QueryMismatch {
             detail: format!("The task's query type is \"{query_type_for_task}\", but the request indicates \"{query_type_for_request}\"."),
-            task_id: task_id.clone(),
+            task_id: *task_id,
         }
     }
 

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -39,7 +39,9 @@ const EXTENSION_TASKPROV: u16 = 0xff00;
 macro_rules! id_struct {
     ($sname:ident, $len:expr, $doc:expr) => {
         #[doc=$doc]
-        #[derive(Clone, Default, Deserialize, Hash, PartialEq, Eq, Serialize, PartialOrd, Ord)]
+        #[derive(
+            Copy, Clone, Default, Deserialize, Hash, PartialEq, Eq, Serialize, PartialOrd, Ord,
+        )]
         #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
         pub struct $sname(#[serde(with = "hex")] pub [u8; $len]);
 
@@ -107,7 +109,7 @@ impl TaskId {
     /// request payload; in draft07, the task ID is included in the HTTP request path.
     pub fn for_request_payload(&self, version: &DapVersion) -> Option<TaskId> {
         match version {
-            DapVersion::Draft02 => Some(self.clone()),
+            DapVersion::Draft02 => Some(*self),
             DapVersion::Draft07 => None,
         }
     }

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -114,7 +114,7 @@ pub(crate) fn compute_vdaf_verify_key(
 fn malformed_task_config(task_id: &TaskId, detail: String) -> DapError {
     DapError::Abort(DapAbort::InvalidTask {
         detail,
-        task_id: task_id.clone(),
+        task_id: *task_id,
     })
 }
 
@@ -201,7 +201,7 @@ fn get_taskprov_task_config<S>(
 
     // Return unrecognizedMessage if parsing fails following section 5.1 of the taskprov draft.
     let task_config = TaskConfig::get_decoded_with_param(&taskprov_version, taskprov_data.as_ref())
-        .map_err(|e| DapAbort::from_codec_error(e, task_id.clone()))?;
+        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     Ok(Some(task_config))
 }
@@ -388,7 +388,7 @@ mod test {
 
         let from_request_header = resolve_advertised_task_config(
             &DapRequest::<BearerToken> {
-                task_id: Some(task_id.clone()),
+                task_id: Some(task_id),
                 taskprov: Some(taskprov_task_config_base64url),
                 ..Default::default()
             },
@@ -403,7 +403,7 @@ mod test {
 
         let from_report_metadata = resolve_advertised_task_config(
             &DapRequest::<BearerToken> {
-                task_id: Some(task_id.clone()),
+                task_id: Some(task_id),
                 ..Default::default()
             },
             taskprov_version,
@@ -487,7 +487,7 @@ mod test {
             let req = DapRequest::<()> {
                 version,
                 media_type: DapMediaType::Missing, // ignored by test
-                task_id: Some(task_id.clone()),
+                task_id: Some(task_id),
                 resource: DapResource::Undefined, // ignored by test
                 payload: Vec::default(),          // ignored by test
                 url: Url::parse("https://example.com/").unwrap(), // ignored by test

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -92,10 +92,10 @@ impl DapReportInitializer for AggregationJobTest {
             .into_iter()
             .map(|consumed| {
                 if reports_processed.contains(&consumed.metadata().id) {
-                    Ok(EarlyReportStateInitialized::Rejected {
-                        metadata: Cow::Owned(consumed.metadata().clone()),
-                        failure: TransitionFailure::ReportReplayed,
-                    })
+                    Ok(
+                        consumed
+                            .into_initialized_rejected_due_to(TransitionFailure::ReportReplayed),
+                    )
                 } else {
                     reports_processed.insert(consumed.metadata().id);
                     EarlyReportStateInitialized::initialize(
@@ -950,10 +950,7 @@ impl DapReportInitializer for MockAggregator {
             .into_iter()
             .map(|consumed| {
                 if let Some(failure) = early_fails.get(&consumed.metadata().id) {
-                    Ok(EarlyReportStateInitialized::Rejected {
-                        metadata: Cow::Owned(consumed.metadata().clone()),
-                        failure: *failure,
-                    })
+                    Ok(consumed.into_initialized_rejected_due_to(*failure))
                 } else {
                     EarlyReportStateInitialized::initialize(
                         is_leader,

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -161,7 +161,7 @@ impl LeaderBatchQueue {
                 };
 
                 let mut batch_assignments = vec![BatchCount {
-                    batch_id: curr.batch_id.clone(),
+                    batch_id: curr.batch_id,
                     report_count: 0,
                 }];
 

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -110,7 +110,7 @@ impl LeaderCollectionJobQueue {
                 let collect_queue_req: CollectQueueRequest = req_parse(&mut req).await?;
                 let collection_job_id: CollectionJobId =
                     if let Some(cid) = &collect_queue_req.collect_job_id {
-                        cid.clone()
+                        *cid
                     } else {
                         // draft02 legacy: Compute the collect job ID, used to derive the collect
                         // URI for this request. This value is computed by applying a pseudorandom
@@ -148,7 +148,7 @@ impl LeaderCollectionJobQueue {
                         &self.state,
                         (
                             collect_queue_req.task_id,
-                            collection_job_id.clone(),
+                            collection_job_id,
                             collect_queue_req.collect_req,
                         ),
                         PENDING_PREFIX,

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -117,7 +117,7 @@ impl ReportsProcessed {
                     })
                     .buffer_unordered(usize::MAX)
                     .try_filter_map(|replay| ready(Ok(replay)))
-                    .try_collect::<Vec<_>>()
+                    .try_collect::<Vec<&ReportId>>()
                     .await?;
 
                 Response::from_json(&replays)
@@ -145,7 +145,7 @@ impl ReportsProcessed {
                             .await?
                             {
                                 if exists {
-                                    return Result::Ok(Some(consumed_report.metadata().id.clone()));
+                                    return Result::Ok(Some(consumed_report.metadata().id));
                                 }
                             }
                             Ok(None)

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -159,10 +159,9 @@ impl ReportsProcessed {
                     .into_iter()
                     .map(|consumed_report| {
                         if replayed_reports.contains(&consumed_report.metadata().id) {
-                            Ok(EarlyReportStateInitialized::Rejected {
-                                metadata: Cow::Owned(consumed_report.metadata().clone()),
-                                failure: TransitionFailure::ReportReplayed,
-                            })
+                            Ok(consumed_report.into_initialized_rejected_due_to(
+                                TransitionFailure::ReportReplayed,
+                            ))
                         } else {
                             EarlyReportStateInitialized::initialize(
                                 reports_processed_request.is_leader,

--- a/daphne_worker/src/roles/helper.rs
+++ b/daphne_worker/src/roles/helper.rs
@@ -66,7 +66,7 @@ impl<'srv> DapHelper<DaphneWorkerAuth> for DaphneWorker<'srv> {
         match res {
             Some(helper_state_hex) => {
                 let data = hex::decode(helper_state_hex)
-                    .map_err(|e| DapAbort::from_hex_error(e, task_id.clone()))?;
+                    .map_err(|e| DapAbort::from_hex_error(e, *task_id))?;
                 let helper_state =
                     DapAggregationJobState::get_decoded(&task_config.as_ref().vdaf, &data)?;
                 Ok(Some(helper_state))


### PR DESCRIPTION
For all types `T` a `Cow<'_, T>'` takes up more space than a `T`. As such, if
the `T` contains no heap allocations using `Cow` is usually a pessimisation
instead of an optimization.

If copies should be avoided for a type a normal reference is the best approach.
