### PR TITLE
Make abort->error conversion one way

### DIFF
--- a/daphne/src/error/mod.rs
+++ b/daphne/src/error/mod.rs
@@ -8,6 +8,8 @@ use std::fmt::{Debug, Display};
 use crate::{messages::TransitionFailure, vdaf::VdafError};
 pub use aborts::DapAbort;
 
+use self::aborts::ProblemDetails;
+
 /// DAP errors.
 #[derive(Debug, thiserror::Error)]
 pub enum DapError {
@@ -26,6 +28,23 @@ pub enum DapError {
     /// certain conditions, trigger an abort.
     #[error("transition error: {0}")]
     Transition(#[from] TransitionFailure),
+}
+
+impl DapError {
+    pub fn into_problem_details(self) -> ProblemDetails {
+        if let Self::Abort(a) = self {
+            return a.into_problem_details();
+        }
+
+        ProblemDetails {
+            typ: None,
+            title: "Internal server error".into(),
+            agg_job_id: None,
+            task_id: None,
+            instance: None,
+            detail: None,
+        }
+    }
 }
 
 impl FatalDapError {

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -142,14 +142,14 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
     ) -> Result<(), DapError>;
 
     /// Handle request for the Aggregator's HPKE configuration.
-    async fn handle_hpke_config_req(&self, req: &DapRequest<S>) -> Result<DapResponse, DapAbort> {
+    async fn handle_hpke_config_req(&self, req: &DapRequest<S>) -> Result<DapResponse, DapError> {
         let metrics = self.metrics();
 
         // Parse the task ID from the query string, ensuring that it is the only query parameter.
         let mut id = None;
         for (k, v) in req.url.query_pairs() {
             if k != "task_id" {
-                return Err(DapAbort::BadRequest("unexpected query parameter".into()));
+                return Err(DapAbort::BadRequest("unexpected query parameter".into()).into());
             }
 
             let bytes = decode_base64url(v.as_bytes()).ok_or(DapAbort::BadRequest(
@@ -169,10 +169,9 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
 
             // Check whether the DAP version in the request matches the task config.
             if task_config.as_ref().version != req.version {
-                return Err(DapAbort::version_mismatch(
-                    req.version,
-                    task_config.as_ref().version,
-                ));
+                return Err(
+                    DapAbort::version_mismatch(req.version, task_config.as_ref().version).into(),
+                );
             }
         }
 

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -280,7 +280,7 @@ impl AggregationJobTest {
         &self,
         leader_state: DapAggregationJobState,
         agg_job_resp: AggregationJobResp,
-    ) -> DapAbort {
+    ) -> DapError {
         let metrics = &self.leader_metrics;
         self.task_config
             .vdaf
@@ -321,7 +321,7 @@ impl AggregationJobTest {
         &self,
         helper_state: DapAggregationJobState,
         agg_job_cont_req: &AggregationJobContinueReq,
-    ) -> DapAbort {
+    ) -> DapError {
         self.task_config
             .vdaf
             .handle_agg_job_cont_req(

--- a/daphne_worker/src/error_reporting.rs
+++ b/daphne_worker/src/error_reporting.rs
@@ -3,17 +3,17 @@
 
 //! Daphne-Worker error reporting trait and default implementation.
 
-use daphne::error::DapAbort;
+use daphne::DapError;
 
 /// Interface for error reporting in Daphne
 /// Refer to `NoopErrorReporter` for implementation example.
 pub trait ErrorReporter {
-    fn report_abort(&self, error: &DapAbort);
+    fn report_abort(&self, error: &DapError);
 }
 
 /// Default implementation of the error reporting trait, which is a no-op.
 pub(crate) struct NoopErrorReporter {}
 
 impl ErrorReporter for NoopErrorReporter {
-    fn report_abort(&self, _error: &DapAbort) {}
+    fn report_abort(&self, _error: &DapError) {}
 }

--- a/daphne_worker/src/roles/mod.rs
+++ b/daphne_worker/src/roles/mod.rs
@@ -81,7 +81,7 @@ impl<'srv> HpkeDecrypter for DaphneWorker<'srv> {
         })
         .await
         .map_err(|e| fatal_error!(err = ?e))?
-        .ok_or_else(|| DapError::Transition(TransitionFailure::HpkeUnknownConfigId))?
+        .ok_or(DapError::Transition(TransitionFailure::HpkeUnknownConfigId))?
     }
 }
 

--- a/daphne_worker/src/router/aggregator.rs
+++ b/daphne_worker/src/router/aggregator.rs
@@ -10,7 +10,7 @@ pub(super) fn add_aggregator_routes(router: DapRouter<'_>) -> DapRouter<'_> {
         let daph = ctx.data.handler(&ctx.env);
         let req = match daph.worker_request_to_dap(req, &ctx).await {
             Ok(req) => req,
-            Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+            Err(e) => return daph.state.dap_abort_to_worker_response(e),
         };
 
         let span = info_span_from_dap_request!("hpke_config", req);

--- a/daphne_worker/src/router/helper.rs
+++ b/daphne_worker/src/router/helper.rs
@@ -35,7 +35,7 @@ async fn handle_agg_job(
     let daph = ctx.data.handler(&ctx.env);
     let req = match daph.worker_request_to_dap(req, &ctx).await {
         Ok(req) => req,
-        Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+        Err(e) => return daph.state.dap_abort_to_worker_response(e),
     };
 
     let span = match req.media_type {
@@ -61,7 +61,7 @@ async fn handle_agg_share_req(
     let daph = ctx.data.handler(&ctx.env);
     let req = match daph.worker_request_to_dap(req, &ctx).await {
         Ok(req) => req,
-        Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+        Err(e) => return daph.state.dap_abort_to_worker_response(e),
     };
 
     let span = info_span_from_dap_request!(MeasuredSpanName::AggregateShares.as_str(), req);

--- a/daphne_worker/src/router/leader.rs
+++ b/daphne_worker/src/router/leader.rs
@@ -22,7 +22,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             let daph = ctx.data.handler(&ctx.env);
             let req = match daph.worker_request_to_dap(req, &ctx).await {
                 Ok(req) => req,
-                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                Err(e) => return daph.state.dap_abort_to_worker_response(e),
             };
             if req.version != DapVersion::Draft02 {
                 return Response::error("not implemented", 404);
@@ -33,7 +33,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             let daph = ctx.data.handler(&ctx.env);
             let req = match daph.worker_request_to_dap(req, &ctx).await {
                 Ok(req) => req,
-                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                Err(e) => return daph.state.dap_abort_to_worker_response(e),
             };
             put_report_into_task(req, daph).await
         })
@@ -41,7 +41,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
             let daph = ctx.data.handler(&ctx.env);
             let req = match daph.worker_request_to_dap(req, &ctx).await {
                 Ok(req) => req,
-                Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                Err(e) => return daph.state.dap_abort_to_worker_response(e),
             };
 
             if req.version != DapVersion::Draft02 {
@@ -103,7 +103,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                                 "unknown collect id".into(),
                             ))
                     }
-                    Err(e) => daph.state.dap_abort_to_worker_response(e.into()),
+                    Err(e) => daph.state.dap_abort_to_worker_response(e),
                 }
             },
         ) // draft02
@@ -113,7 +113,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                 let daph = ctx.data.handler(&ctx.env);
                 let req = match daph.worker_request_to_dap(req, &ctx).await {
                     Ok(req) => req,
-                    Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                    Err(e) => return daph.state.dap_abort_to_worker_response(e),
                 };
 
                 let span = info_span_from_dap_request!("collect (PUT)", req);
@@ -130,7 +130,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                 let daph = ctx.data.handler(&ctx.env);
                 let req = match daph.worker_request_to_dap(req, &ctx).await {
                     Ok(req) => req,
-                    Err(e) => return daph.state.dap_abort_to_worker_response(e.into()),
+                    Err(e) => return daph.state.dap_abort_to_worker_response(e),
                 };
                 let task_id = match req.task_id() {
                     Ok(id) => id,
@@ -175,7 +175,7 @@ pub(super) fn add_leader_routes(router: DapRouter<'_>) -> DapRouter<'_> {
                                 "unknown collect id".into(),
                             ))
                     }
-                    Err(e) => daph.state.dap_abort_to_worker_response(e.into()),
+                    Err(e) => daph.state.dap_abort_to_worker_response(e),
                 }
             },
         )

--- a/daphne_worker/src/router/test_routes.rs
+++ b/daphne_worker/src/router/test_routes.rs
@@ -55,7 +55,7 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
                         Ok(batch_id) => {
                             Response::from_bytes(batch_id.to_base64url().as_bytes().to_owned())
                         }
-                        Err(e) => daph.state.dap_abort_to_worker_response(e.into()),
+                        Err(e) => daph.state.dap_abort_to_worker_response(e),
                     }
                 },
             )
@@ -71,7 +71,7 @@ pub(super) fn add_internal_test_routes(router: DapRouter<'_>, role: Role) -> Dap
                 .await
             {
                 Ok(()) => Response::empty(),
-                Err(e) => daph.state.dap_abort_to_worker_response(e.into()),
+                Err(e) => daph.state.dap_abort_to_worker_response(e),
             }
         })
         // Endpoints for draft-dcook-ppm-dap-interop-test-design-02


### PR DESCRIPTION
Having DapError convertible into DapAbort means that an Error can be
converted into an abort and an abort converted into an error an infinite
number of times, meaning the type can grow in an unbounded way at
runtime. This is very confusing to reason about when reading the
signature of a method that returns a `DapAbort`. Now a method that
returns a `DapAbort` can only return due to a documented protocol error
and not another system related error (such as mis configuration or IO).

This PR removes the `impl From<DapError> for DapAbort` implementation and fixes
the code accordingly.
