### PR TITLE
Enable taskprov in draft07

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -404,6 +404,7 @@ impl Extend<(DapBatchBucket, (ReportId, Time))> for DapAggregateSpan<()> {
 
 /// Per-task DAP parameters.
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct DapTaskConfig {
     /// The protocol version (i.e., which draft).
     pub version: DapVersion,

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -166,7 +166,7 @@ impl AggregationJobTest {
                 vdaf: vdaf.clone(),
                 vdaf_verify_key,
                 collector_hpke_config,
-                taskprov: false,
+                method: Default::default(),
             },
             leader_registry,
             helper_registry,
@@ -843,7 +843,7 @@ impl BearerTokenProvider for MockAggregator {
         _task_id: &'s TaskId,
         task_config: &DapTaskConfig,
     ) -> Result<Option<Self::WrappedBearerToken<'s>>, DapError> {
-        if task_config.taskprov {
+        if task_config.method_is_taskprov() {
             Ok(Some(&self.taskprov_leader_token))
         } else {
             Ok(Some(&self.leader_token))
@@ -855,7 +855,7 @@ impl BearerTokenProvider for MockAggregator {
         _task_id: &'s TaskId,
         task_config: &DapTaskConfig,
     ) -> Result<Option<Self::WrappedBearerToken<'s>>, DapError> {
-        if task_config.taskprov {
+        if task_config.method_is_taskprov() {
             Ok(Some(self.taskprov_collector_token.as_ref().expect(
                 "MockAggregator not configured with taskprov collector token",
             )))

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -109,7 +109,10 @@ pub(crate) enum VdafError {
 /// A VDAF verification key.
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
+#[cfg_attr(
+    any(test, feature = "test-utils"),
+    derive(deepsize::DeepSizeOf, PartialEq, Debug)
+)]
 pub enum VdafVerifyKey {
     Prio3(#[serde(with = "hex")] [u8; VDAF_VERIFY_KEY_SIZE_PRIO3]),
     Prio2(#[serde(with = "hex")] [u8; VDAF_VERIFY_KEY_SIZE_PRIO2]),

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -1032,7 +1032,7 @@ impl<'srv> DaphneWorker<'srv> {
                     vdaf,
                     vdaf_verify_key,
                     collector_hpke_config,
-                    taskprov: false,
+                    method: Default::default(),
                 },
             )
             .await?
@@ -1226,6 +1226,15 @@ impl<'srv> DaphneWorker<'srv> {
                 reqwest_wasm::header::HeaderName::from_static("dap-auth-token"),
                 reqwest_wasm::header::HeaderValue::from_str(bearer_token.as_ref()).map_err(
                     |e| fatal_error!(err = ?e, "failed to construct dap-auth-token header"),
+                )?,
+            );
+        }
+
+        if let Some(taskprov_advertisement) = req.taskprov.as_deref() {
+            headers.insert(
+                reqwest_wasm::header::HeaderName::from_static("dap-taskprov"),
+                reqwest_wasm::header::HeaderValue::from_str(taskprov_advertisement).map_err(
+                    |e| fatal_error!(err = ?e, "failed to construct dap-taskprov header"),
                 )?,
             );
         }

--- a/daphne_worker/src/roles/mod.rs
+++ b/daphne_worker/src/roles/mod.rs
@@ -96,7 +96,7 @@ impl<'srv> BearerTokenProvider for DaphneWorker<'srv> {
         task_config: &DapTaskConfig,
     ) -> std::result::Result<Option<BearerTokenKvPair<'s>>, DapError> {
         if let Some(ref taskprov_config) = self.config().taskprov {
-            if self.get_global_config().allow_taskprov && task_config.taskprov {
+            if self.get_global_config().allow_taskprov && task_config.method_is_taskprov() {
                 return Ok(Some(BearerTokenKvPair::new(
                     task_id,
                     taskprov_config.leader_auth.as_ref(),
@@ -115,7 +115,7 @@ impl<'srv> BearerTokenProvider for DaphneWorker<'srv> {
         task_config: &DapTaskConfig,
     ) -> std::result::Result<Option<Self::WrappedBearerToken<'s>>, DapError> {
         if let Some(ref taskprov_config) = self.config().taskprov {
-            if self.get_global_config().allow_taskprov && task_config.taskprov {
+            if self.get_global_config().allow_taskprov && task_config.method_is_taskprov() {
                 return Ok(Some(BearerTokenKvPair::new(
                     task_id,
                     taskprov_config

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -4,7 +4,7 @@
 //! End-to-end tests for daphne.
 use super::test_runner::{TestRunner, MIN_BATCH_SIZE, TIME_PRECISION};
 use daphne::{
-    async_test_version, async_test_versions,
+    async_test_versions,
     constants::DapMediaType,
     messages::{
         taskprov::{
@@ -1416,4 +1416,4 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     );
 }
 
-async_test_version! { leader_collect_taskprov_ok, Draft02 }
+async_test_versions! { leader_collect_taskprov_ok }


### PR DESCRIPTION
Stacked on #435.
Partially addresses #350.

Enable taskprov in draft07

Enable support for taskprov in the latest draft. The main technical
hurdle is to ensure the Leader can advertise the taskprov config to the
Helper in an HTTP Header. The simplest solution is to add the
information to `DapTaskConfig` that is needed in order to reconstruct
the serialized taskprov config, in particular the "task_info" field.

To do this, we add a new `method` field to the `DapTaskConfig` struct
that conveys the method by which the task was configured. The method has
type `enum DapTaskConfigMethod`, of which there are two variants. The
first is `Taskprov` and includes the "task_info". The second is
`Unknown` and is a catch-all for existing, manually configured tasks.

Accordingly, we deprecate the `taskprov` field of the `DapTaskConfig`
struct. We've kept the field in the struct for backwards compatibility:
there are some situations for which the indication is sufficient; in
situations where the "task_info" field is needed, we must abort.

This change also includes a number of related, but minor changes:

* Have `resolve_advertised_task_config()` return a `DapAbort` rather
  than a `DapError` (an error in this flow always leads to an abort and
  is never an internal error).

* Opt-out of the task unless (1) the "none" variant for "DpConfig" is
  indicated and (2) the indicated max batch query count is 1. Other
  values for these parameters are not currently supported by Daphne.

* Introduce a type `DapTaskParameters` that encapsulates the parameters
  used to configure a task and implement a method for generating a task
  config using the taskprov method. This change is intended to simplify
  the test code, but should be independently useful.