### PR TITLE
Handle draft02 report extensions like other version specific fields

### DIFF
--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -197,6 +197,13 @@ mod test {
         }};
     }
 
+    fn empty_report_extensions_for_version(version: DapVersion) -> Option<Vec<Extension>> {
+        match version {
+            DapVersion::Draft02 => Some(Vec::new()),
+            DapVersion::Draft07 => None,
+        }
+    }
+
     /// Check for transition failures due to:
     ///
     /// * the report having already been processed
@@ -1850,7 +1857,7 @@ mod test {
         let metadata = ReportMetadata {
             id: ReportId(rng.gen()),
             time: t.now,
-            extensions: vec![],
+            draft02_extensions: empty_report_extensions_for_version(version),
         };
         // We declare these so the first call to early_metadata_check() is more readable.
         let processed = false;
@@ -1879,7 +1886,7 @@ mod test {
         let metadata = ReportMetadata {
             id: ReportId(rng.gen()),
             time: t.now + 100,
-            extensions: vec![],
+            draft02_extensions: empty_report_extensions_for_version(version),
         };
         assert_matches!(
             early_metadata_check(&metadata, false, false, t.now - 100, t.now + 100),
@@ -1889,7 +1896,7 @@ mod test {
         let metadata = ReportMetadata {
             id: ReportId(rng.gen()),
             time: t.now + 101,
-            extensions: vec![],
+            draft02_extensions: empty_report_extensions_for_version(version),
         };
         assert_matches!(
             early_metadata_check(&metadata, false, false, t.now - 100, t.now + 100),
@@ -1899,7 +1906,7 @@ mod test {
         let metadata = ReportMetadata {
             id: ReportId(rng.gen()),
             time: t.now - 100,
-            extensions: vec![],
+            draft02_extensions: empty_report_extensions_for_version(version),
         };
         assert_matches!(
             early_metadata_check(&metadata, false, false, t.now - 100, t.now + 100),
@@ -1909,7 +1916,7 @@ mod test {
         let metadata = ReportMetadata {
             id: ReportId(rng.gen()),
             time: t.now - 101,
-            extensions: vec![],
+            draft02_extensions: empty_report_extensions_for_version(version),
         };
         assert_matches!(
             early_metadata_check(&metadata, false, false, t.now - 100, t.now + 100),

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -579,14 +579,13 @@ impl VdafConfig {
         extensions: Vec<Extension>,
         version: DapVersion,
     ) -> Result<Report, DapError> {
-        let report_extensions = match version {
-            DapVersion::Draft02 => extensions.clone(),
-            DapVersion::Draft07 => vec![],
-        };
         let metadata = ReportMetadata {
             id: *report_id,
             time,
-            extensions: report_extensions,
+            draft02_extensions: match version {
+                DapVersion::Draft02 => Some(extensions.clone()),
+                DapVersion::Draft07 => None,
+            },
         };
 
         if version != DapVersion::Draft02 {

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -726,7 +726,10 @@ mod test {
             report_metadata: ReportMetadata {
                 id: ReportId(rng.gen()),
                 time: rng.gen(),
-                extensions: Vec::default(),
+                draft02_extensions: match version {
+                    DapVersion::Draft02 => Some(Vec::new()),
+                    DapVersion::Draft07 => None,
+                },
             },
             public_share: Vec::default(),
             encrypted_input_shares: Vec::default(),

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -308,7 +308,10 @@ async fn leader_upload(version: DapVersion) {
                 report_metadata: ReportMetadata {
                     id: ReportId([1; 16]),
                     time: t.now,
-                    extensions: Vec::default(),
+                    draft02_extensions: match version {
+                        DapVersion::Draft02 => Some(Vec::default()),
+                        DapVersion::Draft07 => None,
+                    },
                 },
                 public_share: b"public share".to_vec(),
                 encrypted_input_shares: vec![


### PR DESCRIPTION
Partially addresses #350.
Stacked on #425.

Make ReportMetadata.extensions semantically consistent with other draft02-specific fields. In particular, it should be an `Option` that is set only in draft02.