### PR TITLE
Update daphne traits so that they can be conditionally compiled with or without Send bounds

### DIFF
--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -48,4 +48,5 @@ tokio.workspace = true
 
 [features]
 test-utils = ["dep:assert_matches", "dep:deepsize"]
+send-traits = []
 default = []

--- a/daphne/src/auth.rs
+++ b/daphne/src/auth.rs
@@ -52,10 +52,11 @@ impl AsRef<BearerToken> for BearerToken {
 }
 
 /// A source of bearer tokens used for authorizing DAP requests.
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 pub trait BearerTokenProvider {
     /// A reference to a bearer token owned by the provider.
-    type WrappedBearerToken<'a>: AsRef<BearerToken>
+    type WrappedBearerToken<'a>: AsRef<BearerToken> + Send
     where
         Self: 'a;
 
@@ -101,7 +102,7 @@ pub trait BearerTokenProvider {
     ///
     /// Return `None` if the request is authorized. Otherwise return `Some(reason)`, where `reason`
     /// is the reason for the failure.
-    async fn bearer_token_authorized<T: AsRef<BearerToken>>(
+    async fn bearer_token_authorized<T: AsRef<BearerToken> + Sync>(
         &self,
         task_config: &DapTaskConfig,
         req: &DapRequest<T>,

--- a/daphne/src/hpke.rs
+++ b/daphne/src/hpke.rs
@@ -206,10 +206,11 @@ impl HpkeConfig {
 }
 
 /// HPKE decrypter functionality.
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 pub trait HpkeDecrypter {
     /// Return type of `get_hpke_config_for()`, wraps a reference to an HPKE config.
-    type WrappedHpkeConfig<'a>: AsRef<HpkeConfig>
+    type WrappedHpkeConfig<'a>: AsRef<HpkeConfig> + Send
     where
         Self: 'a;
 
@@ -329,7 +330,8 @@ impl TryFrom<(HpkeConfig, HpkePrivateKey)> for HpkeReceiverConfig {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl HpkeDecrypter for HpkeReceiverConfig {
     type WrappedHpkeConfig<'a> = HpkeConfig;
 

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1234,11 +1234,31 @@ pub struct DapLeaderProcessTelemetry {
 /// string included in the HTTP request payload; in the latest draft, this is a 16-byte string
 /// included in the HTTP request path. This type unifies these into one type so that any protocol
 /// logic that is agnostic to these details can use the same object.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub enum MetaAggregationJobId {
     Draft02(Draft02AggregationJobId),
     DraftLatest(AggregationJobId),
 }
+
+macro_rules! generate_from_id_impls_for_meta_agg_job_id {
+    ($draft:ident => $t:ty) => {
+        impl From<&$t> for MetaAggregationJobId {
+            fn from(id: &$t) -> Self {
+                Self::$draft(*id)
+            }
+        }
+
+        impl From<$t> for MetaAggregationJobId {
+            fn from(id: $t) -> Self {
+                Self::$draft(id)
+            }
+        }
+    };
+}
+
+generate_from_id_impls_for_meta_agg_job_id!(Draft02 => Draft02AggregationJobId);
+generate_from_id_impls_for_meta_agg_job_id!(DraftLatest => AggregationJobId);
 
 impl MetaAggregationJobId {
     /// Generate a random ID of the type required for the version.

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -27,8 +27,9 @@ use crate::{
 };
 
 /// DAP Helper functionality.
-#[async_trait(?Send)]
-pub trait DapHelper<S>: DapAggregator<S> {
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
+pub trait DapHelper<S: Sync>: DapAggregator<S> {
     /// Store the Helper's aggregation-flow state unless it already exists. Returns a boolean
     /// indicating if the operation succeeded.
     async fn put_helper_state_if_not_exists<Id>(
@@ -51,7 +52,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
         Id: Into<MetaAggregationJobId> + Send;
 }
 
-pub async fn handle_agg_job_init_req<'req, S, A: DapHelper<S>>(
+pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
     aggregator: &A,
     req: &'req DapRequest<S>,
 ) -> Result<DapResponse, DapError> {
@@ -222,7 +223,7 @@ pub async fn handle_agg_job_init_req<'req, S, A: DapHelper<S>>(
     })
 }
 
-pub async fn handle_agg_job_cont_req<'req, S, A: DapHelper<S>>(
+pub async fn handle_agg_job_cont_req<'req, S: Sync, A: DapHelper<S>>(
     aggregator: &A,
     req: &'req DapRequest<S>,
 ) -> Result<DapResponse, DapError> {
@@ -304,7 +305,7 @@ pub async fn handle_agg_job_cont_req<'req, S, A: DapHelper<S>>(
 }
 
 /// Handle a request pertaining to an aggregation job.
-pub async fn handle_agg_job_req<'req, S, A: DapHelper<S>>(
+pub async fn handle_agg_job_req<'req, S: Sync, A: DapHelper<S>>(
     aggregator: &A,
     req: &DapRequest<S>,
 ) -> Result<DapResponse, DapError> {
@@ -318,7 +319,7 @@ pub async fn handle_agg_job_req<'req, S, A: DapHelper<S>>(
 
 /// Handle a request for an aggregate share. This is called by the Leader to complete a
 /// collection job.
-pub async fn handle_agg_share_req<'req, S, A: DapHelper<S>>(
+pub async fn handle_agg_share_req<'req, S: Sync, A: DapHelper<S>>(
     aggregator: &A,
     req: &DapRequest<S>,
 ) -> Result<DapResponse, DapError> {
@@ -474,7 +475,7 @@ fn resolve_agg_job_id<'id, S>(
     }
 }
 
-async fn finish_agg_job_and_aggregate<S>(
+async fn finish_agg_job_and_aggregate<S: Sync>(
     helper: &impl DapHelper<S>,
     task_id: &TaskId,
     task_config: &DapTaskConfig,

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -149,504 +149,517 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
 
     /// Send an HTTP PUT request.
     async fn send_http_put(&self, req: DapRequest<S>) -> Result<DapResponse, DapError>;
+}
 
-    /// Handle a report from a Client.
-    async fn handle_upload_req(&self, req: &DapRequest<S>) -> Result<(), DapError> {
-        let metrics = self.metrics();
-        let task_id = req.task_id()?;
-        debug!("upload for task {task_id}");
+/// Handle a report from a Client.
+pub async fn handle_upload_req<S, A: DapLeader<S>>(
+    aggregator: &A,
+    req: &DapRequest<S>,
+) -> Result<(), DapError> {
+    let metrics = aggregator.metrics();
+    let task_id = req.task_id()?;
+    debug!("upload for task {task_id}");
 
-        check_request_content_type(req, DapMediaType::Report)?;
+    check_request_content_type(req, DapMediaType::Report)?;
 
-        let report = Report::get_decoded_with_param(&req.version, req.payload.as_ref())
-            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
-        debug!("report id is {}", report.report_metadata.id);
+    let report = Report::get_decoded_with_param(&req.version, req.payload.as_ref())
+        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+    debug!("report id is {}", report.report_metadata.id);
 
-        if self.get_global_config().allow_taskprov {
-            resolve_taskprov(self, task_id, req, Some(&report.report_metadata)).await?;
-        }
-        let task_config = self
-            .get_task_config_for(task_id)
-            .await?
-            .ok_or(DapAbort::UnrecognizedTask)?;
+    if aggregator.get_global_config().allow_taskprov {
+        resolve_taskprov(aggregator, task_id, req, Some(&report.report_metadata)).await?;
+    }
+    let task_config = aggregator
+        .get_task_config_for(task_id)
+        .await?
+        .ok_or(DapAbort::UnrecognizedTask)?;
 
-        // Check whether the DAP version in the request matches the task config.
-        if task_config.as_ref().version != req.version {
-            return Err(
-                DapAbort::version_mismatch(req.version, task_config.as_ref().version).into(),
-            );
-        }
-
-        if report.encrypted_input_shares.len() != 2 {
-            return Err(DapAbort::InvalidMessage {
-                detail: format!(
-                    "expected exactly two encrypted input shares; got {}",
-                    report.encrypted_input_shares.len()
-                ),
-                task_id: Some(*task_id),
-            }
-            .into());
-        }
-
-        // Check that the indicated HpkeConfig is present.
-        //
-        // TODO spec: It's not clear if this behavior is MUST, SHOULD, or MAY.
-        if !self
-            .can_hpke_decrypt(req.task_id()?, report.encrypted_input_shares[0].config_id)
-            .await?
-        {
-            return Err(DapAbort::ReportRejected {
-                detail: "No current HPKE configuration matches the indicated ID.".into(),
-            }
-            .into());
-        }
-
-        // Check that the task has not expired.
-        if report.report_metadata.time >= task_config.as_ref().expiration {
-            return Err(DapAbort::ReportTooLate.into());
-        }
-
-        // Store the report for future processing. At this point, the report may be rejected if
-        // the Leader detects that the report was replayed or pertains to a batch that has already
-        // been collected.
-        self.put_report(&report, req.task_id()?).await?;
-
-        metrics.inbound_req_inc(DaphneRequestType::Upload);
-        Ok(())
+    // Check whether the DAP version in the request matches the task config.
+    if task_config.as_ref().version != req.version {
+        return Err(DapAbort::version_mismatch(req.version, task_config.as_ref().version).into());
     }
 
-    /// Handle a collect job from the Collector. The response is the URI that the Collector will
-    /// poll later on to get the collection.
-    async fn handle_collect_job_req(&self, req: &DapRequest<S>) -> Result<Url, DapError> {
-        let now = self.get_current_time();
-        let metrics = self.metrics();
-        let task_id = req.task_id()?;
-        debug!("collect for task {task_id}");
-
-        check_request_content_type(req, DapMediaType::CollectReq)?;
-
-        if self.get_global_config().allow_taskprov {
-            resolve_taskprov(self, task_id, req, None).await?;
+    if report.encrypted_input_shares.len() != 2 {
+        return Err(DapAbort::InvalidMessage {
+            detail: format!(
+                "expected exactly two encrypted input shares; got {}",
+                report.encrypted_input_shares.len()
+            ),
+            task_id: Some(*task_id),
         }
-
-        let wrapped_task_config = self
-            .get_task_config_for(req.task_id()?)
-            .await?
-            .ok_or(DapAbort::UnrecognizedTask)?;
-        let task_config = wrapped_task_config.as_ref();
-
-        if let Some(reason) = self.unauthorized_reason(task_config, req).await? {
-            error!("aborted unauthorized collect request: {reason}");
-            return Err(DapAbort::UnauthorizedRequest {
-                detail: reason,
-                task_id: *task_id,
-            }
-            .into());
-        }
-
-        let mut collect_req =
-            CollectionReq::get_decoded_with_param(&req.version, req.payload.as_ref())
-                .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
-
-        // Check whether the DAP version in the request matches the task config.
-        if task_config.version != req.version {
-            return Err(DapAbort::version_mismatch(req.version, task_config.version).into());
-        }
-
-        if collect_req.query == Query::FixedSizeCurrentBatch {
-            // This is where we assign the current batch, and convert the
-            // Query::FixedSizeCurrentBatch into a Query::FixedSizeByBatchId.
-            //
-            // TODO(bhalleycf) Note that currently we are just looking at the
-            // head of the uncollected batch queue, so there is no parallelism
-            // possible for collectors on a given task.  To allow multiple
-            // batches for a task to be collected concurrently for the same task,
-            // we'd need a more complex DO state that allowed us to have batch
-            // state go from unassigned -> in-progress -> complete.
-            let batch_id = self.current_batch(task_id).await?;
-            debug!("FixedSize batch id is {batch_id}");
-            collect_req.query = Query::FixedSizeByBatchId { batch_id };
-        }
-
-        // Ensure the batch boundaries are valid and that the batch doesn't overlap with previosuly
-        // collected batches.
-        let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
-        check_batch(
-            self,
-            task_config,
-            task_id,
-            &batch_selector,
-            &collect_req.agg_param,
-            now,
-        )
-        .await?;
-
-        // draft02 compatibility: In draft02, the collection job ID is generated as a result of the
-        // initial collection request, whereas in the latest draft, the collection job ID is parsed
-        // from the request path.
-        let collect_job_id = match (req.version, &req.resource) {
-            (DapVersion::Draft02, DapResource::Undefined) => None,
-            (DapVersion::DraftLatest, DapResource::CollectionJob(ref collect_job_id)) => {
-                Some(*collect_job_id)
-            }
-            (DapVersion::DraftLatest, DapResource::Undefined) => {
-                return Err(DapAbort::BadRequest("undefined resource".into()).into());
-            }
-            _ => unreachable!("unhandled resource {:?}", req.resource),
-        };
-
-        let collect_job_uri = self
-            .init_collect_job(task_id, &collect_job_id, &collect_req)
-            .await?;
-
-        metrics.inbound_req_inc(DaphneRequestType::Collect);
-        Ok(collect_job_uri)
+        .into());
     }
 
-    /// Run an aggregation job for a set of reports. Return the number of reports that were
-    /// aggregated successfully.
+    // Check that the indicated HpkeConfig is present.
     //
-    // TODO Handle non-encodable messages gracefully. The length of `reports` may be too long to
-    // encode in `AggregationJobInitReq`, in which case this method will panic. We should increase
-    // the capacity of this message in the spec. In the meantime, we should at a minimum log this
-    // when it happens.
-    async fn run_agg_job(
-        &self,
-        task_id: &TaskId,
-        task_config: &DapTaskConfig,
-        part_batch_sel: &PartialBatchSelector,
-        reports: Vec<Report>,
-    ) -> Result<u64, DapError> {
-        let metrics = self.metrics();
+    // TODO spec: It's not clear if this behavior is MUST, SHOULD, or MAY.
+    if !aggregator
+        .can_hpke_decrypt(req.task_id()?, report.encrypted_input_shares[0].config_id)
+        .await?
+    {
+        return Err(DapAbort::ReportRejected {
+            detail: "No current HPKE configuration matches the indicated ID.".into(),
+        }
+        .into());
+    }
 
-        let taskprov = task_config.resolve_taskprove_advertisement()?;
+    // Check that the task has not expired.
+    if report.report_metadata.time >= task_config.as_ref().expiration {
+        return Err(DapAbort::ReportTooLate.into());
+    }
 
-        // Prepare AggregationJobInitReq.
-        let agg_job_id = MetaAggregationJobId::gen_for_version(task_config.version);
-        let transition = task_config
-            .vdaf
-            .produce_agg_job_init_req(
-                self,
-                self,
-                task_id,
-                task_config,
-                &agg_job_id,
-                part_batch_sel,
-                reports,
-                metrics,
-            )
-            .await?;
+    // Store the report for future processing. At this point, the report may be rejected if
+    // the Leader detects that the report was replayed or pertains to a batch that has already
+    // been collected.
+    aggregator.put_report(&report, req.task_id()?).await?;
 
-        let (state, agg_job_init_req) = match transition {
-            DapLeaderAggregationJobTransition::Continued(state, agg_job_init_req) => {
-                (state, agg_job_init_req)
-            }
-            DapLeaderAggregationJobTransition::Finished(agg_span)
-                if agg_span.report_count() == 0 =>
-            {
-                return Ok(0)
-            }
-            DapLeaderAggregationJobTransition::Finished(..)
-            | DapLeaderAggregationJobTransition::Uncommitted(..) => {
-                return Err(fatal_error!(
-                    err = "unexpected state transition (uncommitted)"
-                ))
-            }
-        };
-        let method = if task_config.version != DapVersion::Draft02 {
-            LeaderHttpRequestMethod::Put
-        } else {
-            LeaderHttpRequestMethod::Post
-        };
-        let url_path = if task_config.version == DapVersion::Draft02 {
-            "aggregate".to_string()
-        } else {
-            format!(
-                "tasks/{}/aggregation_jobs/{}",
-                task_id.to_base64url(),
-                agg_job_id.to_base64url()
-            )
-        };
+    metrics.inbound_req_inc(DaphneRequestType::Upload);
+    Ok(())
+}
 
-        // Send AggregationJobInitReq and receive AggregationJobResp.
-        let resp = leader_send_http_request(
-            self,
-            task_id,
-            task_config,
-            LeaderHttpRequestOptions {
-                path: &url_path,
-                req_media_type: DapMediaType::AggregationJobInitReq,
-                resp_media_type: DapMediaType::AggregationJobResp,
-                resource: agg_job_id.for_request_path(),
-                req_data: agg_job_init_req.get_encoded_with_param(&task_config.version),
-                method,
-                taskprov: taskprov.clone(),
-            },
-        )
+/// Handle a collect job from the Collector. The response is the URI that the Collector will
+/// poll later on to get the collection.
+pub async fn handle_collect_job_req<S, A: DapLeader<S>>(
+    aggregator: &A,
+    req: &DapRequest<S>,
+) -> Result<Url, DapError> {
+    let now = aggregator.get_current_time();
+    let metrics = aggregator.metrics();
+    let task_id = req.task_id()?;
+    debug!("collect for task {task_id}");
+
+    check_request_content_type(req, DapMediaType::CollectReq)?;
+
+    if aggregator.get_global_config().allow_taskprov {
+        resolve_taskprov(aggregator, task_id, req, None).await?;
+    }
+
+    let wrapped_task_config = aggregator
+        .get_task_config_for(req.task_id()?)
+        .await?
+        .ok_or(DapAbort::UnrecognizedTask)?;
+    let task_config = wrapped_task_config.as_ref();
+
+    if let Some(reason) = aggregator.unauthorized_reason(task_config, req).await? {
+        error!("aborted unauthorized collect request: {reason}");
+        return Err(DapAbort::UnauthorizedRequest {
+            detail: reason,
+            task_id: *task_id,
+        }
+        .into());
+    }
+
+    let mut collect_req = CollectionReq::get_decoded_with_param(&req.version, req.payload.as_ref())
+        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+
+    // Check whether the DAP version in the request matches the task config.
+    if task_config.version != req.version {
+        return Err(DapAbort::version_mismatch(req.version, task_config.version).into());
+    }
+
+    if collect_req.query == Query::FixedSizeCurrentBatch {
+        // This is where we assign the current batch, and convert the
+        // Query::FixedSizeCurrentBatch into a Query::FixedSizeByBatchId.
+        //
+        // TODO(bhalleycf) Note that currently we are just looking at the
+        // head of the uncollected batch queue, so there is no parallelism
+        // possible for collectors on a given task.  To allow multiple
+        // batches for a task to be collected concurrently for the same task,
+        // we'd need a more complex DO state that allowed us to have batch
+        // state go from unassigned -> in-progress -> complete.
+        let batch_id = aggregator.current_batch(task_id).await?;
+        debug!("FixedSize batch id is {batch_id}");
+        collect_req.query = Query::FixedSizeByBatchId { batch_id };
+    }
+
+    // Ensure the batch boundaries are valid and that the batch doesn't overlap with previosuly
+    // collected batches.
+    let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
+    check_batch(
+        aggregator,
+        task_config,
+        task_id,
+        &batch_selector,
+        &collect_req.agg_param,
+        now,
+    )
+    .await?;
+
+    // draft02 compatibility: In draft02, the collection job ID is generated as a result of the
+    // initial collection request, whereas in the latest draft, the collection job ID is parsed
+    // from the request path.
+    let collect_job_id = match (req.version, &req.resource) {
+        (DapVersion::Draft02, DapResource::Undefined) => None,
+        (DapVersion::DraftLatest, DapResource::CollectionJob(ref collect_job_id)) => {
+            Some(*collect_job_id)
+        }
+        (DapVersion::DraftLatest, DapResource::Undefined) => {
+            return Err(DapAbort::BadRequest("undefined resource".into()).into());
+        }
+        _ => unreachable!("unhandled resource {:?}", req.resource),
+    };
+
+    let collect_job_uri = aggregator
+        .init_collect_job(task_id, &collect_job_id, &collect_req)
         .await?;
-        let agg_job_resp = AggregationJobResp::get_decoded(&resp.payload)
-            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
-        // Handle AggregationJobResp.
-        let transition = task_config.vdaf.handle_agg_job_resp(
+    metrics.inbound_req_inc(DaphneRequestType::Collect);
+    Ok(collect_job_uri)
+}
+
+/// Run an aggregation job for a set of reports. Return the number of reports that were
+/// aggregated successfully.
+//
+// TODO Handle non-encodable messages gracefully. The length of `reports` may be too long to
+// encode in `AggregationJobInitReq`, in which case this method will panic. We should increase
+// the capacity of this message in the spec. In the meantime, we should at a minimum log this
+// when it happens.
+pub async fn run_agg_job<S, A: DapLeader<S>>(
+    aggregator: &A,
+    task_id: &TaskId,
+    task_config: &DapTaskConfig,
+    part_batch_sel: &PartialBatchSelector,
+    reports: Vec<Report>,
+) -> Result<u64, DapError> {
+    let metrics = aggregator.metrics();
+
+    let taskprov = task_config.resolve_taskprove_advertisement()?;
+
+    // Prepare AggregationJobInitReq.
+    let agg_job_id = MetaAggregationJobId::gen_for_version(task_config.version);
+    let transition = task_config
+        .vdaf
+        .produce_agg_job_init_req(
+            aggregator,
+            aggregator,
             task_id,
             task_config,
             &agg_job_id,
-            state,
-            agg_job_resp,
+            part_batch_sel,
+            reports,
             metrics,
-        )?;
-        let agg_span = match transition {
-            DapLeaderAggregationJobTransition::Uncommitted(uncommited, agg_job_cont_req) => {
-                // Send AggregationJobContinueReq and receive AggregationJobResp.
-                let resp = leader_send_http_request(
-                    self,
-                    task_id,
-                    task_config,
-                    LeaderHttpRequestOptions {
-                        path: &url_path,
-                        req_media_type: DapMediaType::AggregationJobContinueReq,
-                        resp_media_type: DapMediaType::agg_job_cont_resp_for_version(
-                            task_config.version,
-                        ),
-                        resource: agg_job_id.for_request_path(),
-                        req_data: agg_job_cont_req.get_encoded_with_param(&task_config.version),
-                        method: LeaderHttpRequestMethod::Post,
-                        taskprov,
-                    },
-                )
-                .await?;
-                let agg_job_resp = AggregationJobResp::get_decoded(&resp.payload)
-                    .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
-
-                // Handle AggregationJobResp.
-                task_config.vdaf.handle_final_agg_job_resp(
-                    task_config,
-                    uncommited,
-                    agg_job_resp,
-                    metrics,
-                )?
-            }
-            DapLeaderAggregationJobTransition::Finished(agg_span) => {
-                if agg_span.report_count() > 0 {
-                    agg_span
-                } else {
-                    return Ok(0);
-                }
-            }
-            DapLeaderAggregationJobTransition::Continued(..) => {
-                return Err(fatal_error!(err = "unexpected state transition (continue)"))
-            }
-        };
-
-        let out_shares_count = agg_span.report_count() as u64;
-
-        // At this point we're committed to aggregating the reports: if we do detect an error (a
-        // report was replayed at this stage or the span overlaps with a collected batch), then we
-        // may end up with a batch mismatch. However, this should only happen if there are multiple
-        // aggregation jobs in-flight that include the same report.
-        let (replayed, collected) = self
-            .try_put_agg_share_span(task_id, task_config, agg_span)
-            .await
-            .into_iter()
-            .map(|(_bucket, (result, _report_metadata))| match result {
-                Ok(()) => Ok((0, 0)),
-                Err(MergeAggShareError::AlreadyCollected) => Ok((0, 1)),
-                Err(MergeAggShareError::ReplaysDetected(replays)) => Ok((replays.len(), 0)),
-                Err(MergeAggShareError::Other(e)) => Err(e),
-            })
-            .try_fold((0, 0), |(replayed, collected), rc| {
-                let (r, c) = rc?;
-                Ok::<_, DapError>((replayed + r, collected + c))
-            })?;
-
-        if replayed > 0 {
-            tracing::error!(
-                replay_count = replayed,
-                "tried to aggregate replayed reports"
-            );
-        }
-
-        if collected > 0 {
-            tracing::error!(
-                collected_count = collected,
-                "tried to aggregate reports belonging to collected spans"
-            );
-        }
-
-        metrics.report_inc_by("aggregated", out_shares_count);
-        Ok(out_shares_count)
-    }
-
-    /// Handle a pending collection job. If the results are ready, then compute the aggregate
-    /// results and store them to be retrieved by the Collector later. Returns the number of
-    /// reports in the batch.
-    async fn run_collect_job(
-        &self,
-        task_id: &TaskId,
-        collect_id: &CollectionJobId,
-        task_config: &DapTaskConfig,
-        collect_req: &CollectionReq,
-    ) -> Result<u64, DapError> {
-        let metrics = self.metrics();
-
-        debug!("collecting id {collect_id}");
-        let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
-        let leader_agg_share = self.get_agg_share(task_id, &batch_selector).await?;
-
-        let taskprov = task_config.resolve_taskprove_advertisement()?;
-
-        // Check the batch size. If not not ready, then return early.
-        //
-        // TODO Consider logging this error, as it should never happen.
-        if !task_config.is_report_count_compatible(task_id, leader_agg_share.report_count)? {
-            return Ok(0);
-        }
-
-        let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
-
-        // Prepare the Leader's aggregate share.
-        let leader_enc_agg_share = task_config.vdaf.produce_leader_encrypted_agg_share(
-            &task_config.collector_hpke_config,
-            task_id,
-            &batch_selector,
-            &collect_req.agg_param,
-            &leader_agg_share,
-            task_config.version,
-        )?;
-
-        // Prepare AggregateShareReq.
-        let agg_share_req = AggregateShareReq {
-            draft02_task_id: task_id.for_request_payload(&task_config.version),
-            batch_sel: batch_selector.clone(),
-            agg_param: collect_req.agg_param.clone(),
-            report_count: leader_agg_share.report_count,
-            checksum: leader_agg_share.checksum,
-        };
-
-        let url_path = if task_config.version == DapVersion::Draft02 {
-            "aggregate_share".to_string()
-        } else {
-            format!("tasks/{}/aggregate_shares", task_id.to_base64url())
-        };
-
-        // Send AggregateShareReq and receive AggregateShareResp.
-        let resp = leader_send_http_request(
-            self,
-            task_id,
-            task_config,
-            LeaderHttpRequestOptions {
-                path: &url_path,
-                req_media_type: DapMediaType::AggregateShareReq,
-                resp_media_type: DapMediaType::AggregateShare,
-                resource: DapResource::Undefined,
-                req_data: agg_share_req.get_encoded_with_param(&task_config.version),
-                method: LeaderHttpRequestMethod::Post,
-                taskprov,
-            },
         )
         .await?;
-        let agg_share_resp = AggregateShare::get_decoded(&resp.payload)
-            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
-        // In the latest draft, the Collection message includes the smallest quantized time
-        // interval containing all reports in the batch.
-        let draft_latest_interval = match task_config.version {
-            DapVersion::Draft02 => None,
-            DapVersion::DraftLatest => {
-                let low = task_config.quantized_time_lower_bound(leader_agg_share.min_time);
-                let high = task_config.quantized_time_upper_bound(leader_agg_share.max_time);
-                Some(Interval {
-                    start: low,
-                    duration: if high > low {
-                        high - low
-                    } else {
-                        // This should never happen!
-                        task_config.time_precision
-                    },
-                })
+
+    let (state, agg_job_init_req) = match transition {
+        DapLeaderAggregationJobTransition::Continued(state, agg_job_init_req) => {
+            (state, agg_job_init_req)
+        }
+        DapLeaderAggregationJobTransition::Finished(agg_span) if agg_span.report_count() == 0 => {
+            return Ok(0)
+        }
+        DapLeaderAggregationJobTransition::Finished(..)
+        | DapLeaderAggregationJobTransition::Uncommitted(..) => {
+            return Err(fatal_error!(
+                err = "unexpected state transition (uncommitted)"
+            ))
+        }
+    };
+    let method = if task_config.version != DapVersion::Draft02 {
+        LeaderHttpRequestMethod::Put
+    } else {
+        LeaderHttpRequestMethod::Post
+    };
+    let url_path = if task_config.version == DapVersion::Draft02 {
+        "aggregate".to_string()
+    } else {
+        format!(
+            "tasks/{}/aggregation_jobs/{}",
+            task_id.to_base64url(),
+            agg_job_id.to_base64url()
+        )
+    };
+
+    // Send AggregationJobInitReq and receive AggregationJobResp.
+    let resp = leader_send_http_request(
+        aggregator,
+        task_id,
+        task_config,
+        LeaderHttpRequestOptions {
+            path: &url_path,
+            req_media_type: DapMediaType::AggregationJobInitReq,
+            resp_media_type: DapMediaType::AggregationJobResp,
+            resource: agg_job_id.for_request_path(),
+            req_data: agg_job_init_req.get_encoded_with_param(&task_config.version),
+            method,
+            taskprov: taskprov.clone(),
+        },
+    )
+    .await?;
+    let agg_job_resp = AggregationJobResp::get_decoded(&resp.payload)
+        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+
+    // Handle AggregationJobResp.
+    let transition = task_config.vdaf.handle_agg_job_resp(
+        task_id,
+        task_config,
+        &agg_job_id,
+        state,
+        agg_job_resp,
+        metrics,
+    )?;
+    let agg_span = match transition {
+        DapLeaderAggregationJobTransition::Uncommitted(uncommited, agg_job_cont_req) => {
+            // Send AggregationJobContinueReq and receive AggregationJobResp.
+            let resp = leader_send_http_request(
+                aggregator,
+                task_id,
+                task_config,
+                LeaderHttpRequestOptions {
+                    path: &url_path,
+                    req_media_type: DapMediaType::AggregationJobContinueReq,
+                    resp_media_type: DapMediaType::agg_job_cont_resp_for_version(
+                        task_config.version,
+                    ),
+                    resource: agg_job_id.for_request_path(),
+                    req_data: agg_job_cont_req.get_encoded_with_param(&task_config.version),
+                    method: LeaderHttpRequestMethod::Post,
+                    taskprov,
+                },
+            )
+            .await?;
+            let agg_job_resp = AggregationJobResp::get_decoded(&resp.payload)
+                .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+
+            // Handle AggregationJobResp.
+            task_config.vdaf.handle_final_agg_job_resp(
+                task_config,
+                uncommited,
+                agg_job_resp,
+                metrics,
+            )?
+        }
+        DapLeaderAggregationJobTransition::Finished(agg_span) => {
+            if agg_span.report_count() > 0 {
+                agg_span
+            } else {
+                return Ok(0);
             }
-        };
+        }
+        DapLeaderAggregationJobTransition::Continued(..) => {
+            return Err(fatal_error!(err = "unexpected state transition (continue)"))
+        }
+    };
 
-        // Complete the collect job.
-        let collection = Collection {
-            part_batch_sel: batch_selector.into(),
-            report_count: leader_agg_share.report_count,
-            draft_latest_interval,
-            encrypted_agg_shares: [leader_enc_agg_share, agg_share_resp.encrypted_agg_share],
-        };
-        self.finish_collect_job(task_id, collect_id, &collection)
-            .await?;
+    let out_shares_count = agg_span.report_count() as u64;
 
-        // Mark reports as collected.
-        self.mark_collected(task_id, &agg_share_req.batch_sel)
-            .await?;
+    // At this point we're committed to aggregating the reports: if we do detect an error (a
+    // report was replayed at this stage or the span overlaps with a collected batch), then we
+    // may end up with a batch mismatch. However, this should only happen if there are multiple
+    // aggregation jobs in-flight that include the same report.
+    let (replayed, collected) = aggregator
+        .try_put_agg_share_span(task_id, task_config, agg_span)
+        .await
+        .into_iter()
+        .map(|(_bucket, (result, _report_metadata))| match result {
+            Ok(()) => Ok((0, 0)),
+            Err(MergeAggShareError::AlreadyCollected) => Ok((0, 1)),
+            Err(MergeAggShareError::ReplaysDetected(replays)) => Ok((replays.len(), 0)),
+            Err(MergeAggShareError::Other(e)) => Err(e),
+        })
+        .try_fold((0, 0), |(replayed, collected), rc| {
+            let (r, c) = rc?;
+            Ok::<_, DapError>((replayed + r, collected + c))
+        })?;
 
-        metrics.report_inc_by("collected", agg_share_req.report_count);
-        Ok(agg_share_req.report_count)
+    if replayed > 0 {
+        tracing::error!(
+            replay_count = replayed,
+            "tried to aggregate replayed reports"
+        );
     }
 
-    /// Fetch a set of reports grouped by task, then run an aggregation job for each task. Once all
-    /// jobs are completed, process the collect job queue. It is not safe to run multiple instances
-    /// of this function in parallel.
-    ///
-    /// This method is geared primarily towards testing. It also demonstrates how to properly
-    /// synchronize collect and aggregation jobs. If used in a large DAP deployment, it is likely
-    /// create a bottleneck. Such deployments can improve throughput by running many aggregation
-    /// jobs in parallel.
-    async fn process(
-        &self,
-        selector: &Self::ReportSelector,
-        host: &str,
-    ) -> Result<DapLeaderProcessTelemetry, DapError> {
-        let mut telem = DapLeaderProcessTelemetry::default();
+    if collected > 0 {
+        tracing::error!(
+            collected_count = collected,
+            "tried to aggregate reports belonging to collected spans"
+        );
+    }
 
-        tracing::debug!("RUNNING get_reports");
-        // Fetch reports and run an aggregation job for each task.
-        for (task_id, reports) in self.get_reports(selector).await? {
-            tracing::debug!("RUNNING get_task_config_for {task_id}");
-            let task_config = self
-                .get_task_config_for(&task_id)
-                .await?
-                .ok_or(DapAbort::UnrecognizedTask)?;
+    metrics.report_inc_by("aggregated", out_shares_count);
+    Ok(out_shares_count)
+}
 
-            for (part_batch_sel, reports) in reports {
-                // TODO Consider splitting reports into smaller chunks.
-                // TODO Consider handling tasks in parallel.
-                telem.reports_processed += reports.len() as u64;
-                debug!(
-                    "process {} reports for task {task_id} with selector {part_batch_sel:?}",
-                    reports.len()
+/// Handle a pending collection job. If the results are ready, then compute the aggregate
+/// results and store them to be retrieved by the Collector later. Returns the number of
+/// reports in the batch.
+pub async fn run_collect_job<S, A: DapLeader<S>>(
+    aggregator: &A,
+    task_id: &TaskId,
+    collect_id: &CollectionJobId,
+    task_config: &DapTaskConfig,
+    collect_req: &CollectionReq,
+) -> Result<u64, DapError> {
+    let metrics = aggregator.metrics();
+
+    debug!("collecting id {collect_id}");
+    let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
+    let leader_agg_share = aggregator.get_agg_share(task_id, &batch_selector).await?;
+
+    let taskprov = task_config.resolve_taskprove_advertisement()?;
+
+    // Check the batch size. If not not ready, then return early.
+    //
+    // TODO Consider logging this error, as it should never happen.
+    if !task_config.is_report_count_compatible(task_id, leader_agg_share.report_count)? {
+        return Ok(0);
+    }
+
+    let batch_selector = BatchSelector::try_from(collect_req.query.clone())?;
+
+    // Prepare the Leader's aggregate share.
+    let leader_enc_agg_share = task_config.vdaf.produce_leader_encrypted_agg_share(
+        &task_config.collector_hpke_config,
+        task_id,
+        &batch_selector,
+        &collect_req.agg_param,
+        &leader_agg_share,
+        task_config.version,
+    )?;
+
+    // Prepare AggregateShareReq.
+    let agg_share_req = AggregateShareReq {
+        draft02_task_id: task_id.for_request_payload(&task_config.version),
+        batch_sel: batch_selector.clone(),
+        agg_param: collect_req.agg_param.clone(),
+        report_count: leader_agg_share.report_count,
+        checksum: leader_agg_share.checksum,
+    };
+
+    let url_path = if task_config.version == DapVersion::Draft02 {
+        "aggregate_share".to_string()
+    } else {
+        format!("tasks/{}/aggregate_shares", task_id.to_base64url())
+    };
+
+    // Send AggregateShareReq and receive AggregateShareResp.
+    let resp = leader_send_http_request(
+        aggregator,
+        task_id,
+        task_config,
+        LeaderHttpRequestOptions {
+            path: &url_path,
+            req_media_type: DapMediaType::AggregateShareReq,
+            resp_media_type: DapMediaType::AggregateShare,
+            resource: DapResource::Undefined,
+            req_data: agg_share_req.get_encoded_with_param(&task_config.version),
+            method: LeaderHttpRequestMethod::Post,
+            taskprov,
+        },
+    )
+    .await?;
+    let agg_share_resp = AggregateShare::get_decoded(&resp.payload)
+        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+    // In the latest draft, the Collection message includes the smallest quantized time
+    // interval containing all reports in the batch.
+    let draft_latest_interval = match task_config.version {
+        DapVersion::Draft02 => None,
+        DapVersion::DraftLatest => {
+            let low = task_config.quantized_time_lower_bound(leader_agg_share.min_time);
+            let high = task_config.quantized_time_upper_bound(leader_agg_share.max_time);
+            Some(Interval {
+                start: low,
+                duration: if high > low {
+                    high - low
+                } else {
+                    // This should never happen!
+                    task_config.time_precision
+                },
+            })
+        }
+    };
+
+    // Complete the collect job.
+    let collection = Collection {
+        part_batch_sel: batch_selector.into(),
+        report_count: leader_agg_share.report_count,
+        draft_latest_interval,
+        encrypted_agg_shares: [leader_enc_agg_share, agg_share_resp.encrypted_agg_share],
+    };
+    aggregator
+        .finish_collect_job(task_id, collect_id, &collection)
+        .await?;
+
+    // Mark reports as collected.
+    aggregator
+        .mark_collected(task_id, &agg_share_req.batch_sel)
+        .await?;
+
+    metrics.report_inc_by("collected", agg_share_req.report_count);
+    Ok(agg_share_req.report_count)
+}
+
+/// Fetch a set of reports grouped by task, then run an aggregation job for each task. Once all
+/// jobs are completed, process the collect job queue. It is not safe to run multiple instances
+/// of this function in parallel.
+///
+/// This method is geared primarily towards testing. It also demonstrates how to properly
+/// synchronize collect and aggregation jobs. If used in a large DAP deployment, it is likely
+/// create a bottleneck. Such deployments can improve throughput by running many aggregation
+/// jobs in parallel.
+pub async fn process<S, A: DapLeader<S>>(
+    aggregator: &A,
+    selector: &A::ReportSelector,
+    host: &str,
+) -> Result<DapLeaderProcessTelemetry, DapError> {
+    let mut telem = DapLeaderProcessTelemetry::default();
+
+    tracing::debug!("RUNNING get_reports");
+    // Fetch reports and run an aggregation job for each task.
+    for (task_id, reports) in aggregator.get_reports(selector).await? {
+        tracing::debug!("RUNNING get_task_config_for {task_id}");
+        let task_config = aggregator
+            .get_task_config_for(&task_id)
+            .await?
+            .ok_or(DapAbort::UnrecognizedTask)?;
+
+        for (part_batch_sel, reports) in reports {
+            // TODO Consider splitting reports into smaller chunks.
+            // TODO Consider handling tasks in parallel.
+            telem.reports_processed += reports.len() as u64;
+            debug!(
+                "process {} reports for task {task_id} with selector {part_batch_sel:?}",
+                reports.len()
+            );
+            if !reports.is_empty() {
+                tracing::debug!(
+                    "RUNNING run_agg_job FOR TID {task_id} AND {part_batch_sel:?} AND {host}"
                 );
-                if !reports.is_empty() {
-                    tracing::debug!(
-                        "RUNNING run_agg_job FOR TID {task_id} AND {part_batch_sel:?} AND {host}"
-                    );
-                    telem.reports_aggregated += self
-                        .run_agg_job(&task_id, task_config.as_ref(), &part_batch_sel, reports)
-                        .await?;
-                }
+                telem.reports_aggregated += run_agg_job(
+                    aggregator,
+                    &task_id,
+                    task_config.as_ref(),
+                    &part_batch_sel,
+                    reports,
+                )
+                .await?;
             }
         }
-        // Process pending collect jobs. We wait until all aggregation jobs are finished before
-        // proceeding to this step. This is to prevent a race condition involving an aggregate
-        // share computed during a collect job and any output shares computed during an aggregation
-        // job.
-        tracing::debug!("GETTING get_pending_collect_jobs");
-        for (task_id, collect_id, collect_req) in self.get_pending_collect_jobs().await? {
-            tracing::debug!("GETTING get_task_config_for {task_id}");
-            let task_config = self
-                .get_task_config_for(&task_id)
-                .await?
-                .ok_or(DapAbort::UnrecognizedTask)?;
-
-            tracing::debug!("RUNNING run_collect_job FOR TID {task_id} AND {collect_id} AND {collect_req:?} AND {host}");
-            telem.reports_collected += self
-                .run_collect_job(&task_id, &collect_id, task_config.as_ref(), &collect_req)
-                .await?;
-        }
-
-        Ok(telem)
     }
+    // Process pending collect jobs. We wait until all aggregation jobs are finished before
+    // proceeding to this step. This is to prevent a race condition involving an aggregate
+    // share computed during a collect job and any output shares computed during an aggregation
+    // job.
+    tracing::debug!("GETTING get_pending_collect_jobs");
+    for (task_id, collect_id, collect_req) in aggregator.get_pending_collect_jobs().await? {
+        tracing::debug!("GETTING get_task_config_for {task_id}");
+        let task_config = aggregator
+            .get_task_config_for(&task_id)
+            .await?
+            .ok_or(DapAbort::UnrecognizedTask)?;
+
+        tracing::debug!("RUNNING run_collect_job FOR TID {task_id} AND {collect_id} AND {collect_req:?} AND {host}");
+        telem.reports_collected += run_collect_job(
+            aggregator,
+            &task_id,
+            &collect_id,
+            task_config.as_ref(),
+            &collect_req,
+        )
+        .await?;
+    }
+
+    Ok(telem)
 }
 
 fn check_response_content_type(resp: &DapResponse, expected: DapMediaType) -> Result<(), DapError> {

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -18,7 +18,7 @@ pub use aggregator::{DapAggregator, DapReportInitializer};
 pub use helper::DapHelper;
 pub use leader::{DapAuthorizedSender, DapLeader};
 
-async fn check_batch<S>(
+async fn check_batch<S: Sync>(
     agg: &impl DapAggregator<S>,
     task_config: &DapTaskConfig,
     task_id: &TaskId,
@@ -108,7 +108,7 @@ fn check_request_content_type<S>(
     }
 }
 
-async fn resolve_taskprov<S>(
+async fn resolve_taskprov<S: Sync>(
     agg: &impl DapAggregator<S>,
     task_id: &TaskId,
     req: &DapRequest<S>,

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -74,7 +74,8 @@ pub struct AggregationJobTest {
 // NOTE(cjpatton) This implementation of the report initializer is not feature complete. Since
 // [`AggrregationJobTest`], is only used to test the aggregation flow, features that are not
 // directly relevant to the tests aren't implemented.
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapReportInitializer for AggregationJobTest {
     async fn initialize_reports<'req>(
         &self,
@@ -736,13 +737,13 @@ impl MockAggregator {
         report: &Report,
         task_id: &TaskId,
     ) -> Option<DapBatchBucket> {
-        let mut rng = thread_rng();
         let task_config = self
             .get_task_config_for(task_id)
             .await
             .unwrap()
             .expect("tasks: unrecognized task");
 
+        let mut rng = thread_rng();
         match task_config.query {
             // For fixed-size queries, the bucket corresponds to a single batch.
             DapQueryConfig::FixedSize { .. } => {
@@ -808,7 +809,8 @@ impl MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl BearerTokenProvider for MockAggregator {
     type WrappedBearerToken<'a> = &'a BearerToken;
 
@@ -841,7 +843,8 @@ impl BearerTokenProvider for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl HpkeDecrypter for MockAggregator {
     type WrappedHpkeConfig<'a> = &'a HpkeConfig;
 
@@ -887,7 +890,8 @@ impl HpkeDecrypter for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapAuthorizedSender<BearerToken> for MockAggregator {
     async fn authorize(
         &self,
@@ -903,7 +907,8 @@ impl DapAuthorizedSender<BearerToken> for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapReportInitializer for MockAggregator {
     async fn initialize_reports<'req>(
         &self,
@@ -948,7 +953,8 @@ impl DapReportInitializer for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapAggregator<BearerToken> for MockAggregator {
     // The lifetimes on the traits ensure that we can return a reference to a task config stored by
     // the DapAggregator. (See DaphneWorkerConfig for an example.) For simplicity, MockAggregator
@@ -1158,7 +1164,8 @@ impl DapAggregator<BearerToken> for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapHelper<BearerToken> for MockAggregator {
     async fn put_helper_state_if_not_exists<Id>(
         &self,
@@ -1214,7 +1221,8 @@ impl DapHelper<BearerToken> for MockAggregator {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send-traits"), async_trait(?Send))]
+#[cfg_attr(feature = "send-traits", async_trait)]
 impl DapLeader<BearerToken> for MockAggregator {
     type ReportSelector = MockAggregatorReportSelector;
 
@@ -1296,12 +1304,12 @@ impl DapLeader<BearerToken> for MockAggregator {
         collect_job_id: &Option<CollectionJobId>,
         collect_req: &CollectionReq,
     ) -> Result<Url, DapError> {
-        let mut rng = thread_rng();
         let task_config = self
             .get_task_config_for(task_id)
             .await?
             .ok_or_else(|| fatal_error!(err = "task not found"))?;
 
+        let mut rng = thread_rng();
         let mut leader_state_store = self
             .leader_state_store
             .lock()

--- a/daphne_worker/src/auth.rs
+++ b/daphne_worker/src/auth.rs
@@ -5,7 +5,25 @@
 
 use daphne::auth::BearerToken;
 use serde::{Deserialize, Serialize};
-use worker::TlsClientAuth;
+
+pub(crate) struct TlsClientAuth {
+    pub verified: String,
+    pub issuer: String,
+    pub subject: String,
+}
+
+impl From<worker::TlsClientAuth> for TlsClientAuth {
+    fn from(value: worker::TlsClientAuth) -> Self {
+        let verified: String = value.cert_verified();
+        let issuer: String = value.cert_issuer_dn_rfc2253();
+        let subject: String = value.cert_subject_dn_rfc2253();
+        Self {
+            verified,
+            issuer,
+            subject,
+        }
+    }
+}
 
 /// HTTP client authorization for Daphne-Worker.
 ///

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -6,7 +6,7 @@
 //! Daphne-Worker configuration.
 
 use crate::{
-    auth::{DaphneWorkerAuth, DaphneWorkerAuthMethod},
+    auth::{DaphneWorkerAuth, DaphneWorkerAuthMethod, TlsClientAuth},
     durable::{
         durable_name_report_store, durable_name_task,
         leader_batch_queue::{LeaderBatchQueueResult, DURABLE_LEADER_BATCH_QUEUE_CURRENT},
@@ -1096,7 +1096,8 @@ impl<'srv> DaphneWorker<'srv> {
             cf_tls_client_auth: req
                 .cf()
                 .tls_client_auth()
-                .filter(|auth| auth.cert_presented() == "1"),
+                .filter(|auth| auth.cert_presented() == "1")
+                .map(TlsClientAuth::from),
         });
 
         let content_type = req

--- a/daphne_worker/src/router/aggregator.rs
+++ b/daphne_worker/src/router/aggregator.rs
@@ -1,4 +1,4 @@
-use daphne::roles::DapAggregator;
+use daphne::roles::aggregator;
 use tracing::Instrument;
 
 use crate::info_span_from_dap_request;
@@ -15,7 +15,10 @@ pub(super) fn add_aggregator_routes(router: DapRouter<'_>) -> DapRouter<'_> {
 
         let span = info_span_from_dap_request!("hpke_config", req);
 
-        match daph.handle_hpke_config_req(&req).instrument(span).await {
+        match aggregator::handle_hpke_config_req(&daph, &req)
+            .instrument(span)
+            .await
+        {
             Ok(req) => dap_response_to_worker(req),
             Err(e) => daph.state.dap_abort_to_worker_response(e),
         }

--- a/daphne_worker/src/router/helper.rs
+++ b/daphne_worker/src/router/helper.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use super::{dap_response_to_worker, DapRouter};
-use daphne::{constants::DapMediaType, roles::DapHelper};
+use daphne::{constants::DapMediaType, roles::helper};
 use tracing::Instrument;
 use worker::{Request, Response, Result, RouteContext};
 
@@ -48,7 +48,10 @@ async fn handle_agg_job(
         _ => info_span_from_dap_request!("aggregate", req),
     };
 
-    match daph.handle_agg_job_req(&req).instrument(span).await {
+    match helper::handle_agg_job_req(&daph, &req)
+        .instrument(span)
+        .await
+    {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }
@@ -66,7 +69,10 @@ async fn handle_agg_share_req(
 
     let span = info_span_from_dap_request!(MeasuredSpanName::AggregateShares.as_str(), req);
 
-    match daph.handle_agg_share_req(&req).instrument(span).await {
+    match helper::handle_agg_share_req(&daph, &req)
+        .instrument(span)
+        .await
+    {
         Ok(resp) => dap_response_to_worker(resp),
         Err(e) => daph.state.dap_abort_to_worker_response(e),
     }

--- a/daphne_worker/src/router/test_routes.rs
+++ b/daphne_worker/src/router/test_routes.rs
@@ -5,7 +5,7 @@ use daphne::{
     error::DapAbort,
     hpke::HpkeReceiverConfig,
     messages::{Duration, TaskId, Time},
-    roles::DapLeader,
+    roles::leader,
 };
 use serde::Deserialize;
 use tracing::{debug, info_span, Instrument};
@@ -21,8 +21,7 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
             .post_async("/internal/process", |mut req, ctx| async move {
                 let daph = ctx.data.handler(&ctx.env);
                 let report_sel: DaphneWorkerReportSelector = req.json().await?;
-                match daph
-                    .process(&report_sel, &daph.state.host)
+                match leader::process(&daph, &report_sel, &daph.state.host)
                     .instrument(info_span!("process"))
                     .await
                 {


### PR DESCRIPTION
The native version of this service will require that the daphne traits return `Send` futures. This however requires that the receiver of the methods be `Send`, which `DaphneWorker` is not.

To solve this problem, there are 3 solutions:
- duplicate all the traits and methods that use them as a trait bound
- `unsafe impl Send` for `DaphneWorker`
- use conditional compilation to generate `Send` and non-`Send` versions of the traits

I chose to go with the 3rd option because by conditionally compiling the traits based on a feature, the worker and the server can use the same traits but decide whether they want `Send` bounds or not.

The tradeoff of this technique is that `cargo check --all-targets` will no longer work. This is because `cargo` for every dependency finds the maximum set of features required by all dependents and then only compiles the code once. But since the enabling the feature is a breaking change for `daphne_worker` it will fail to compile when it tries to link with it, but I think this is an okay compromise for a temporary change
