### PR TITLE
Fix warnings provided by clippy::pendantic

### DIFF
--- a/daphne/benches/aggregation.rs
+++ b/daphne/benches/aggregation.rs
@@ -30,9 +30,7 @@ fn handle_agg_job_init_req(c: &mut Criterion) {
             VdafConfig::Prio2 { dimension },
             DapMeasurement::U32Vec(vec![1; dimension]),
         ),
-    ]
-    .into_iter()
-    {
+    ] {
         let agg_job_test =
             AggregationJobTest::new(&vdaf, HpkeKemId::X25519HkdfSha256, DapVersion::Draft02);
 

--- a/daphne/benches/aggregation.rs
+++ b/daphne/benches/aggregation.rs
@@ -49,7 +49,7 @@ fn handle_agg_job_init_req(c: &mut Criterion) {
         c.bench_function(&format!("handle_agg_job_init_req {vdaf}"), |b| {
             b.to_async(&rt).iter(|| async {
                 black_box(agg_job_test.handle_agg_job_init_req(&agg_job_init_req)).await
-            })
+            });
         });
     }
 }

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -118,7 +118,6 @@ impl DapMediaType {
             (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
             }
-            (_, Self::Draft02AggregateContinueResp) => None,
             (DapVersion::Draft02 | DapVersion::Draft07, Self::AggregateShareReq) => {
                 Some(MEDIA_TYPE_AGG_SHARE_REQ)
             }
@@ -132,8 +131,8 @@ impl DapMediaType {
             (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
             (DapVersion::Draft07, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
             (DapVersion::Draft02 | DapVersion::Draft07, Self::Report) => Some(MEDIA_TYPE_REPORT),
+            (_, Self::Draft02AggregateContinueResp | Self::Missing) => None,
             (_, Self::Invalid(ref content_type)) => Some(content_type),
-            (_, Self::Missing) => None,
         }
     }
 

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -137,7 +137,7 @@ impl DapMediaType {
     }
 
     /// draft02 compatibility: Construct the media type for the response to an
-    /// AggregatecontinueResp. This various depending upon the version used.
+    /// `AggregatecontinueResp`. This various depending upon the version used.
     pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
         match version {
             DapVersion::Draft02 => Self::Draft02AggregateContinueResp,

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -86,12 +86,13 @@ impl DapMediaType {
             | (DapVersion::Draft07, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG))
             | (DapVersion::Draft07, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
-            (DapVersion::Draft02, Some(MEDIA_TYPE_AGG_SHARE_REQ))
-            | (DapVersion::Draft07, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => Self::AggregateShareReq,
-            (DapVersion::Draft02, Some(MEDIA_TYPE_COLLECT_REQ))
-            | (DapVersion::Draft07, Some(MEDIA_TYPE_COLLECT_REQ)) => Self::CollectReq,
-            (DapVersion::Draft02, Some(MEDIA_TYPE_REPORT))
-            | (DapVersion::Draft07, Some(MEDIA_TYPE_REPORT)) => Self::Report,
+            (DapVersion::Draft02 | DapVersion::Draft07, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => {
+                Self::AggregateShareReq
+            }
+            (DapVersion::Draft02 | DapVersion::Draft07, Some(MEDIA_TYPE_COLLECT_REQ)) => {
+                Self::CollectReq
+            }
+            (DapVersion::Draft02 | DapVersion::Draft07, Some(MEDIA_TYPE_REPORT)) => Self::Report,
             (_, Some(content_type)) => Self::Invalid(content_type.to_string()),
             (_, None) => Self::Missing,
         }
@@ -118,20 +119,19 @@ impl DapMediaType {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
             }
             (_, Self::Draft02AggregateContinueResp) => None,
-            (DapVersion::Draft02, Self::AggregateShareReq)
-            | (DapVersion::Draft07, Self::AggregateShareReq) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
+            (DapVersion::Draft02 | DapVersion::Draft07, Self::AggregateShareReq) => {
+                Some(MEDIA_TYPE_AGG_SHARE_REQ)
+            }
             (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
             (DapVersion::Draft07, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
-            (DapVersion::Draft02, Self::CollectReq) | (DapVersion::Draft07, Self::CollectReq) => {
+            (DapVersion::Draft02 | DapVersion::Draft07, Self::CollectReq) => {
                 Some(MEDIA_TYPE_COLLECT_REQ)
             }
             (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
             (DapVersion::Draft07, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
             (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
             (DapVersion::Draft07, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
-            (DapVersion::Draft02, Self::Report) | (DapVersion::Draft07, Self::Report) => {
-                Some(MEDIA_TYPE_REPORT)
-            }
+            (DapVersion::Draft02 | DapVersion::Draft07, Self::Report) => Some(MEDIA_TYPE_REPORT),
             (_, Self::Invalid(ref content_type)) => Some(content_type),
             (_, Self::Missing) => None,
         }

--- a/daphne/src/error/aborts.rs
+++ b/daphne/src/error/aborts.rs
@@ -110,7 +110,7 @@ pub enum DapAbort {
 
 impl DapAbort {
     /// Construct a problem details JSON object for this abort. `url` is the URL to which the
-    /// request was targeted and `task_id` is the associated TaskID.
+    /// request was targeted and `task_id` is the associated `TaskID`.
     pub fn into_problem_details(self) -> ProblemDetails {
         let (title, typ) = self.title_and_type();
         let (task_id, detail, agg_job_id_base64url) = match self {

--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -55,10 +55,11 @@ fn check_suite<T: HpkeCrypto>(
     let kdf = KdfAlgorithm::try_from(u16::from(kdf_id)).map_err(maperr)?;
     let aead = AeadAlgorithm::try_from(u16::from(aead_id)).map_err(maperr)?;
     match (kem, kdf, aead) {
-        (KemAlgorithm::DhKemP256, KdfAlgorithm::HkdfSha256, AeadAlgorithm::Aes128Gcm)
-        | (KemAlgorithm::DhKem25519, KdfAlgorithm::HkdfSha256, AeadAlgorithm::Aes128Gcm) => {
-            Ok(Hpke::new(Mode::Base, kem, kdf, aead))
-        }
+        (
+            KemAlgorithm::DhKemP256 | KemAlgorithm::DhKem25519,
+            KdfAlgorithm::HkdfSha256,
+            AeadAlgorithm::Aes128Gcm,
+        ) => Ok(Hpke::new(Mode::Base, kem, kdf, aead)),
         _ => Err(fatal_error!(err = s)),
     }
 }

--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -233,7 +233,7 @@ pub trait HpkeDecrypter {
     ) -> Result<Vec<u8>, DapError>;
 }
 
-/// Struct that combines HpkeConfig and HpkeSecretKey
+/// Struct that combines `HpkeConfig` and `HpkeSecretKey`
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct HpkeReceiverConfig {
     pub config: HpkeConfig,
@@ -309,8 +309,8 @@ impl HpkeReceiverConfig {
 
 impl TryFrom<(HpkeConfig, HpkePrivateKey)> for HpkeReceiverConfig {
     type Error = DapError;
-    /// Create a new HPKE receiver context given an HpkeConfig and a corresponding private key.
-    /// Returns an error if the public key does not correspond to the private_key.
+    /// Create a new HPKE receiver context given an `HpkeConfig` and a corresponding private key.
+    /// Returns an error if the public key does not correspond to the `private_key`.
     fn try_from((config, private_key): (HpkeConfig, HpkePrivateKey)) -> Result<Self, Self::Error> {
         let kem_id_u16: u16 = config.kem_id.into();
         let kem_id: KemAlgorithm = kem_id_u16.try_into().unwrap();

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -318,7 +318,7 @@ impl DapAggregateSpan<DapAggregateShare> {
 
     /// Merge the span with another.
     pub fn merge(&mut self, other: Self) -> Result<(), DapError> {
-        for (bucket, (other_agg_share, mut other_reports)) in other.into_iter() {
+        for (bucket, (other_agg_share, mut other_reports)) in other {
             let (agg_share, reports) = self.span.entry(bucket).or_default();
             agg_share.merge(other_agg_share)?;
             reports.append(&mut other_reports);

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -3,6 +3,21 @@
 
 #![warn(unused_crate_dependencies)]
 #![warn(rustdoc::broken_intra_doc_links)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::if_not_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::redundant_closure_for_method_calls)]
+#![allow(clippy::inconsistent_struct_constructor)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::inline_always)]
 
 //! This crate implements the core protocol logic for the Distributed Aggregation Protocol
 //! ([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard under development in the

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1022,7 +1022,7 @@ pub enum MetaAggregationJobId {
 
 impl MetaAggregationJobId {
     /// Generate a random ID of the type required for the version.
-    pub(crate) fn gen_for_version(version: &DapVersion) -> Self {
+    pub(crate) fn gen_for_version(version: DapVersion) -> Self {
         let mut rng = thread_rng();
         match version {
             DapVersion::Draft02 => Self::Draft02(Draft02AggregationJobId(rng.gen())),

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -456,13 +456,13 @@ impl DapTaskConfig {
         }
     }
 
-    /// Return the greatest multiple of the time_precision which is less than or equal to the
+    /// Return the greatest multiple of the `time_precision` which is less than or equal to the
     /// specified time.
     pub fn quantized_time_lower_bound(&self, time: Time) -> Time {
         time - (time % self.time_precision)
     }
 
-    /// Return the least multiple of the time_precision which is greater than the specified time.
+    /// Return the least multiple of the `time_precision` which is greater than the specified time.
     pub fn quantized_time_upper_bound(&self, time: Time) -> Time {
         self.quantized_time_lower_bound(time) + self.time_precision
     }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -614,7 +614,7 @@ pub struct DapAggregationJobUncommitted {
 impl Encode for DapAggregationJobState {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.part_batch_sel.encode(bytes);
-        for report_state in self.seq.iter() {
+        for report_state in &self.seq {
             if report_state.draft02_prep_share.is_some() {
                 // draft02 compatibility: The prep share is kept in this data structure for
                 // backwards compatibility. It's only used by the Leader, so we don't ever expect

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -357,7 +357,7 @@ impl<T> Extend<(DapBatchBucket, (T, Vec<(ReportId, Time)>))> for DapAggregateSpa
     where
         I: IntoIterator<Item = (DapBatchBucket, (T, Vec<(ReportId, Time)>))>,
     {
-        self.span.extend(iter)
+        self.span.extend(iter);
     }
 }
 

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -200,7 +200,7 @@ impl ParameterizedDecode<DapVersion> for ReportMetadata {
             time: Time::decode(bytes)?,
             extensions: match version {
                 DapVersion::Draft02 => decode_u16_items(&(), bytes)?,
-                _ => Vec::new(),
+                DapVersion::Draft07 => Vec::new(),
             },
         };
         // Check for duplicate extensions and unknown extensions.

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -1232,7 +1232,7 @@ mod test {
             draft02_task_id: task_id_for_version(version),
             report_metadata: ReportMetadata {
                 id: ReportId([23; 16]),
-                time: 1637364244,
+                time: 1_637_364_244,
                 extensions: vec![],
             },
             public_share: b"public share".to_vec(),
@@ -1264,7 +1264,7 @@ mod test {
             draft02_task_id: task_id_for_version(DapVersion::Draft02),
             report_metadata: ReportMetadata {
                 id: ReportId([23; 16]),
-                time: 1637364244,
+                time: 1_637_364_244,
                 extensions: vec![Extension::Unhandled {
                     typ: 0xfff,
                     payload: b"some extension".to_vec(),
@@ -1325,7 +1325,7 @@ mod test {
                         report_share: ReportShare {
                             report_metadata: ReportMetadata {
                                 id: ReportId([99; 16]),
-                                time: 1637361337,
+                                time: 1_637_361_337,
                                 extensions: Vec::default(),
                             },
                             public_share: b"public share".to_vec(),
@@ -1341,7 +1341,7 @@ mod test {
                         report_share: ReportShare {
                             report_metadata: ReportMetadata {
                                 id: ReportId([17; 16]),
-                                time: 163736423,
+                                time: 163_736_423,
                                 extensions: Vec::default(),
                             },
                             public_share: b"public share".to_vec(),
@@ -1372,7 +1372,7 @@ mod test {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([99; 16]),
-                            time: 1637361337,
+                            time: 1_637_361_337,
                             extensions: Vec::default(),
                         },
                         public_share: b"public share".to_vec(),
@@ -1388,7 +1388,7 @@ mod test {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([17; 16]),
-                            time: 163736423,
+                            time: 163_736_423,
                             extensions: Vec::default(),
                         },
                         public_share: b"public share".to_vec(),
@@ -1422,7 +1422,7 @@ mod test {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([99; 16]),
-                            time: 1637361337,
+                            time: 1_637_361_337,
                             extensions: Vec::default(),
                         },
                         public_share: b"public share".to_vec(),
@@ -1438,7 +1438,7 @@ mod test {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([17; 16]),
-                            time: 163736423,
+                            time: 163_736_423,
                             extensions: Vec::default(),
                         },
                         public_share: b"public share".to_vec(),

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -769,9 +769,10 @@ impl ParameterizedEncode<DapVersion> for Query {
                 batch_id.encode(bytes);
             }
             Self::FixedSizeCurrentBatch => {
-                if *version == DapVersion::Draft02 {
-                    panic!("tried to encode a Query or BatchSelector fixed size current batch in DAP 02");
-                }
+                assert!(
+                    !(*version == DapVersion::Draft02),
+                    "tried to encode a Query or BatchSelector fixed size current batch in DAP 02"
+                );
                 QUERY_TYPE_FIXED_SIZE.encode(bytes);
                 FIXED_SIZE_QUERY_TYPE_CURRENT_BATCH.encode(bytes);
             }

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -413,7 +413,7 @@ impl TryFrom<Query> for BatchSelector {
     }
 }
 
-/// The PrepareInit message consisting of the report share and the Leader's initial prep share.
+/// The `PrepareInit` message consisting of the report share and the Leader's initial prep share.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrepareInit {
     pub report_share: ReportShare,

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
 // VDAF type codes.
-const VDAF_TYPE_PRIO2: u32 = 0xFFFF0000;
+const VDAF_TYPE_PRIO2: u32 = 0xFFFF_0000;
 
 // Differential privacy mechanism types.
 const DP_MECHANISM_NONE: u8 = 0x01;

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -158,7 +158,7 @@ impl Decode for UrlBytes {
     }
 }
 
-/// A QueryConfig type and its associated task configuration data.
+/// A `QueryConfig` type and its associated task configuration data.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum QueryConfigVar {
     TimeInterval,

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -146,7 +146,7 @@ pub struct UrlBytes {
 
 impl Encode for UrlBytes {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        encode_u16_bytes(bytes, &self.bytes)
+        encode_u16_bytes(bytes, &self.bytes);
     }
 }
 

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -36,7 +36,7 @@ impl KeyType for VdafType {
     fn len(&self) -> usize {
         match self {
             VdafType::Prio2 => VDAF_VERIFY_KEY_SIZE_PRIO2,
-            _ => panic!("tried to get key length for undefined VDAF"),
+            VdafType::NotImplemented(_) => panic!("tried to get key length for undefined VDAF"),
         }
     }
 }

--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -31,6 +31,7 @@ impl DaphneMetrics {
     /// Register Daphne metrics with the specified registry. If a prefix is provided, then
     /// "{prefix_}" is prepended to the name.
     pub fn register(registry: &Registry) -> Result<Self, DapError> {
+        #[allow(clippy::ignored_unit_patterns)]
         let inbound_request_counter = register_int_counter_vec_with_registry!(
             "inbound_request_counter",
             "Total number of successful inbound requests.",
@@ -39,6 +40,7 @@ impl DaphneMetrics {
         )
         .map_err(|e| fatal_error!(err = ?e, "failed to regsiter inbound_request_counter"))?;
 
+        #[allow(clippy::ignored_unit_patterns)]
         let report_counter = register_int_counter_vec_with_registry!(
             "report_counter",
             "Total number reports rejected, aggregated, and collected.",
@@ -47,6 +49,7 @@ impl DaphneMetrics {
         )
         .map_err(|e| fatal_error!(err = ?e, "failed to register report_counter"))?;
 
+        #[allow(clippy::ignored_unit_patterns)]
         let aggregation_job_batch_size_histogram = register_histogram_with_registry!(
             "aggregation_job_batch_size",
             "Number of records in an incoming AggregationJobInitReq.",
@@ -57,6 +60,7 @@ impl DaphneMetrics {
         )
         .map_err(|e| fatal_error!(err = ?e, "failed to register aggregation_job_batch_size"))?;
 
+        #[allow(clippy::ignored_unit_patterns)]
         let aggregation_job_counter = register_int_counter_vec_with_registry!(
             format!("aggregation_job_counter"),
             "Total number of aggregation jobs started and completed.",
@@ -65,6 +69,7 @@ impl DaphneMetrics {
         )
         .map_err(|e| fatal_error!(err = ?e, "failed to register aggregation_job_counter"))?;
 
+        #[allow(clippy::ignored_unit_patterns)]
         let aggregation_job_put_span_retry_counter =
             register_int_counter_with_registry!(
                 format!("aggregation_job_put_span_retry_counter"),

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -156,7 +156,7 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
                 "failed to parse query parameter as URL-safe Base64".into(),
             ))?;
 
-            id = Some(TaskId(bytes))
+            id = Some(TaskId(bytes));
         }
 
         let hpke_config = self.get_hpke_config_for(req.version, id.as_ref()).await?;

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -261,7 +261,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
 
         for transition in agg_job_resp.transitions.iter() {
             if let TransitionVar::Failed(failure) = &transition.var {
-                metrics.report_inc_by(&format!("rejected_{failure}"), 1)
+                metrics.report_inc_by(&format!("rejected_{failure}"), 1);
             }
         }
 

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -259,7 +259,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
             })
             .await?;
 
-        for transition in agg_job_resp.transitions.iter() {
+        for transition in &agg_job_resp.transitions {
             if let TransitionVar::Failed(failure) = &transition.var {
                 metrics.report_inc_by(&format!("rejected_{failure}"), 1);
             }

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -579,14 +579,14 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
 
         tracing::debug!("RUNNING get_reports");
         // Fetch reports and run an aggregation job for each task.
-        for (task_id, reports) in self.get_reports(selector).await?.into_iter() {
+        for (task_id, reports) in self.get_reports(selector).await? {
             tracing::debug!("RUNNING get_task_config_for {task_id}");
             let task_config = self
                 .get_task_config_for(&task_id)
                 .await?
                 .ok_or(DapAbort::UnrecognizedTask)?;
 
-            for (part_batch_sel, reports) in reports.into_iter() {
+            for (part_batch_sel, reports) in reports {
                 // TODO Consider splitting reports into smaller chunks.
                 // TODO Consider handling tasks in parallel.
                 telem.reports_processed += reports.len() as u64;

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -321,7 +321,7 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         let metrics = self.metrics();
 
         // Prepare AggregationJobInitReq.
-        let agg_job_id = MetaAggregationJobId::gen_for_version(&task_config.version);
+        let agg_job_id = MetaAggregationJobId::gen_for_version(task_config.version);
         let transition = task_config
             .vdaf
             .produce_agg_job_init_req(

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -260,11 +260,11 @@ mod test {
             // Global config. In a real deployment, the Leader and Helper may make different choices
             // here.
             let global_config = DapGlobalConfig {
-                report_storage_epoch_duration: 604800,    // one week
+                report_storage_epoch_duration: 604_800,   // one week
                 report_storage_max_future_time_skew: 300, // 5 minutes
-                max_batch_duration: 360000,
-                min_batch_interval_start: 259200,
-                max_batch_interval_end: 259200,
+                max_batch_duration: 360_000,
+                min_batch_interval_start: 259_200,
+                max_batch_interval_end: 259_200,
                 supported_hpke_kems: vec![HpkeKemId::X25519HkdfSha256],
                 taskprov_version: Some(TaskprovVersion::Draft02),
             };
@@ -1382,7 +1382,7 @@ mod test {
             } else {
                 Some(Interval {
                     start: 0,
-                    duration: 2000000000,
+                    duration: 2_000_000_000,
                 })
             },
             encrypted_agg_shares: Vec::default(),

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -508,7 +508,7 @@ mod test {
                 },
             };
 
-            let agg_job_id = MetaAggregationJobId::gen_for_version(&version);
+            let agg_job_id = MetaAggregationJobId::gen_for_version(version);
 
             let DapLeaderAggregationJobTransition::Continued(_leader_state, agg_job_init_req) =
                 task_config
@@ -757,7 +757,7 @@ mod test {
         let t = Test::new(version);
         let task_id = &t.time_interval_task_id;
         let task_config = t.leader.unchecked_get_task_config(task_id).await;
-        let agg_job_id = MetaAggregationJobId::gen_for_version(&version);
+        let agg_job_id = MetaAggregationJobId::gen_for_version(version);
 
         // Helper expects "time_interval" query, but Leader indicates "fixed_size".
         let req = t
@@ -895,7 +895,7 @@ mod test {
 
     async fn handle_agg_job_cont_req_unauthorized_request(version: DapVersion) {
         let t = Test::new(version);
-        let agg_job_id = MetaAggregationJobId::gen_for_version(&version);
+        let agg_job_id = MetaAggregationJobId::gen_for_version(version);
         let mut req = t
             .gen_test_agg_job_cont_req(&agg_job_id, Vec::default(), version)
             .await;
@@ -1228,7 +1228,7 @@ mod test {
 
     async fn handle_agg_job_req_fail_send_cont_req(version: DapVersion) {
         let t = Test::new(version);
-        let agg_job_id = MetaAggregationJobId::gen_for_version(&version);
+        let agg_job_id = MetaAggregationJobId::gen_for_version(version);
         let req = t
             .gen_test_agg_job_cont_req(&agg_job_id, Vec::default(), version)
             .await;

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -511,7 +511,7 @@ mod test {
             None,
         ) {
             Err(DapError::Abort(DapAbort::UnrecognizedMessage { detail, .. })) => {
-                assert_eq!(detail, "codec error: unexpected value")
+                assert_eq!(detail, "codec error: unexpected value");
             }
             Err(e) => panic!("unexpected error: {e}"),
             Ok(..) => panic!("expected error"),

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -87,12 +87,12 @@ pub(crate) fn expand_prk_into_verify_key(
     }
 }
 
-/// Compute the VDAF verify key for task_id and the specified VDAF type using the
-/// pre-shared secret verify_key_init.
+/// Compute the VDAF verify key for `task_id` and the specified VDAF type using the
+/// pre-shared secret `verify_key_init`.
 ///
-/// This is a convenience function to call compute_vdaf_verify_prk() and
-/// compute_vdaf_verify_key_from_prk(). Callers reusing the same PRK frequently
-/// should consider computing the prk once and then calling compute_vdaf_verify_key_from_prk()
+/// This is a convenience function to call `compute_vdaf_verify_prk`() and
+/// `compute_vdaf_verify_key_from_prk`(). Callers reusing the same PRK frequently
+/// should consider computing the prk once and then calling `compute_vdaf_verify_key_from_prk`()
 /// directly.
 #[allow(dead_code)]
 pub(crate) fn compute_vdaf_verify_key(

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -83,7 +83,7 @@ pub(crate) fn expand_prk_into_verify_key(
             okm.fill(&mut bytes[..]).unwrap();
             VdafVerifyKey::Prio2(bytes)
         }
-        _ => panic!("Unknown VDAF type"),
+        VdafType::NotImplemented(_) => panic!("Unknown VDAF type"),
     }
 }
 
@@ -182,7 +182,7 @@ fn get_taskprov_task_config<S>(
             0 => return Ok(None),
             1 => match &taskprovs[0] {
                 Extension::Taskprov { payload } => Cow::Borrowed(payload),
-                _ => panic!("cannot happen"),
+                Extension::Unhandled { .. } => panic!("cannot happen"),
             },
             _ => {
                 // The decoder already returns an error if an extension of a give type occurs more
@@ -291,7 +291,7 @@ impl ReportMetadata {
     pub fn is_taskprov(&self, version: TaskprovVersion, task_id: &TaskId) -> bool {
         return self.extensions.iter().any(|x| match x {
             Extension::Taskprov { payload } => *task_id == compute_task_id(version, payload),
-            _ => false,
+            Extension::Unhandled { .. } => false,
         });
     }
 }
@@ -344,7 +344,7 @@ mod test {
         ];
         match &vk {
             VdafVerifyKey::Prio2(bytes) => assert_eq!(*bytes, expected),
-            _ => unreachable!(),
+            VdafVerifyKey::Prio3(_) => unreachable!(),
         }
     }
 

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -371,7 +371,7 @@ mod test {
                     max_batch_size: 2048,
                 },
             },
-            task_expiration: 0x6352f9a5,
+            task_expiration: 0x6352_f9a5,
             vdaf_config: VdafConfig {
                 dp_config: DpConfig::None,
                 var: VdafTypeVar::Prio2 { dimension: 10 },

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -183,7 +183,7 @@ impl AggregationJobTest {
     pub fn produce_reports(&self, measurements: Vec<DapMeasurement>) -> Vec<Report> {
         let mut reports = Vec::with_capacity(measurements.len());
 
-        for measurement in measurements.into_iter() {
+        for measurement in measurements {
             reports.push(
                 self.task_config
                     .vdaf

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -1183,12 +1183,10 @@ impl DapHelper<BearerToken> for MockAggregator {
             agg_job_id_owned: agg_job_id.into(),
         };
 
-        let mut helper_state_store_mutex_guard = self
+        let mut helper_state_store = self
             .helper_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-
-        let helper_state_store = helper_state_store_mutex_guard.deref_mut();
 
         if helper_state_store.contains_key(&helper_state_info) {
             return Ok(false);
@@ -1211,12 +1209,10 @@ impl DapHelper<BearerToken> for MockAggregator {
             agg_job_id_owned: agg_job_id.into(),
         };
 
-        let mut helper_state_store_mutex_guard = self
+        let helper_state_store = self
             .helper_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-
-        let helper_state_store = helper_state_store_mutex_guard.deref_mut();
 
         // NOTE: This code is only correct for VDAFs with exactly one round of preparation.
         // For VDAFs with more rounds, the helper state blob will need to be updated here.
@@ -1320,11 +1316,10 @@ impl DapLeader<BearerToken> for MockAggregator {
             .await?
             .ok_or_else(|| fatal_error!(err = "task not found"))?;
 
-        let mut leader_state_store_mutex_guard = self
+        let mut leader_state_store = self
             .leader_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-        let leader_state_store = leader_state_store_mutex_guard.deref_mut();
 
         // Construct a new Collect URI for this CollectReq.
         let collect_id = collect_job_id
@@ -1356,11 +1351,10 @@ impl DapLeader<BearerToken> for MockAggregator {
         task_id: &TaskId,
         collect_id: &CollectionJobId,
     ) -> Result<DapCollectJob, DapError> {
-        let mut leader_state_store_mutex_guard = self
+        let leader_state_store = self
             .leader_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-        let leader_state_store = leader_state_store_mutex_guard.deref_mut();
 
         let leader_state = leader_state_store
             .get(task_id)
@@ -1379,11 +1373,10 @@ impl DapLeader<BearerToken> for MockAggregator {
     async fn get_pending_collect_jobs(
         &self,
     ) -> Result<Vec<(TaskId, CollectionJobId, CollectionReq)>, DapError> {
-        let mut leader_state_store_mutex_guard = self
+        let leader_state_store = self
             .leader_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-        let leader_state_store = leader_state_store_mutex_guard.deref_mut();
 
         let mut res = Vec::new();
         for (task_id, leader_state) in &*leader_state_store {
@@ -1405,11 +1398,10 @@ impl DapLeader<BearerToken> for MockAggregator {
         collect_id: &CollectionJobId,
         collect_resp: &Collection,
     ) -> Result<(), DapError> {
-        let mut leader_state_store_mutex_guard = self
+        let mut leader_state_store = self
             .leader_state_store
             .lock()
             .map_err(|e| fatal_error!(err = ?e))?;
-        let leader_state_store = leader_state_store_mutex_guard.deref_mut();
 
         let leader_state = leader_state_store
             .get_mut(task_id)

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -812,8 +812,7 @@ impl MockAggregator {
         leader_state_store
             .batch_queue
             .front()
-            .cloned() // TODO(cjpatton) Avoid clone by returning MutexGuard
-            .map(|(batch_id, _report_count)| batch_id)
+            .map(|(batch_id, _report_count)| *batch_id)
     }
 
     pub(crate) async fn unchecked_get_task_config(&self, task_id: &TaskId) -> DapTaskConfig {
@@ -1085,9 +1084,8 @@ impl DapAggregator<BearerToken> for MockAggregator {
             .map(|(bucket, (agg_share, report_metadatas))| {
                 let replayed = report_metadatas
                     .iter()
-                    .map(|(id, _)| id)
+                    .map(|(id, _)| *id)
                     .filter(|id| report_store.processed.contains(id))
-                    .cloned()
                     .collect::<HashSet<_>>();
 
                 let result = if replayed.is_empty() {

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -710,7 +710,7 @@ impl MockAggregator {
     /// Conducts checks on a received report to see whether:
     /// 1) the report falls into a batch that has been already collected, or
     /// 2) the report has been submitted by the client in the past.
-    async fn check_report_early_fail(
+    fn check_report_early_fail(
         &self,
         task_id: &TaskId,
         bucket: &DapBatchBucket,
@@ -937,8 +937,7 @@ impl DapReportInitializer for MockAggregator {
         for (bucket, ((), report_ids_and_time)) in span.iter() {
             for (id, _) in report_ids_and_time {
                 // Check whether Report has been collected or replayed.
-                if let Some(transition_failure) =
-                    self.check_report_early_fail(task_id, bucket, id).await
+                if let Some(transition_failure) = self.check_report_early_fail(task_id, bucket, id)
                 {
                     early_fails.insert(*id, transition_failure);
                 };
@@ -1231,9 +1230,8 @@ impl DapLeader<BearerToken> for MockAggregator {
             .expect("could not determine batch for report");
 
         // Check whether Report has been collected or replayed.
-        if let Some(transition_failure) = self
-            .check_report_early_fail(task_id, &bucket, &report.report_metadata.id)
-            .await
+        if let Some(transition_failure) =
+            self.check_report_early_fail(task_id, &bucket, &report.report_metadata.id)
         {
             return Err(DapError::Transition(transition_failure));
         };

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -1035,9 +1035,7 @@ impl DapAggregator<BearerToken> for MockAggregator {
             .unwrap()
             .expect("tasks: unrecognized task");
         let guard = self.agg_store.lock().expect("agg_store: failed to lock");
-        let agg_store = if let Some(agg_store) = guard.get(task_id) {
-            agg_store
-        } else {
+        let Some(agg_store) = guard.get(task_id) else {
             return Ok(false);
         };
 

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -1095,7 +1095,7 @@ impl DapAggregator<BearerToken> for MockAggregator {
                         .or_default()
                         .agg_share
                         .merge(agg_share.clone())
-                        .map(|_| HashSet::new())
+                        .map(|()| HashSet::new())
                 } else {
                     Ok(replayed)
                 };

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -200,7 +200,7 @@ impl AggregationJobTest {
         reports
     }
 
-    /// Leader: Produce AggregationJobInitReq.
+    /// Leader: Produce `AggregationJobInitReq`.
     ///
     /// Panics if the Leader aborts.
     pub async fn produce_agg_job_init_req(
@@ -223,7 +223,7 @@ impl AggregationJobTest {
             .unwrap()
     }
 
-    /// Helper: Handle AggregationJobInitReq, produce first AggregationJobResp.
+    /// Helper: Handle `AggregationJobInitReq`, produce first `AggregationJobResp`.
     ///
     /// Panics if the Helper aborts.
     pub async fn handle_agg_job_init_req(
@@ -254,7 +254,7 @@ impl AggregationJobTest {
             .unwrap()
     }
 
-    /// Leader: Handle first AggregationJobResp, produce AggregationJobContinueReq.
+    /// Leader: Handle first `AggregationJobResp`, produce `AggregationJobContinueReq`.
     ///
     /// Panics if the Leader aborts.
     pub fn handle_agg_job_resp(
@@ -295,7 +295,7 @@ impl AggregationJobTest {
             .expect_err("handle_agg_job_resp() succeeded; expected failure")
     }
 
-    /// Helper: Handle AggregationJobContinueReq, produce second AggregationJobResp.
+    /// Helper: Handle `AggregationJobContinueReq`, produce second `AggregationJobResp`.
     ///
     /// Panics if the Helper aborts.
     pub fn handle_agg_job_cont_req(
@@ -335,7 +335,7 @@ impl AggregationJobTest {
             .expect_err("handle_agg_job_cont_req() succeeded; expected failure")
     }
 
-    /// Leader: Handle the last AggregationJobResp.
+    /// Leader: Handle the last `AggregationJobResp`.
     ///
     /// Panics if the Leader aborts.
     pub fn handle_final_agg_job_resp(
@@ -1514,7 +1514,7 @@ pub enum CollectJobState {
     Processed(Collection),
 }
 
-/// LeaderState keeps track of the following:
+/// `LeaderState` keeps track of the following:
 /// * Collect IDs in their order of arrival.
 /// * The state of the collect job associated to the Collect ID.
 #[derive(Default)]
@@ -1525,7 +1525,7 @@ pub struct LeaderState {
     batch_queue: VecDeque<(BatchId, u64)>, // Batch ID, batch size
 }
 
-/// AggStore keeps track of the following:
+/// `AggStore` keeps track of the following:
 /// * Aggregate share
 /// * Whether this aggregate share has been collected
 #[derive(Default)]

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -120,7 +120,7 @@ impl AggregationJobTest {
             .unwrap()
             .as_secs();
         let task_id = TaskId(rng.gen());
-        let agg_job_id = MetaAggregationJobId::gen_for_version(&version);
+        let agg_job_id = MetaAggregationJobId::gen_for_version(version);
         let vdaf_verify_key = vdaf.gen_verify_key();
         let leader_hpke_receiver_config = HpkeReceiverConfig::gen(rng.gen(), kem_id).unwrap();
         let helper_hpke_receiver_config = HpkeReceiverConfig::gen(rng.gen(), kem_id).unwrap();

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -1128,9 +1128,8 @@ impl DapAggregator<BearerToken> for MockAggregator {
             if let Some(inner_agg_store) = agg_store.get(&bucket) {
                 if inner_agg_store.collected {
                     return Err(DapError::Abort(DapAbort::batch_overlap(task_id, batch_sel)));
-                } else {
-                    agg_share.merge(inner_agg_store.agg_share.clone())?;
                 }
+                agg_share.merge(inner_agg_store.agg_share.clone())?;
             }
         }
 

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -768,7 +768,7 @@ impl MockAggregator {
                 let leader_state_store = guard.entry(*task_id).or_default();
 
                 // Assign the report to the first unsaturated batch.
-                for (batch_id, report_count) in leader_state_store.batch_queue.iter_mut() {
+                for (batch_id, report_count) in &mut leader_state_store.batch_queue {
                     if *report_count < task_config.min_batch_size {
                         *report_count += 1;
                         return Some(DapBatchBucket::FixedSize {
@@ -1278,7 +1278,7 @@ impl DapLeader<BearerToken> for MockAggregator {
             DapQueryConfig::TimeInterval { .. } => {
                 // Aggregate reports in any order.
                 let mut reports = Vec::new();
-                for (_bucket, queue) in report_store.pending.iter_mut() {
+                for queue in report_store.pending.values_mut() {
                     if !queue.is_empty() {
                         reports.append(&mut queue.drain(..1).collect());
                         break;
@@ -1390,9 +1390,9 @@ impl DapLeader<BearerToken> for MockAggregator {
         let leader_state_store = leader_state_store_mutex_guard.deref_mut();
 
         let mut res = Vec::new();
-        for (task_id, leader_state) in leader_state_store.iter() {
+        for (task_id, leader_state) in &*leader_state_store {
             // Iterate over collect IDs and copy them and their associated requests to the response.
-            for collect_id in leader_state.collect_ids.iter() {
+            for collect_id in &leader_state.collect_ids {
                 if let CollectJobState::Pending(collect_req) =
                     leader_state.collect_jobs.get(collect_id).unwrap()
                 {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -1367,16 +1367,11 @@ impl VdafConfig {
                 break;
             };
 
-            let leader_message = match &leader.var {
-                TransitionVar::Continued(message) => message,
-
-                // TODO Log the fact that the helper sent an unexpected message.
-                _ => {
-                    return Err(DapAbort::UnrecognizedMessage {
-                        detail: "helper sent unexpected message instead of `Continued`".to_string(),
-                        task_id: Some(*task_id),
-                    })
-                }
+            let TransitionVar::Continued(leader_message) = &leader.var else {
+                return Err(DapAbort::UnrecognizedMessage {
+                    detail: "helper sent unexpected message instead of `Continued`".to_string(),
+                    task_id: Some(*task_id),
+                });
             };
 
             let var = match report_status.get(&leader.report_id) {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -196,8 +196,7 @@ impl<'req> EarlyReportStateConsumed<'req> {
         failure: TransitionFailure,
     ) -> EarlyReportStateInitialized<'req> {
         let metadata = match self {
-            Self::Ready { metadata, .. } => metadata,
-            Self::Rejected { metadata, .. } => metadata,
+            Self::Ready { metadata, .. } | Self::Rejected { metadata, .. } => metadata,
         };
         EarlyReportStateInitialized::Rejected { metadata, failure }
     }
@@ -206,8 +205,7 @@ impl<'req> EarlyReportStateConsumed<'req> {
 impl EarlyReportState for EarlyReportStateConsumed<'_> {
     fn metadata(&self) -> &ReportMetadata {
         match self {
-            Self::Ready { metadata, .. } => metadata,
-            Self::Rejected { metadata, .. } => metadata,
+            Self::Ready { metadata, .. } | Self::Rejected { metadata, .. } => metadata,
         }
     }
 
@@ -329,8 +327,7 @@ impl<'req> EarlyReportStateInitialized<'req> {
         // this never aborts because the closure never panics
         replace_with_or_abort(self, |self_| {
             let metadata = match self_ {
-                Self::Rejected { metadata, .. } => metadata,
-                Self::Ready { metadata, .. } => metadata,
+                Self::Rejected { metadata, .. } | Self::Ready { metadata, .. } => metadata,
             };
             Self::Rejected { metadata, failure }
         })
@@ -340,8 +337,7 @@ impl<'req> EarlyReportStateInitialized<'req> {
 impl EarlyReportState for EarlyReportStateInitialized<'_> {
     fn metadata(&self) -> &ReportMetadata {
         match self {
-            Self::Ready { metadata, .. } => metadata,
-            Self::Rejected { metadata, .. } => metadata,
+            Self::Ready { metadata, .. } | Self::Rejected { metadata, .. } => metadata,
         }
     }
 
@@ -376,9 +372,9 @@ impl deepsize::DeepSizeOf for VdafPrepState {
         //
         // This happens to be correct for helpers but not for leaders
         match self {
-            VdafPrepState::Prio2(_) => 0,
-            VdafPrepState::Prio3Field64(_) => 0,
-            VdafPrepState::Prio3Field128(_) => 0,
+            VdafPrepState::Prio2(_)
+            | VdafPrepState::Prio3Field64(_)
+            | VdafPrepState::Prio3Field128(_) => 0,
         }
     }
 }
@@ -1698,8 +1694,7 @@ mod test {
 
         fn unwrap_msg(self) -> M {
             match self {
-                Self::Continued(_, msg) => msg,
-                Self::Finished(_, msg) => msg,
+                Self::Continued(_, msg) | Self::Finished(_, msg) => msg,
             }
         }
     }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -1026,7 +1026,7 @@ impl VdafConfig {
                                 TransitionVar::Continued(prep_msg)
                             }
 
-                            Err(VdafError::Codec(..)) | Err(VdafError::Vdaf(..)) => {
+                            Err(VdafError::Codec(..) | VdafError::Vdaf(..)) => {
                                 let failure = TransitionFailure::VdafPrepError;
                                 metrics.report_inc_by(&format!("rejected_{failure}"), 1);
                                 TransitionVar::Failed(failure)
@@ -1167,7 +1167,7 @@ impl VdafConfig {
                 }
 
                 // Skip report that can't be processed any further.
-                Err(VdafError::Codec(..)) | Err(VdafError::Vdaf(..)) => {
+                Err(VdafError::Codec(..) | VdafError::Vdaf(..)) => {
                     let failure = TransitionFailure::VdafPrepError;
                     metrics.report_inc_by(&format!("rejected_{failure}"), 1);
                 }
@@ -1267,7 +1267,7 @@ impl VdafConfig {
                     )?;
                 }
 
-                Err(VdafError::Codec(..)) | Err(VdafError::Vdaf(..)) => {
+                Err(VdafError::Codec(..) | VdafError::Vdaf(..)) => {
                     let failure = TransitionFailure::VdafPrepError;
                     metrics.report_inc_by(&format!("rejected_{failure}"), 1);
                 }
@@ -1408,7 +1408,7 @@ impl VdafConfig {
                             TransitionVar::Finished
                         }
 
-                        Err(VdafError::Codec(..)) | Err(VdafError::Vdaf(..)) => {
+                        Err(VdafError::Codec(..) | VdafError::Vdaf(..)) => {
                             let failure = TransitionFailure::VdafPrepError;
                             TransitionVar::Failed(failure)
                         }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -593,7 +593,7 @@ impl VdafConfig {
 
         if version != DapVersion::Draft02 {
             let mut encoded: Vec<Vec<u8>> = Vec::new();
-            for share in input_shares.into_iter() {
+            for share in input_shares {
                 let input_share = PlaintextInputShare {
                     extensions: extensions.clone(),
                     payload: share,
@@ -720,7 +720,7 @@ impl VdafConfig {
         let mut seq = Vec::with_capacity(reports.len());
         let mut consumed_reports = Vec::with_capacity(reports.len());
         let mut helper_shares = Vec::with_capacity(reports.len());
-        for report in reports.into_iter() {
+        for report in reports {
             if processed.contains(&report.report_metadata.id) {
                 return Err(fatal_error!(
                     err = "tried to process report sequence with non-unique report IDs",

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -556,7 +556,7 @@ impl VdafConfig {
         let mut rng = thread_rng();
         let report_id = ReportId(rng.gen());
         let (public_share, input_shares) = self.produce_input_shares(measurement, &report_id.0)?;
-        self.produce_report_with_extensions_for_shares(
+        Self::produce_report_with_extensions_for_shares(
             public_share,
             input_shares,
             hpke_config_list,
@@ -571,7 +571,6 @@ impl VdafConfig {
     /// Generate a report for the given public and input shares with the given extensions.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn produce_report_with_extensions_for_shares(
-        &self,
         public_share: Vec<u8>,
         mut input_shares: Vec<Vec<u8>>,
         hpke_config_list: &[HpkeConfig],
@@ -884,7 +883,7 @@ impl VdafConfig {
         metrics: &DaphneMetrics,
     ) -> Result<DapHelperAggregationJobTransition<AggregationJobResp>, DapAbort> {
         match task_config.version {
-            DapVersion::Draft02 => Ok(self.draft02_handle_agg_job_init_req(
+            DapVersion::Draft02 => Ok(Self::draft02_handle_agg_job_init_req(
                 report_status,
                 initialized_reports,
                 agg_job_init_req,
@@ -902,7 +901,6 @@ impl VdafConfig {
     }
 
     fn draft02_handle_agg_job_init_req(
-        &self,
         report_status: &HashMap<ReportId, ReportProcessedStatus>,
         initialized_reports: &[EarlyReportStateInitialized<'_>],
         agg_job_init_req: &AggregationJobInitReq,
@@ -2451,19 +2449,17 @@ mod test {
                 .produce_input_shares(measurement, &report_id.0)
                 .unwrap();
             invalid_input_shares[1][0] ^= 1; // The first bit is incorrect!
-            self.task_config
-                .vdaf
-                .produce_report_with_extensions_for_shares(
-                    invalid_public_share,
-                    invalid_input_shares,
-                    &self.client_hpke_config_list,
-                    self.now,
-                    &self.task_id,
-                    &report_id,
-                    Vec::new(), // extensions
-                    version,
-                )
-                .unwrap()
+            VdafConfig::produce_report_with_extensions_for_shares(
+                invalid_public_share,
+                invalid_input_shares,
+                &self.client_hpke_config_list,
+                self.now,
+                &self.task_id,
+                &report_id,
+                Vec::new(), // extensions
+                version,
+            )
+            .unwrap()
         }
 
         // Tweak the public share so that it can't be decoded.
@@ -2479,19 +2475,17 @@ mod test {
                 .produce_input_shares(measurement, &report_id.0)
                 .unwrap();
             invalid_public_share.push(1); // Add spurious byte at the end
-            self.task_config
-                .vdaf
-                .produce_report_with_extensions_for_shares(
-                    invalid_public_share,
-                    invalid_input_shares,
-                    &self.client_hpke_config_list,
-                    self.now,
-                    &self.task_id,
-                    &report_id,
-                    Vec::new(), // extensions
-                    version,
-                )
-                .unwrap()
+            VdafConfig::produce_report_with_extensions_for_shares(
+                invalid_public_share,
+                invalid_input_shares,
+                &self.client_hpke_config_list,
+                self.now,
+                &self.task_id,
+                &report_id,
+                Vec::new(), // extensions
+                version,
+            )
+            .unwrap()
         }
 
         // Tweak the input shares so that they can't be decoded.
@@ -2508,19 +2502,17 @@ mod test {
                 .unwrap();
             invalid_input_shares[0].push(1); // Add a spurious byte to the Leader's share
             invalid_input_shares[1].push(1); // Add a spurious byte to the Helper's share
-            self.task_config
-                .vdaf
-                .produce_report_with_extensions_for_shares(
-                    invalid_public_share,
-                    invalid_input_shares,
-                    &self.client_hpke_config_list,
-                    self.now,
-                    &self.task_id,
-                    &report_id,
-                    Vec::new(), // extensions
-                    version,
-                )
-                .unwrap()
+            VdafConfig::produce_report_with_extensions_for_shares(
+                invalid_public_share,
+                invalid_input_shares,
+                &self.client_hpke_config_list,
+                self.now,
+                &self.task_id,
+                &report_id,
+                Vec::new(), // extensions
+                version,
+            )
+            .unwrap()
         }
     }
 }

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -832,7 +832,7 @@ impl VdafConfig {
         let num_reports = agg_job_init_req.prep_inits.len();
         let mut processed = HashSet::with_capacity(num_reports);
         let mut consumed_reports = Vec::with_capacity(num_reports);
-        for prep_init in agg_job_init_req.prep_inits.iter() {
+        for prep_init in &agg_job_init_req.prep_inits {
             if processed.contains(&prep_init.report_share.report_metadata.id) {
                 return Err(DapAbort::UnrecognizedMessage {
                     detail: format!(

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -330,7 +330,7 @@ impl<'req> EarlyReportStateInitialized<'req> {
                 Self::Rejected { metadata, .. } | Self::Ready { metadata, .. } => metadata,
             };
             Self::Rejected { metadata, failure }
-        })
+        });
     }
 }
 
@@ -2439,7 +2439,7 @@ mod test {
         let got = DapAggregationJobState::get_decoded(TEST_VDAF, &want.get_encoded()).unwrap();
         assert_eq!(got.get_encoded(), want.get_encoded());
 
-        assert!(DapAggregationJobState::get_decoded(TEST_VDAF, b"invalid helper state").is_err())
+        assert!(DapAggregationJobState::get_decoded(TEST_VDAF, b"invalid helper state").is_err());
     }
 
     impl AggregationJobTest {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -583,7 +583,7 @@ impl VdafConfig {
     ) -> Result<Report, DapError> {
         let report_extensions = match version {
             DapVersion::Draft02 => extensions.clone(),
-            _ => vec![],
+            DapVersion::Draft07 => vec![],
         };
         let metadata = ReportMetadata {
             id: *report_id,
@@ -1235,7 +1235,7 @@ impl VdafConfig {
                     continue;
                 }
 
-                _ => {
+                TransitionVar::Finished => {
                     return Err(DapAbort::UnrecognizedMessage {
                         detail: "helper sent unexpected `Finished` message".to_string(),
                         task_id: Some(*task_id),
@@ -1656,40 +1656,40 @@ mod test {
 
     impl<M: Debug> DapLeaderAggregationJobTransition<M> {
         fn unwrap_continued(self) -> (DapAggregationJobState, M) {
-            match self {
-                Self::Continued(state, message) => (state, message),
-                _ => panic!("unexpected transition"),
-            }
+            let Self::Continued(state, message) = self else {
+                panic!("unexpected transition")
+            };
+            (state, message)
         }
 
         fn unwrap_finished(self) -> DapAggregateSpan<DapAggregateShare> {
-            match self {
-                Self::Finished(agg_span) => agg_span,
-                _ => panic!("unexpected transition"),
-            }
+            let Self::Finished(agg_span) = self else {
+                panic!("unexpected transition")
+            };
+            agg_span
         }
 
         pub(crate) fn unwrap_uncommitted(self) -> (DapAggregationJobUncommitted, M) {
-            match self {
-                Self::Uncommitted(uncommitted, message) => (uncommitted, message),
-                _ => panic!("unexpected transition"),
-            }
+            let Self::Uncommitted(uncommitted, message) = self else {
+                panic!("unexpected transition")
+            };
+            (uncommitted, message)
         }
     }
 
     impl<M: Debug> DapHelperAggregationJobTransition<M> {
         fn unwrap_continued(self) -> (DapAggregationJobState, M) {
-            match self {
-                Self::Continued(state, message) => (state, message),
-                _ => panic!("unexpected transition"),
-            }
+            let Self::Continued(state, message) = self else {
+                panic!("unexpected transition")
+            };
+            (state, message)
         }
 
         fn unwrap_finished(self) -> (DapAggregateSpan<DapAggregateShare>, M) {
-            match self {
-                Self::Finished(agg_span, msg) => (agg_span, msg),
-                _ => panic!("unexpected transition"),
-            }
+            let Self::Finished(agg_span, msg) = self else {
+                panic!("unexpected transition")
+            };
+            (agg_span, msg)
         }
 
         fn unwrap_msg(self) -> M {

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -2384,8 +2384,8 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let leader_agg_share = DapAggregateShare {
             report_count: 50,
-            min_time: 1637359200,
-            max_time: 1637359200,
+            min_time: 1_637_359_200,
+            max_time: 1_637_359_200,
             checksum: [0; 32],
             data: Some(VdafAggregateShare::Field64(AggregateShare::from(
                 OutputShare::from(vec![Field64::from(23)]),
@@ -2393,8 +2393,8 @@ mod test {
         };
         let helper_agg_share = DapAggregateShare {
             report_count: 50,
-            min_time: 1637359200,
-            max_time: 1637359200,
+            min_time: 1_637_359_200,
+            max_time: 1_637_359_200,
             checksum: [0; 32],
             data: Some(VdafAggregateShare::Field64(AggregateShare::from(
                 OutputShare::from(vec![Field64::from(9)]),
@@ -2403,7 +2403,7 @@ mod test {
 
         let batch_selector = BatchSelector::TimeInterval {
             batch_interval: Interval {
-                start: 1637359200,
+                start: 1_637_359_200,
                 duration: 7200,
             },
         };

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -1692,7 +1692,7 @@ mod test {
             (agg_span, msg)
         }
 
-        fn unwrap_msg(self) -> M {
+        fn into_message(self) -> M {
             match self {
                 Self::Continued(_, msg) | Self::Finished(_, msg) => msg,
             }
@@ -1956,7 +1956,7 @@ mod test {
         let agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
         assert_matches!(
@@ -1985,7 +1985,7 @@ mod test {
         let agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
         assert_matches!(
@@ -2035,7 +2035,7 @@ mod test {
         let agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         assert_eq!(agg_job_resp.transitions.len(), 2);
         assert_matches!(
@@ -2062,7 +2062,7 @@ mod test {
         let mut agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         // Helper sends transitions out of order.
         let tmp = agg_job_resp.transitions[0].clone();
@@ -2085,7 +2085,7 @@ mod test {
         let mut agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         // Helper sends a transition twice.
         let repeated_transition = agg_job_resp.transitions[0].clone();
@@ -2108,7 +2108,7 @@ mod test {
         let mut agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         // Helper sent a transition with an unrecognized report ID.
         agg_job_resp.transitions.push(Transition {
@@ -2132,7 +2132,7 @@ mod test {
         let mut agg_job_resp = t
             .handle_agg_job_init_req(&agg_job_init_req)
             .await
-            .unwrap_msg();
+            .into_message();
 
         // Helper sent a transition with an unrecognized report ID.
         agg_job_resp.transitions[0].var = TransitionVar::Finished;

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -188,7 +188,7 @@ impl<'req> EarlyReportStateConsumed<'req> {
         })
     }
 
-    /// Convert this EarlyReportStateConsumed into a rejected [EarlyReportStateInitialized] using
+    /// Convert this `EarlyReportStateConsumed` into a rejected [`EarlyReportStateInitialized`] using
     /// `failure` as the reason. If this is already a rejected report, the passed in `failure`
     /// value overwrites the previous one.
     pub fn into_initialized_rejected_due_to(
@@ -541,7 +541,7 @@ impl VdafConfig {
     ///
     /// * `extensions` are the extensions.
     ///
-    /// * `version` is the DapVersion to use.
+    /// * `version` is the `DapVersion` to use.
     //
     // TODO(issue #100): Truncate the timestamp, as required in DAP-02.
     pub fn produce_report_with_extensions(
@@ -681,7 +681,7 @@ impl VdafConfig {
     ///
     /// * `measurement` is the measurement.
     ///
-    /// * `version` is the DapVersion to use.
+    /// * `version` is the `DapVersion` to use.
     pub fn produce_report(
         &self,
         hpke_config_list: &[HpkeConfig],
@@ -1519,7 +1519,7 @@ impl VdafConfig {
     /// * `encrypted_agg_shares` is the set of encrypted aggregate shares produced by the
     /// Aggregators. The first encrypted aggregate shares must be the Leader's.
     ///
-    /// * `version` is the DapVersion to use.
+    /// * `version` is the `DapVersion` to use.
     //
     // TODO spec: Allow the collector to have multiple HPKE public keys (the way Aggregators do).
     pub async fn consume_encrypted_agg_shares(

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -884,12 +884,12 @@ impl VdafConfig {
         metrics: &DaphneMetrics,
     ) -> Result<DapHelperAggregationJobTransition<AggregationJobResp>, DapAbort> {
         match task_config.version {
-            DapVersion::Draft02 => self.draft02_handle_agg_job_init_req(
+            DapVersion::Draft02 => Ok(self.draft02_handle_agg_job_init_req(
                 report_status,
                 initialized_reports,
                 agg_job_init_req,
                 metrics,
-            ),
+            )),
             DapVersion::Draft07 => self.draft07_handle_agg_job_init_req(
                 task_id,
                 task_config,
@@ -907,7 +907,7 @@ impl VdafConfig {
         initialized_reports: &[EarlyReportStateInitialized<'_>],
         agg_job_init_req: &AggregationJobInitReq,
         metrics: &DaphneMetrics,
-    ) -> Result<DapHelperAggregationJobTransition<AggregationJobResp>, DapAbort> {
+    ) -> DapHelperAggregationJobTransition<AggregationJobResp> {
         let num_reports = agg_job_init_req.prep_inits.len();
         let mut states = Vec::with_capacity(num_reports);
         let mut transitions = Vec::with_capacity(num_reports);
@@ -951,13 +951,13 @@ impl VdafConfig {
             });
         }
 
-        Ok(DapHelperAggregationJobTransition::Continued(
+        DapHelperAggregationJobTransition::Continued(
             DapAggregationJobState {
                 part_batch_sel: agg_job_init_req.part_batch_sel.clone(),
                 seq: states,
             },
             AggregationJobResp { transitions },
-        ))
+        )
     }
 
     fn draft07_handle_agg_job_init_req(

--- a/daphne/src/vdaf/prio2.rs
+++ b/daphne/src/vdaf/prio2.rs
@@ -126,7 +126,7 @@ pub(crate) fn prio2_unshard<M: IntoIterator<Item = Vec<u8>>>(
 ) -> Result<DapAggregateResult, VdafError> {
     let vdaf = Prio2::new(dimension)?;
     let mut agg_shares = Vec::with_capacity(vdaf.num_aggregators());
-    for encoded in encoded_agg_shares.into_iter() {
+    for encoded in encoded_agg_shares {
         let agg_share = AggregateShare::get_decoded_with_param(&(&vdaf, &()), encoded.as_ref())?;
         agg_shares.push(agg_share);
     }

--- a/daphne/src/vdaf/prio2.rs
+++ b/daphne/src/vdaf/prio2.rs
@@ -128,7 +128,7 @@ pub(crate) fn prio2_unshard<M: IntoIterator<Item = Vec<u8>>>(
     let mut agg_shares = Vec::with_capacity(vdaf.num_aggregators());
     for encoded in encoded_agg_shares.into_iter() {
         let agg_share = AggregateShare::get_decoded_with_param(&(&vdaf, &()), encoded.as_ref())?;
-        agg_shares.push(agg_share)
+        agg_shares.push(agg_share);
     }
     let agg_res = vdaf.unshard(&(), agg_shares, num_measurements)?;
     Ok(DapAggregateResult::U32Vec(agg_res))

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -46,7 +46,7 @@ pub(crate) fn prio3_shard(
         }
         (Prio3Config::Sum { bits }, DapMeasurement::U64(measurement)) => {
             let vdaf = Prio3::new_sum(2, *bits)?;
-            shard(vdaf, &(measurement as u128), nonce)
+            shard(vdaf, &u128::from(measurement), nonce)
         }
         (
             Prio3Config::SumVec {

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -451,7 +451,7 @@ pub(crate) fn prio3_unshard<M: IntoIterator<Item = Vec<u8>>>(
         let mut agg_shares_vec = Vec::with_capacity(vdaf.num_aggregators());
         for data in agg_shares.into_iter() {
             let agg_share = AggregateShare::get_decoded_with_param(&(vdaf, &()), data.as_ref())?;
-            agg_shares_vec.push(agg_share)
+            agg_shares_vec.push(agg_share);
         }
         Ok(vdaf.unshard(&(), agg_shares_vec, num_measurements)?)
     }

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -449,7 +449,7 @@ pub(crate) fn prio3_unshard<M: IntoIterator<Item = Vec<u8>>>(
         M: IntoIterator<Item = Vec<u8>>,
     {
         let mut agg_shares_vec = Vec::with_capacity(vdaf.num_aggregators());
-        for data in agg_shares.into_iter() {
+        for data in agg_shares {
             let agg_share = AggregateShare::get_decoded_with_param(&(vdaf, &()), data.as_ref())?;
             agg_shares_vec.push(agg_share);
         }

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -352,7 +352,7 @@ impl DaphneWorkerConfig {
                 .unwrap(),
         ) % self.report_shard_count;
         let epoch = report_time - (report_time % self.global.report_storage_epoch_duration);
-        durable_name_report_store(&task_config.version, task_id_hex, epoch, shard)
+        durable_name_report_store(task_config.version, task_id_hex, epoch, shard)
     }
 }
 
@@ -860,7 +860,7 @@ impl<'srv> DaphneWorker<'srv> {
             .get(
                 BINDING_DAP_LEADER_BATCH_QUEUE,
                 DURABLE_LEADER_BATCH_QUEUE_CURRENT,
-                durable_name_task(&task_config.as_ref().version, &task_id.to_hex()),
+                durable_name_task(task_config.as_ref().version, &task_id.to_hex()),
             )
             .await
             .map_err(|e| fatal_error!(err = ?e))?;

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -620,7 +620,7 @@ impl<'srv> DaphneWorker<'srv> {
         }
 
         // If the value is not cached, try to populate it from KV before returning.
-        let kv_key = format!("{}/{}", kv_key_prefix, kv_key_suffix);
+        let kv_key = format!("{kv_key_prefix}/{kv_key_suffix}");
 
         tracing::debug!(%kv_key, "looking up key in kv");
         let kv_store = self.kv()?;

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -877,7 +877,7 @@ impl<'srv> DaphneWorker<'srv> {
 
     /// Get the URL to use for this endpoint, as required by
     /// draft-dcook-ppm-dap-interop-test-design-02.
-    pub(crate) async fn internal_endpoint_for_task(
+    pub(crate) fn internal_endpoint_for_task(
         &self,
         version: DapVersion,
         cmd: InternalTestEndpointForTask,

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -20,7 +20,10 @@ use prio::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::Instrument;
-use worker::{wasm_bindgen::JsValue, *};
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen::JsValue, wasm_bindgen_futures,
+    worker_sys, Env, Error, Method, Request, Response, Result, State,
+};
 
 use super::{req_parse, DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -65,11 +65,11 @@ pub struct AggregateStore {
 /// Minimum number of chunks needed to store 512K of aggregate share data.
 const MAX_AGG_SHARE_CHUNK_KEY_COUNT: usize = 4;
 
-/// Minimum number of chunks needed to store 10_000 report ids.
+/// Minimum number of chunks needed to store `10_000` report ids.
 const MAX_REPORT_ID_CHUNK_KEY_COUNT: usize = 2;
 
-/// The maximum chunk size as documented in:
-/// https://developers.cloudflare.com/durable-objects/platform/limits/
+/// The maximum chunk size as documented in
+/// [the public docs](https://developers.cloudflare.com/durable-objects/platform/limits/)
 const MAX_CHUNK_SIZE: usize = 128_000;
 
 /// Key used to store metadata under.

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -247,7 +247,9 @@ fn shard_bytes_to_object(
         let end = usize::min(base_idx + MAX_CHUNK_SIZE + 1, bytes.len());
         let chunk = &bytes[base_idx..end];
 
-        let value = js_sys::Uint8Array::new_with_length(chunk.len() as _);
+        // unwrap cannot fail because chunk len is bounded by MAX_CHUNK_SIZE which is smaller than
+        // u32::MAX
+        let value = js_sys::Uint8Array::new_with_length(u32::try_from(chunk.len()).unwrap());
         value.copy_from(chunk);
 
         js_sys::Reflect::set(

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -144,13 +144,13 @@ fn js_map_to_chunks<T: DeserializeOwned>(keys: &[String], map: js_sys::Map) -> V
 }
 
 impl AggregateStore {
-    fn agg_share_shard_keys(&self) -> Vec<String> {
+    fn agg_share_shard_keys() -> Vec<String> {
         (0..MAX_AGG_SHARE_CHUNK_KEY_COUNT)
             .map(|n| format!("chunk_v2_{n:03}"))
             .collect()
     }
 
-    fn aggregated_reports_keys(&self) -> Vec<String> {
+    fn aggregated_reports_keys() -> Vec<String> {
         (0..MAX_REPORT_ID_CHUNK_KEY_COUNT)
             .map(|n| format!("aggregated_report_ids_{n:03}"))
             .collect()
@@ -208,10 +208,10 @@ impl AggregateStore {
         let chunks_map = self
             .state
             .storage()
-            .get_multiple(self.aggregated_reports_keys())
+            .get_multiple(Self::aggregated_reports_keys())
             .await?;
 
-        let bytes = js_map_to_chunks::<u8>(&self.aggregated_reports_keys(), chunks_map);
+        let bytes = js_map_to_chunks::<u8>(&Self::aggregated_reports_keys(), chunks_map);
 
         assert_eq!(bytes.len() % std::mem::size_of::<ReportId>(), 0);
         let mut ids = HashSet::with_capacity(bytes.len() / size_of::<ReportId>());
@@ -331,10 +331,10 @@ impl AggregateStore {
                     merged_report_ids
                         .into_iter()
                         .for_each(|id| id.encode(&mut as_bytes));
-                    shard_bytes_to_object(&self.aggregated_reports_keys(), as_bytes, &chunks_map)?;
+                    shard_bytes_to_object(&Self::aggregated_reports_keys(), as_bytes, &chunks_map)?;
                 };
 
-                let keys = self.agg_share_shard_keys();
+                let keys = Self::agg_share_shard_keys();
                 let mut agg_share = self.get_agg_share(&keys).await?;
                 agg_share.merge(agg_share_delta).map_err(int_err)?;
 
@@ -361,7 +361,7 @@ impl AggregateStore {
             // Idempotent
             // Output: `DapAggregateShare`
             (DURABLE_AGGREGATE_STORE_GET, Method::Get) => {
-                let agg_share = self.get_agg_share(&self.agg_share_shard_keys()).await?;
+                let agg_share = self.get_agg_share(&Self::agg_share_shard_keys()).await?;
                 Response::from_json(&agg_share)
             }
 

--- a/daphne_worker/src/durable/garbage_collector.rs
+++ b/daphne_worker/src/durable/garbage_collector.rs
@@ -9,7 +9,10 @@ use crate::{
     initialize_tracing, int_err,
 };
 use tracing::{error, trace, Instrument};
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Method, Request, Response, Result, State,
+};
 
 pub(crate) const DURABLE_GARBAGE_COLLECTOR_PUT: &str = "/internal/do/garbage_collector/put";
 

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -13,7 +13,7 @@ use worker::*;
 use super::{req_parse, Alarmed, DapDurableObject};
 
 pub(crate) fn durable_helper_state_name(
-    version: &DapVersion,
+    version: DapVersion,
     task_id: &TaskId,
     agg_job_id: &MetaAggregationJobId,
 ) -> String {

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -8,7 +8,10 @@ use crate::{
 };
 use daphne::{messages::TaskId, DapVersion, MetaAggregationJobId};
 use tracing::{trace, Instrument};
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Method, Request, Response, Result, State,
+};
 
 use super::{req_parse, Alarmed, DapDurableObject};
 

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -11,7 +11,10 @@ use crate::{
     initialize_tracing, int_err,
 };
 use tracing::{debug, Instrument};
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Method, Request, Response, Result, State,
+};
 
 use super::{DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -14,7 +14,10 @@ use daphne::messages::BatchId;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, Instrument};
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Method, Request, Response, Result, State,
+};
 
 use super::{req_parse, DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -18,7 +18,10 @@ use daphne::{
 use prio::codec::ParameterizedEncode;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Error, Method, Request, Response, Result, State,
+};
 
 use super::{req_parse, DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -272,7 +272,7 @@ trait Alarmed: DapDurableObject {
                         self.deployment(),
                         crate::config::DaphneWorkerDeployment::Dev
                     ) {
-                        warn!("ignoring get_alarm() failure in a dev environment until --experimental-local implements it: {e}")
+                        warn!("ignoring get_alarm() failure in a dev environment until --experimental-local implements it: {e}");
                     } else {
                         // We only return an error if not in the "dev" deployment as
                         // the experimental-local dev environment doesn't have
@@ -338,7 +338,7 @@ trait GarbageCollectable: DapDurableObject {
                             .await?;
                     }
                 }
-                *self.touched() = true
+                *self.touched() = true;
             }
             _ => {}
         }

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -208,7 +208,10 @@ impl<'srv> DurableConnector<'srv> {
                     let data = bincode::serialize(&data).map_err(|e| {
                         Error::RustError(format!("failed to serialize data: {e:?}"))
                     })?;
-                    let buffer = Uint8Array::new_with_length(data.len() as _);
+                    let buffer =
+                        Uint8Array::new_with_length(data.len().try_into().map_err(|_| {
+                            worker::Error::RustError(format!("buffer is too long {}", data.len()))
+                        })?);
                     buffer.copy_from(&data);
                     Request::new_with_init(
                         &format!("https://fake-host{durable_path}"),

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -686,7 +686,7 @@ mod test {
 
     #[test]
     fn durable_name() {
-        let time = 1664850074;
+        let time = 1_664_850_074;
         let id1 = TaskId([17; 32]);
         let id2 = BatchId([34; 32]);
         let shard = 1234;

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -19,7 +19,10 @@ use rand::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{cmp::min, time::Duration};
 use tracing::{info_span, warn};
-use worker::{js_sys::Uint8Array, *};
+use worker::{
+    async_trait, js_sys::Uint8Array, Delay, Env, Error, Headers, ListOptions, Method, Request,
+    RequestInit, Result, ScheduledTime, State, Stub,
+};
 
 pub(crate) const DURABLE_DELETE_ALL: &str = "/internal/do/delete_all";
 

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -395,7 +395,7 @@ pub(crate) fn durable_name_queue(shard: u64) -> String {
 }
 
 pub(crate) fn durable_name_report_store(
-    version: &DapVersion,
+    version: DapVersion,
     task_id_hex: &str,
     epoch: u64,
     shard: u64,
@@ -409,7 +409,7 @@ pub(crate) fn durable_name_report_store(
 }
 
 pub(crate) fn durable_name_agg_store(
-    version: &DapVersion,
+    version: DapVersion,
     task_id_hex: &str,
     bucket: &DapBatchBucket,
 ) -> String {
@@ -420,7 +420,7 @@ pub(crate) fn durable_name_agg_store(
     )
 }
 
-pub(crate) fn durable_name_task(version: &DapVersion, task_id_hex: &str) -> String {
+pub(crate) fn durable_name_task(version: DapVersion, task_id_hex: &str) -> String {
     format!("{}/task/{}", version.as_ref(), task_id_hex)
 }
 
@@ -694,17 +694,17 @@ mod test {
         assert_eq!(durable_name_queue(shard), "queue/1234");
 
         assert_eq!(
-        durable_name_report_store(&DapVersion::Draft02, &id1.to_hex(), time, shard),
+        durable_name_report_store(DapVersion::Draft02, &id1.to_hex(), time, shard),
         "v02/task/1111111111111111111111111111111111111111111111111111111111111111/epoch/00000000001664850074/shard/1234",
     );
 
         assert_eq!(
-        durable_name_agg_store(&DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::FixedSize{ batch_id: id2 }),
+        durable_name_agg_store(DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::FixedSize{ batch_id: id2 }),
         "v02/task/1111111111111111111111111111111111111111111111111111111111111111/batch/2222222222222222222222222222222222222222222222222222222222222222",
     );
 
         assert_eq!(
-        durable_name_agg_store(&DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::TimeInterval{ batch_window: time }),
+        durable_name_agg_store(DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::TimeInterval{ batch_window: time }),
         "v02/task/1111111111111111111111111111111111111111111111111111111111111111/window/1664850074",
     );
     }

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -17,7 +17,10 @@ use daphne::{messages::TaskId, DapVersion};
 use serde::{Deserialize, Serialize};
 use std::{cmp::min, ops::ControlFlow};
 use tracing::{debug, Instrument};
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    ListOptions, Method, Request, Response, Result, State,
+};
 
 use super::{DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/durable/reports_processed.rs
+++ b/daphne_worker/src/durable/reports_processed.rs
@@ -19,7 +19,10 @@ use prio::codec::{CodecError, ParameterizedDecode};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashSet, future::ready, ops::ControlFlow, time::Duration};
 use tracing::Instrument;
-use worker::*;
+use worker::{
+    async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
+    Method, Request, Response, Result, State,
+};
 
 use super::{req_parse, state_set_if_not_exists, Alarmed, DapDurableObject, GarbageCollectable};
 

--- a/daphne_worker/src/error_reporting.rs
+++ b/daphne_worker/src/error_reporting.rs
@@ -6,7 +6,7 @@
 use daphne::error::DapAbort;
 
 /// Interface for error reporting in Daphne
-/// Refer to NoopErrorReporter for implementation example.
+/// Refer to `NoopErrorReporter` for implementation example.
 pub trait ErrorReporter {
     fn report_abort(&self, error: &DapAbort);
 }

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -214,7 +214,7 @@ impl<'srv> Default for DaphneWorkerRouter<'srv> {
 }
 
 /// The response body for unhandled requests when [`DaphneWorkerRouter::enable_default_response`]
-/// is set. This value can be overrided by DAP_DEFAULT_RESPONSE_HTML.
+/// is set. This value can be overrided by `DAP_DEFAULT_RESPONSE_HTML`.
 pub const DEFAULT_RESPONSE_HTML: &str = "<body>Daphne-Worker</body>";
 
 static ISOLATE_STATE: OnceCell<DaphneWorkerIsolateState> = OnceCell::new();

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -2,6 +2,22 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #![warn(unused_crate_dependencies)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::ignored_unit_patterns)]
+#![allow(clippy::if_not_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::redundant_closure_for_method_calls)]
+#![allow(clippy::inconsistent_struct_constructor)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::inline_always)]
 
 //! Daphne-Worker implements a [Workers](https://developers.cloudflare.com/workers/) backend for
 //! Daphne.

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -174,7 +174,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::str;
 use tracing::{debug, error};
-use worker::*;
+use worker::{Date, Env, Error, Request, Response, Result};
 
 /// Parameters used by the Leader to select a set of reports for aggregation.
 #[derive(Debug, Deserialize, Serialize)]

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -262,7 +262,7 @@ impl DaphneWorkerRouter<'_> {
                 enable_default_response: self.enable_default_response,
                 role: env.var("DAP_AGGREGATOR_ROLE")?.to_string().parse()?,
             },
-        )?;
+        );
 
         // NOTE that we do not have a tracing span for the whole request because it typically
         // reports the same times as the span covering the specific API entry point that the

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -200,7 +200,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
                 (sender, &taskprov_config.leader_auth.cf_tls_client_auth)
             {
                 trusted_certs
-            } else if let (Some(DapSender::Collector), Some(ref trusted_certs)) = (
+            } else if let (Some(DapSender::Collector), Some(trusted_certs)) = (
                 sender,
                 taskprov_config
                     .collector_auth

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -69,7 +69,7 @@ impl DapReportInitializer for DaphneWorker<'_> {
                 }
                 agg_store_request_names.push((
                     bucket,
-                    durable_name_agg_store(&task_config.version, &task_id_hex, bucket),
+                    durable_name_agg_store(task_config.version, &task_id_hex, bucket),
                 ));
             }
 
@@ -339,7 +339,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
         let mut requests = Vec::new();
         for bucket in task_config.as_ref().batch_span_for_sel(batch_sel)? {
             let durable_name =
-                durable_name_agg_store(&task_config.as_ref().version, &task_id.to_hex(), &bucket);
+                durable_name_agg_store(task_config.as_ref().version, &task_id.to_hex(), &bucket);
             requests.push(durable.get(
                 BINDING_DAP_AGGREGATE_STORE,
                 DURABLE_AGGREGATE_STORE_CHECK_COLLECTED,
@@ -374,7 +374,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
                 BINDING_DAP_AGGREGATE_STORE,
                 DURABLE_AGGREGATE_STORE_GET,
                 durable_name_agg_store(
-                    &task_config.as_ref().version,
+                    task_config.as_ref().version,
                     &task_id.to_hex(),
                     &DapBatchBucket::FixedSize {
                         batch_id: *batch_id,
@@ -399,7 +399,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
         futures::stream::iter(agg_share_span)
             .map(|(bucket, (agg_share, report_metadatas))| async {
                 let agg_store_name =
-                    durable_name_agg_store(&task_config.version, &task_id_hex, &bucket);
+                    durable_name_agg_store(task_config.version, &task_id_hex, &bucket);
                 let result = durable
                     .post::<_, HashSet<ReportId>>(
                         BINDING_DAP_AGGREGATE_STORE,
@@ -430,7 +430,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
         let mut requests = Vec::new();
         for bucket in task_config.as_ref().batch_span_for_sel(batch_sel)? {
             let durable_name =
-                durable_name_agg_store(&task_config.as_ref().version, &task_id.to_hex(), &bucket);
+                durable_name_agg_store(task_config.as_ref().version, &task_id.to_hex(), &bucket);
             requests.push(durable.get(
                 BINDING_DAP_AGGREGATE_STORE,
                 DURABLE_AGGREGATE_STORE_GET,
@@ -459,7 +459,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
         let mut requests = Vec::new();
         for bucket in task_config.as_ref().batch_span_for_sel(batch_sel)? {
             let durable_name =
-                durable_name_agg_store(&task_config.as_ref().version, &task_id.to_hex(), &bucket);
+                durable_name_agg_store(task_config.as_ref().version, &task_id.to_hex(), &bucket);
             requests.push(durable.post::<_, ()>(
                 BINDING_DAP_AGGREGATE_STORE,
                 DURABLE_AGGREGATE_STORE_MARK_COLLECTED,

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -406,11 +406,7 @@ impl<'srv> DapAggregator<DaphneWorkerAuth> for DaphneWorker<'srv> {
                         DURABLE_AGGREGATE_STORE_MERGE,
                         agg_store_name,
                         AggregateStoreMergeReq {
-                            contained_reports: report_metadatas
-                                .iter()
-                                .map(|(id, _)| id)
-                                .cloned()
-                                .collect(),
+                            contained_reports: report_metadatas.iter().map(|(id, _)| *id).collect(),
                             agg_share_delta: agg_share,
                         },
                     )

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -65,7 +65,7 @@ impl DapReportInitializer for DaphneWorker<'_> {
                     reports_processed_request_data
                         .entry(durable_name)
                         .or_insert_with(Vec::new)
-                        .push(id)
+                        .push(id);
                 }
                 agg_store_request_names.push((
                     bucket,

--- a/daphne_worker/src/roles/helper.rs
+++ b/daphne_worker/src/roles/helper.rs
@@ -37,7 +37,7 @@ impl<'srv> DapHelper<DaphneWorkerAuth> for DaphneWorker<'srv> {
             .post(
                 BINDING_DAP_HELPER_STATE_STORE,
                 DURABLE_HELPER_STATE_PUT_IF_NOT_EXISTS,
-                durable_helper_state_name(&task_config.as_ref().version, task_id, agg_job_id),
+                durable_helper_state_name(task_config.as_ref().version, task_id, agg_job_id),
                 helper_state_hex,
             )
             .await
@@ -58,7 +58,7 @@ impl<'srv> DapHelper<DaphneWorkerAuth> for DaphneWorker<'srv> {
             .get(
                 BINDING_DAP_HELPER_STATE_STORE,
                 DURABLE_HELPER_STATE_GET,
-                durable_helper_state_name(&task_config.as_ref().version, task_id, agg_job_id),
+                durable_helper_state_name(task_config.as_ref().version, task_id, agg_job_id),
             )
             .await
             .map_err(|e| fatal_error!(err = ?e))?;

--- a/daphne_worker/src/roles/leader.rs
+++ b/daphne_worker/src/roles/leader.rs
@@ -138,7 +138,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
         //
         // TODO Figure out if we can safely handle each instance in parallel.
         let mut reports_per_task: HashMap<TaskId, Vec<Report>> = HashMap::new();
-        for reports_pending_id_hex in res.into_iter() {
+        for reports_pending_id_hex in res {
             let reports_from_durable: Vec<PendingReport> = durable
                 .post_by_id_hex(
                     BINDING_DAP_REPORTS_PENDING,
@@ -170,7 +170,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
 
         let mut reports_per_task_part: HashMap<TaskId, HashMap<PartialBatchSelector, Vec<Report>>> =
             HashMap::new();
-        for (task_id, mut reports) in reports_per_task.into_iter() {
+        for (task_id, mut reports) in reports_per_task {
             let task_config = self
                 .get_task_config(&task_id)
                 .await
@@ -193,7 +193,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
                         )
                         .await
                         .map_err(|e| fatal_error!(err = ?e))?;
-                    for batch_count in batch_assignments.into_iter() {
+                    for batch_count in batch_assignments {
                         let BatchCount {
                             batch_id,
                             report_count,

--- a/daphne_worker/src/roles/leader.rs
+++ b/daphne_worker/src/roles/leader.rs
@@ -214,7 +214,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
             };
         }
 
-        for (task_id, reports) in reports_per_task_part.iter() {
+        for (task_id, reports) in &reports_per_task_part {
             let mut report_count = 0;
             for reports in reports.values() {
                 report_count += reports.len();

--- a/daphne_worker/src/roles/leader.rs
+++ b/daphne_worker/src/roles/leader.rs
@@ -188,7 +188,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
                         .post(
                             BINDING_DAP_LEADER_BATCH_QUEUE,
                             DURABLE_LEADER_BATCH_QUEUE_ASSIGN,
-                            durable_name_task(&task_config.as_ref().version, &task_id_hex),
+                            durable_name_task(task_config.as_ref().version, &task_id_hex),
                             &(task_config.as_ref().min_batch_size, num_unassigned),
                         )
                         .await
@@ -316,7 +316,7 @@ impl<'srv> DapLeader<DaphneWorkerAuth> for DaphneWorker<'srv> {
                 .post(
                     BINDING_DAP_LEADER_BATCH_QUEUE,
                     DURABLE_LEADER_BATCH_QUEUE_REMOVE,
-                    durable_name_task(&task_config.as_ref().version, &task_id.to_hex()),
+                    durable_name_task(task_config.as_ref().version, &task_id.to_hex()),
                     batch_id.to_hex(),
                 )
                 .await

--- a/daphne_worker/src/router/leader.rs
+++ b/daphne_worker/src/router/leader.rs
@@ -70,24 +70,19 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                 if version != DapVersion::Draft02 {
                     return Response::error("not implemented", 404);
                 }
-                let task_id = match ctx.param("task_id").and_then(TaskId::try_from_base64url) {
-                    Some(id) => id,
-                    None => {
-                        return ctx.data.dap_abort_to_worker_response(DapAbort::BadRequest(
-                            "missing task_id parameter".to_string(),
-                        ))
-                    }
+                let Some(task_id) = ctx.param("task_id").and_then(TaskId::try_from_base64url)
+                else {
+                    return ctx.data.dap_abort_to_worker_response(DapAbort::BadRequest(
+                        "missing task_id parameter".to_string(),
+                    ));
                 };
-                let collect_id = match ctx
+                let Some(collect_id) = ctx
                     .param("collect_id")
                     .and_then(CollectionJobId::try_from_base64url)
-                {
-                    Some(id) => id,
-                    None => {
-                        return ctx.data.dap_abort_to_worker_response(DapAbort::BadRequest(
-                            "missing collect_id parameter".to_string(),
-                        ))
-                    }
+                else {
+                    return ctx.data.dap_abort_to_worker_response(DapAbort::BadRequest(
+                        "missing collect_id parameter".to_string(),
+                    ));
                 };
                 let daph = ctx.data.handler(&ctx.env);
                 match daph
@@ -146,17 +141,15 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                 //
                 // We can unwrap() here as the parameter really must exist.
                 let collect_job_id_base64url = ctx.param("collect_job_id").unwrap();
-                let collect_job_id =
-                    match CollectionJobId::try_from_base64url(collect_job_id_base64url) {
-                        Some(id) => id,
-                        None => {
-                            return daph
-                                .state
-                                .dap_abort_to_worker_response(DapAbort::BadRequest(
-                                    "malformed collect id".into(),
-                                ))
-                        }
-                    };
+                let Some(collect_job_id) =
+                    CollectionJobId::try_from_base64url(collect_job_id_base64url)
+                else {
+                    return daph
+                        .state
+                        .dap_abort_to_worker_response(DapAbort::BadRequest(
+                            "malformed collect id".into(),
+                        ));
+                };
 
                 let span = info_span!(
                     "poll_collect_job",

--- a/daphne_worker/src/router/mod.rs
+++ b/daphne_worker/src/router/mod.rs
@@ -58,7 +58,7 @@ pub(super) type DapRouter<'s> = Router<'s, &'s DaphneWorkerRequestState<'s>>;
 pub(super) fn create_router<'s>(
     state: &'s DaphneWorkerRequestState<'s>,
     opts: RouterOptions,
-) -> Result<DapRouter<'s>> {
+) -> DapRouter<'s> {
     let router = Router::with_data(state);
 
     let router = aggregator::add_aggregator_routes(router);
@@ -74,7 +74,7 @@ pub(super) fn create_router<'s>(
         router
     };
 
-    let router = if opts.enable_default_response {
+    if opts.enable_default_response {
         router.or_else_any_method_async("/*catchall", |_req, ctx| async move {
             match ctx.var("DAP_DEFAULT_RESPONSE_HTML") {
                 Ok(text) => Response::from_html(text.to_string()),
@@ -83,9 +83,7 @@ pub(super) fn create_router<'s>(
         })
     } else {
         router
-    };
-
-    Ok(router)
+    }
 }
 
 fn dap_response_to_worker(resp: DapResponse) -> Result<Response> {

--- a/daphne_worker/src/router/test_routes.rs
+++ b/daphne_worker/src/router/test_routes.rs
@@ -39,15 +39,14 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
                     // Return the ID of the oldest, not-yet-collecgted batch for the specified
                     // task. The task ID and batch ID are both encoded in URL-safe base64.
                     let daph = ctx.data.handler(&ctx.env);
-                    let task_id =
-                        match ctx.param("task_id").and_then(TaskId::try_from_base64url) {
-                            Some(id) => id,
-                            None => {
-                                return daph.state.dap_abort_to_worker_response(
-                                    DapAbort::BadRequest("missing or malformed task ID".into()),
-                                )
-                            }
-                        };
+                    let Some(task_id) = ctx.param("task_id").and_then(TaskId::try_from_base64url)
+                    else {
+                        return daph
+                            .state
+                            .dap_abort_to_worker_response(DapAbort::BadRequest(
+                                "missing or malformed task ID".into(),
+                            ));
+                    };
                     match daph
                         .internal_current_batch(&task_id)
                         .instrument(info_span!("current_batch"))

--- a/daphne_worker/src/router/test_routes.rs
+++ b/daphne_worker/src/router/test_routes.rs
@@ -83,9 +83,9 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
             |mut req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
                 let cmd: InternalTestEndpointForTask = req.json().await?;
-                daph.internal_endpoint_for_task(daph.config().default_version, cmd)
-                    .instrument(info_span!("endpoint_for_task"))
-                    .await
+                info_span!("endpoint_for_task").in_scope(|| {
+                    daph.internal_endpoint_for_task(daph.config().default_version, cmd)
+                })
             },
         )
         .post_async(
@@ -95,9 +95,8 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
                 let cmd: InternalTestEndpointForTask = req.json().await?;
                 let version = DaphneWorker::parse_version_param(&ctx)
                     .map_err(|e| worker::Error::RustError(e.to_string()))?;
-                daph.internal_endpoint_for_task(version, cmd)
-                    .instrument(info_span!("endpoint_for_task"))
-                    .await
+                info_span!("endpoint_for_task")
+                    .in_scope(|| daph.internal_endpoint_for_task(version, cmd))
             },
         )
         .post_async("/internal/test/add_task", |mut req, ctx| async move {

--- a/daphne_worker/src/tracing_utils/mod.rs
+++ b/daphne_worker/src/tracing_utils/mod.rs
@@ -12,7 +12,7 @@ use tracing_core::Field;
 use tracing_subscriber::{
     fmt,
     fmt::{format::Writer, time::FormatTime},
-    layer::*,
+    layer::{Layered, SubscriberExt},
     prelude::*,
     registry, EnvFilter, Layer,
 };

--- a/daphne_worker/src/tracing_utils/mod.rs
+++ b/daphne_worker/src/tracing_utils/mod.rs
@@ -66,7 +66,7 @@ impl<'a> Visit for JsonVisitor<'a> {
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        if let Ok(value) = serde_json::to_value(format!("{:?}", value)) {
+        if let Ok(value) = serde_json::to_value(format!("{value:?}")) {
             self.0.insert(field.name().to_string(), value);
         }
     }

--- a/daphne_worker/src/tracing_utils/mod.rs
+++ b/daphne_worker/src/tracing_utils/mod.rs
@@ -72,8 +72,8 @@ impl<'a> Visit for JsonVisitor<'a> {
     }
 }
 
-/// WasmTime provides a `tracing_subscriber::fmt::time::FormatTime` implementation that works
-/// using the clock available to WASM code, as the default FormatTime implementation does not
+/// `WasmTime` provides a `tracing_subscriber::fmt::time::FormatTime` implementation that works
+/// using the clock available to WASM code, as the default `FormatTime` implementation does not
 /// work.
 struct WasmTime {}
 
@@ -92,9 +92,9 @@ impl FormatTime for WasmTime {
     }
 }
 
-/// LogWriter helps us write to the worker console.
+/// `LogWriter` helps us write to the worker console.
 ///
-/// It provides and io::Write implementation that provides line buffering. It also takes care of
+/// It provides and `io::Write` implementation that provides line buffering. It also takes care of
 /// emitting a timestamp as the timestamp code in the tracing library tries to use standard clock
 /// code, which does not work in a worker.
 struct LogWriter {
@@ -185,7 +185,7 @@ where
 
 /// Setup logging.
 ///
-/// Initialize tracing using configuration from DAP_TRACING in the environment
+/// Initialize tracing using configuration from `DAP_TRACING` in the environment
 /// if present, otherwise using a default level of `info` and more severe.
 ///
 /// Panics if the log handler cannot be installed.

--- a/daphne_worker/src/tracing_utils/wasm_timing.rs
+++ b/daphne_worker/src/tracing_utils/wasm_timing.rs
@@ -55,11 +55,7 @@ pub(crate) fn initialize_timing_histograms(
     registry: &Registry,
     prefix: Option<&str>,
 ) -> Result<(), DapError> {
-    let front = if let Some(prefix) = prefix {
-        format!("{prefix}_")
-    } else {
-        "".into()
-    };
+    let front = prefix.map(|p| format!("{p}_")).unwrap_or_default();
     let aggregation_init_request_times = register_histogram_with_registry!(
         format!("{front}aggregation_init_request_times"),
         "Time taken to process an aggregation",

--- a/daphne_worker/src/tracing_utils/wasm_timing.rs
+++ b/daphne_worker/src/tracing_utils/wasm_timing.rs
@@ -101,7 +101,7 @@ pub(crate) fn initialize_timing_histograms(
     Ok(())
 }
 
-/// WasmTimingLayer provides a span's elapsed time.
+/// `WasmTimingLayer` provides a span's elapsed time.
 pub(super) struct WasmTimingLayer;
 
 fn milli_now() -> i64 {

--- a/daphne_worker/src/tracing_utils/wasm_timing.rs
+++ b/daphne_worker/src/tracing_utils/wasm_timing.rs
@@ -104,14 +104,14 @@ pub(crate) fn initialize_timing_histograms(
 /// `WasmTimingLayer` provides a span's elapsed time.
 pub(super) struct WasmTimingLayer;
 
-fn milli_now() -> i64 {
-    Date::now().as_millis() as i64
+fn milli_now() -> u64 {
+    Date::now().as_millis()
 }
 
 struct Timestamps {
-    busy: i64,
-    entered_at: i64,
-    started_at: i64,
+    busy: u64,
+    entered_at: u64,
+    started_at: u64,
 }
 
 impl Timestamps {

--- a/daphne_worker/src/tracing_utils/workers_json_layer.rs
+++ b/daphne_worker/src/tracing_utils/workers_json_layer.rs
@@ -52,7 +52,7 @@ where
                         .entry("current_span".to_owned())
                         .or_insert(serde_json::json!(span.name()));
 
-                    for f in span.fields().iter() {
+                    for f in span.fields() {
                         if let Some(value) = data.and_then(|d| d.get(f.name())) {
                             // As we are going from current span to root, prioritize existing values.
                             fields.entry(f.name().to_owned()).or_insert(value.clone());

--- a/daphne_worker_test/docker/runtests.Dockerfile
+++ b/daphne_worker_test/docker/runtests.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-bullseye
+FROM rust:1.73-bullseye
 
 WORKDIR /tmp/dap_test
 

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -3,7 +3,7 @@
 
 use daphne_worker::{initialize_tracing, DaphneWorkerRouter};
 use tracing::info;
-use worker::*;
+use worker::{event, Env, Request, Response, Result};
 
 mod utils;
 

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::ignored_unit_patterns)]
+#![allow(clippy::if_not_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::redundant_closure_for_method_calls)]
+#![allow(clippy::inconsistent_struct_constructor)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::inline_always)]
+
 use daphne_worker::{initialize_tracing, DaphneWorkerRouter};
 use tracing::info;
 use worker::{event, Env, Request, Response, Result};

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -1204,9 +1204,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
         query: if use_current {
             Query::FixedSizeCurrentBatch
         } else {
-            Query::FixedSizeByBatchId {
-                batch_id: batch_id.clone(),
-            }
+            Query::FixedSizeByBatchId { batch_id }
         },
         agg_param: Vec::new(),
     };
@@ -1240,9 +1238,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
         .consume_encrypted_agg_shares(
             &t.collector_hpke_receiver,
             &t.task_id,
-            &BatchSelector::FixedSizeByBatchId {
-                batch_id: batch_id.clone(),
-            },
+            &BatchSelector::FixedSizeByBatchId { batch_id },
             collection.report_count,
             collection.encrypted_agg_shares.clone(),
             version,
@@ -1306,7 +1302,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
             CollectionReq {
                 draft02_task_id: t.collect_task_id_field(),
                 query: Query::FixedSizeByBatchId {
-                    batch_id: prev_batch_id.clone(),
+                    batch_id: prev_batch_id,
                 },
                 agg_param: Vec::new(),
             }
@@ -1324,7 +1320,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
             CollectionReq {
                 draft02_task_id: t.collect_task_id_field(),
                 query: Query::FixedSizeByBatchId {
-                    batch_id: prev_batch_id.clone(),
+                    batch_id: prev_batch_id,
                 },
                 agg_param: Vec::new(),
             }
@@ -1419,7 +1415,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
 
     // Get the collect URI.
     let collect_req = CollectionReq {
-        draft02_task_id: Some(task_id.clone()),
+        draft02_task_id: Some(task_id),
         query: Query::TimeInterval {
             batch_interval: batch_interval.clone(),
         },

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -140,7 +140,7 @@ impl TestRunner {
         let collector_bearer_token = hex::encode(rng.gen::<[u8; 16]>());
         let t = Self {
             global_config,
-            task_id: task_id.clone(),
+            task_id,
             now,
             task_config,
             leader_url,
@@ -725,7 +725,7 @@ impl TestRunner {
 
     pub fn collect_task_id_field(&self) -> Option<TaskId> {
         if self.version == DapVersion::Draft02 {
-            Some(self.task_id.clone())
+            Some(self.task_id)
         } else {
             None
         }

--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-alpine AS builder
+FROM rust:1.73-alpine AS builder
 WORKDIR /tmp/dap_test
 RUN apk add --update \
     bash \


### PR DESCRIPTION
Each commit fixes one kind of warning included in the clippy::pendantic lint
group.

Some of the warnings in this group are too strict or provide too many false
positives but a lot of them, in my opinion, reduce code noise and improve
reliablity of the code. So I've enabled pendantic warning levels in all top
level files and disabled the ones that I think are more noise than benefit.

Some of these lints can be automatically fixed with `cargo clippy --all --fix -- -W clippy::WARNING_NAME`

