### PR TITLE
Improvements for taskprov

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -74,7 +74,6 @@ use crate::{
         AggregationJobId, BatchId, BatchSelector, Collection, CollectionJobId,
         Draft02AggregationJobId, Duration, Interval, PartialBatchSelector, ReportId, TaskId, Time,
     },
-    taskprov::TaskprovVersion,
     vdaf::{VdafAggregateShare, VdafPrepMessage, VdafPrepState, VdafVerifyKey},
 };
 use constants::DapMediaType;
@@ -171,9 +170,9 @@ pub struct DapGlobalConfig {
     /// receiver config.
     pub supported_hpke_kems: Vec<HpkeKemId>,
 
-    /// Is the taskprov extension allowed and which taskprov draft should be used?
+    /// Indicates if the taskprov extension is enabled.
     #[serde(default)]
-    pub taskprov_version: Option<TaskprovVersion>,
+    pub allow_taskprov: bool,
 }
 
 impl DapGlobalConfig {

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -8,8 +8,8 @@ use crate::messages::{
     decode_u16_bytes, encode_u16_bytes, Duration, Time, QUERY_TYPE_FIXED_SIZE,
     QUERY_TYPE_TIME_INTERVAL,
 };
-use crate::taskprov::TaskprovVersion;
 use crate::vdaf::VDAF_VERIFY_KEY_SIZE_PRIO2;
+use crate::DapVersion;
 use prio::codec::{
     decode_u16_items, decode_u8_items, encode_u16_items, encode_u8_items, CodecError, Decode,
     Encode, ParameterizedDecode, ParameterizedEncode,
@@ -192,8 +192,8 @@ impl QueryConfig {
     }
 }
 
-impl ParameterizedEncode<TaskprovVersion> for QueryConfig {
-    fn encode_with_param(&self, _encoding_parameter: &TaskprovVersion, bytes: &mut Vec<u8>) {
+impl ParameterizedEncode<DapVersion> for QueryConfig {
+    fn encode_with_param(&self, _version: &DapVersion, bytes: &mut Vec<u8>) {
         self.encode_query_type(bytes);
         self.time_precision.encode(bytes);
         self.max_batch_query_count.encode(bytes);
@@ -207,9 +207,9 @@ impl ParameterizedEncode<TaskprovVersion> for QueryConfig {
     }
 }
 
-impl ParameterizedDecode<TaskprovVersion> for QueryConfig {
+impl ParameterizedDecode<DapVersion> for QueryConfig {
     fn decode_with_param(
-        _decoding_parameter: &TaskprovVersion,
+        _version: &DapVersion,
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         let query_type = u8::decode(bytes)?;
@@ -242,26 +242,25 @@ pub struct TaskConfig {
     pub vdaf_config: VdafConfig,
 }
 
-impl ParameterizedEncode<TaskprovVersion> for TaskConfig {
-    fn encode_with_param(&self, encoding_parameter: &TaskprovVersion, bytes: &mut Vec<u8>) {
+impl ParameterizedEncode<DapVersion> for TaskConfig {
+    fn encode_with_param(&self, version: &DapVersion, bytes: &mut Vec<u8>) {
         encode_u8_items(bytes, &(), &self.task_info);
         encode_u16_items(bytes, &(), &self.aggregator_endpoints);
-        self.query_config
-            .encode_with_param(encoding_parameter, bytes);
+        self.query_config.encode_with_param(version, bytes);
         self.task_expiration.encode(bytes);
         self.vdaf_config.encode(bytes);
     }
 }
 
-impl ParameterizedDecode<TaskprovVersion> for TaskConfig {
+impl ParameterizedDecode<DapVersion> for TaskConfig {
     fn decode_with_param(
-        decoding_parameter: &TaskprovVersion,
+        version: &DapVersion,
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         Ok(TaskConfig {
             task_info: decode_u8_items(&(), bytes)?,
             aggregator_endpoints: decode_u16_items(&(), bytes)?,
-            query_config: QueryConfig::decode_with_param(decoding_parameter, bytes)?,
+            query_config: QueryConfig::decode_with_param(version, bytes)?,
             task_expiration: Time::decode(bytes)?,
             vdaf_config: VdafConfig::decode(bytes)?,
         })

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -60,7 +60,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
         // taskprov: Resolve the task config to use for the request. We also need to ensure
         // that all of the reports include the task config in the report extensions. (See
         // section 6 of draft-wang-ppm-dap-taskprov-02.)
-        if let Some(taskprov_version) = self.get_global_config().taskprov_version {
+        if self.get_global_config().allow_taskprov {
             let using_taskprov = agg_job_init_req
                 .prep_inits
                 .iter()
@@ -68,7 +68,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
                     prep_init
                         .report_share
                         .report_metadata
-                        .is_taskprov(taskprov_version, task_id)
+                        .is_taskprov(req.version, task_id)
                 })
                 .count();
 
@@ -91,7 +91,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
                     });
                 }
             };
-            resolve_taskprov(self, task_id, req, first_metadata, taskprov_version).await?;
+            resolve_taskprov(self, task_id, req, first_metadata).await?;
         }
 
         let wrapped_task_config = self
@@ -210,8 +210,8 @@ pub trait DapHelper<S>: DapAggregator<S> {
         metrics: &DaphneMetrics,
         task_id: &TaskId,
     ) -> Result<DapResponse, DapAbort> {
-        if let Some(taskprov_version) = self.get_global_config().taskprov_version {
-            resolve_taskprov(self, task_id, req, None, taskprov_version).await?;
+        if self.get_global_config().allow_taskprov {
+            resolve_taskprov(self, task_id, req, None).await?;
         }
         let wrapped_task_config = self
             .get_task_config_for(task_id)
@@ -315,8 +315,8 @@ pub trait DapHelper<S>: DapAggregator<S> {
 
         check_request_content_type(req, DapMediaType::AggregateShareReq)?;
 
-        if let Some(taskprov_version) = self.get_global_config().taskprov_version {
-            resolve_taskprov(self, task_id, req, None, taskprov_version).await?;
+        if self.get_global_config().allow_taskprov {
+            resolve_taskprov(self, task_id, req, None).await?;
         }
 
         let wrapped_task_config = self

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -157,15 +157,8 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
         debug!("report id is {}", report.report_metadata.id);
 
-        if let Some(taskprov_version) = self.get_global_config().taskprov_version {
-            resolve_taskprov(
-                self,
-                task_id,
-                req,
-                Some(&report.report_metadata),
-                taskprov_version,
-            )
-            .await?;
+        if self.get_global_config().allow_taskprov {
+            resolve_taskprov(self, task_id, req, Some(&report.report_metadata)).await?;
         }
         let task_config = self
             .get_task_config_for(task_id)
@@ -227,8 +220,8 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
 
         check_request_content_type(req, DapMediaType::CollectReq)?;
 
-        if let Some(taskprov_version) = self.get_global_config().taskprov_version {
-            resolve_taskprov(self, task_id, req, None, taskprov_version).await?;
+        if self.get_global_config().allow_taskprov {
+            resolve_taskprov(self, task_id, req, None).await?;
         }
 
         let wrapped_task_config = self

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -1753,14 +1753,12 @@ mod test {
         // Create the upload extension.
         let taskprov_ext_payload = taskprov::TaskConfig {
             task_info: "cool task".as_bytes().to_vec(),
-            aggregator_endpoints: vec![
-                taskprov::UrlBytes {
-                    bytes: b"https://leader.com/".to_vec(),
-                },
-                taskprov::UrlBytes {
-                    bytes: b"http://helper.org:8788/".to_vec(),
-                },
-            ],
+            leader_url: taskprov::UrlBytes {
+                bytes: b"https://leader.com/".to_vec(),
+            },
+            helper_url: taskprov::UrlBytes {
+                bytes: b"http://helper.org:8788/".to_vec(),
+            },
             query_config: taskprov::QueryConfig {
                 time_precision: 3600,
                 max_batch_query_count: 1,

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -137,8 +137,7 @@ impl<'req> EarlyReportStateConsumed<'req> {
             DapVersion::Draft07 => CTX_INPUT_SHARE_DRAFT07,
         };
         let n: usize = input_share_text.len();
-        let mut info = Vec::new();
-        info.reserve(n + 2);
+        let mut info = Vec::with_capacity(n + 2);
         info.extend_from_slice(input_share_text);
         info.push(CTX_ROLE_CLIENT); // Sender role (receiver role set below)
         info.push(if is_leader {
@@ -611,8 +610,7 @@ impl VdafConfig {
             DapVersion::Draft07 => CTX_INPUT_SHARE_DRAFT07,
         };
         let n: usize = input_share_text.len();
-        let mut info = Vec::new();
-        info.reserve(n + 2);
+        let mut info = Vec::with_capacity(n + 2);
         info.extend_from_slice(input_share_text);
         info.push(CTX_ROLE_CLIENT); // Sender role
         info.push(CTX_ROLE_LEADER); // Receiver role placeholder; updated below.
@@ -1529,8 +1527,7 @@ impl VdafConfig {
             DapVersion::Draft07 => CTX_AGG_SHARE_DRAFT07,
         };
         let n: usize = agg_share_text.len();
-        let mut info = Vec::new();
-        info.reserve(n + 2);
+        let mut info = Vec::with_capacity(n + 2);
         info.extend_from_slice(agg_share_text);
         info.push(CTX_ROLE_LEADER); // Sender role placeholder
         info.push(CTX_ROLE_COLLECTOR); // Receiver role
@@ -1590,8 +1587,7 @@ fn produce_encrypted_agg_share(
         DapVersion::Draft07 => CTX_AGG_SHARE_DRAFT07,
     };
     let n: usize = agg_share_text.len();
-    let mut info = Vec::new();
-    info.reserve(n + 2);
+    let mut info = Vec::with_capacity(n + 2);
     info.extend_from_slice(agg_share_text);
     info.push(if is_leader {
         CTX_ROLE_LEADER

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -209,7 +209,7 @@ impl DaphneWorkerConfig {
             trace!("DAP deployment override applied: {deployment:?}");
         }
 
-        let taskprov = if global.taskprov_version.is_some() {
+        let taskprov = if global.allow_taskprov {
             let hpke_collector_config = serde_json::from_str(
                 env.var("DAP_TASKPROV_HPKE_COLLECTOR_CONFIG")?
                     .to_string()

--- a/daphne_worker/src/roles/mod.rs
+++ b/daphne_worker/src/roles/mod.rs
@@ -96,7 +96,7 @@ impl<'srv> BearerTokenProvider for DaphneWorker<'srv> {
         task_config: &DapTaskConfig,
     ) -> std::result::Result<Option<BearerTokenKvPair<'s>>, DapError> {
         if let Some(ref taskprov_config) = self.config().taskprov {
-            if self.get_global_config().taskprov_version.is_some() && task_config.taskprov {
+            if self.get_global_config().allow_taskprov && task_config.taskprov {
                 return Ok(Some(BearerTokenKvPair::new(
                     task_id,
                     taskprov_config.leader_auth.as_ref(),
@@ -115,7 +115,7 @@ impl<'srv> BearerTokenProvider for DaphneWorker<'srv> {
         task_config: &DapTaskConfig,
     ) -> std::result::Result<Option<Self::WrappedBearerToken<'s>>, DapError> {
         if let Some(ref taskprov_config) = self.config().taskprov {
-            if self.get_global_config().taskprov_version.is_some() && task_config.taskprov {
+            if self.get_global_config().allow_taskprov && task_config.taskprov {
                 return Ok(Some(BearerTokenKvPair::new(
                     task_id,
                     taskprov_config

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -10,7 +10,6 @@ use daphne::{
     messages::{
         encode_base64url, BatchId, CollectionJobId, Duration, HpkeConfigList, Interval, TaskId,
     },
-    taskprov::TaskprovVersion,
     DapGlobalConfig, DapLeaderProcessTelemetry, DapQueryConfig, DapTaskConfig, DapVersion,
     Prio3Config, VdafConfig,
 };
@@ -118,7 +117,7 @@ impl TestRunner {
             min_batch_interval_start: 259200,
             max_batch_interval_end: 259200,
             supported_hpke_kems: vec![HpkeKemId::X25519HkdfSha256],
-            taskprov_version: Some(TaskprovVersion::Draft02),
+            allow_taskprov: true,
         };
         let taskprov_vdaf_verify_key_init =
             hex::decode("b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18")

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -34,7 +34,7 @@ DAP_GLOBAL_CONFIG = """{
      "min_batch_interval_start": 259200,
      "max_batch_interval_end": 259200,
      "supported_hpke_kems": ["x25519_hkdf_sha256"],
-     "taskprov_version": "v02"
+     "allow_taskprov": true
 }"""
 DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
 DAP_DEPLOYMENT = "dev"
@@ -114,8 +114,7 @@ DAP_GLOBAL_CONFIG = """{
   "min_batch_interval_start": 259200,
   "max_batch_interval_end": 259200,
   "supported_hpke_kems": ["x25519_hkdf_sha256"],
-  "allow_taskprov": true,
-  "taskprov_version": "v02"
+  "allow_taskprov": true
 }"""
 DAP_PROCESSED_ALARM_SAFETY_INTERVAL = "300"
 DAP_DEPLOYMENT = "dev"


### PR DESCRIPTION
* Remove `TaskprovVersion` and vary taskprov's behavior based on the DAP version. **Note that we have also repalaced the taskprov_version field of the global config with an allow_taskprov flag.
* Start aligning the `TaskConfig` serialization with DAP-07. (More work is needed.)