### PR TITLE
draft07, taskprov: Align `VdafConfig` and clean up

### DIFF
--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -8,13 +8,11 @@ use crate::messages::{
     decode_u16_bytes, encode_u16_bytes, Duration, Time, QUERY_TYPE_FIXED_SIZE,
     QUERY_TYPE_TIME_INTERVAL,
 };
-use crate::vdaf::VDAF_VERIFY_KEY_SIZE_PRIO2;
 use crate::DapVersion;
 use prio::codec::{
     decode_u16_items, decode_u8_items, encode_u16_items, encode_u8_items, CodecError, Decode,
     Encode, ParameterizedDecode, ParameterizedEncode,
 };
-use ring::hkdf::KeyType;
 use serde::{Deserialize, Serialize};
 use std::io::{Cursor, Read};
 
@@ -24,68 +22,59 @@ const VDAF_TYPE_PRIO2: u32 = 0xFFFF_0000;
 // Differential privacy mechanism types.
 const DP_MECHANISM_NONE: u8 = 0x01;
 
-/// A VDAF type.
-#[derive(Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum VdafType {
-    Prio2,
-    NotImplemented(u32),
-}
-
-impl KeyType for VdafType {
-    fn len(&self) -> usize {
-        match self {
-            VdafType::Prio2 => VDAF_VERIFY_KEY_SIZE_PRIO2,
-            VdafType::NotImplemented(_) => panic!("tried to get key length for undefined VDAF"),
-        }
-    }
-}
-
 /// A VDAF type along with its type-specific data.
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum VdafTypeVar {
-    Prio2 {
-        dimension: u32,
-    },
-    #[cfg(test)]
-    NotImplemented(u32),
+    Prio2 { dimension: u32 },
+    NotImplemented { typ: u32, param: Vec<u8> },
 }
 
-impl Encode for VdafTypeVar {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+impl ParameterizedEncode<DapVersion> for VdafTypeVar {
+    fn encode_with_param(&self, version: &DapVersion, bytes: &mut Vec<u8>) {
         match &self {
-            VdafTypeVar::Prio2 { dimension } => {
+            Self::Prio2 { dimension } => {
                 VDAF_TYPE_PRIO2.encode(bytes);
+                if *version != DapVersion::Draft02 {
+                    4_u16.encode(bytes);
+                }
                 dimension.encode(bytes);
             }
-            #[cfg(test)]
-            VdafTypeVar::NotImplemented(x) => {
-                x.encode(bytes);
+            Self::NotImplemented { typ, param } => {
+                typ.encode(bytes);
+                if *version != DapVersion::Draft02 {
+                    u16::try_from(param.len()).unwrap().encode(bytes);
+                }
+                bytes.extend_from_slice(param);
             }
         }
     }
 }
 
-impl Decode for VdafTypeVar {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        let x = u32::decode(bytes)?;
-        match x {
-            VDAF_TYPE_PRIO2 => Ok(Self::Prio2 {
+impl ParameterizedDecode<DapVersion> for VdafTypeVar {
+    fn decode_with_param(
+        version: &DapVersion,
+        bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        let vdaf_type = u32::decode(bytes)?;
+        let vdaf_type_param_len = match version {
+            DapVersion::Draft07 => Some(u16::decode(bytes)?.try_into().unwrap()),
+            DapVersion::Draft02 => None,
+        };
+        match (vdaf_type, vdaf_type_param_len) {
+            (VDAF_TYPE_PRIO2, _) => Ok(Self::Prio2 {
                 dimension: u32::decode(bytes)?,
             }),
-            // We don't recognize the VDAF type, which means there may be parameters that follow
-            // and we don't know how many bytes to parse.
+            (_, Some(len)) => {
+                let mut param = vec![0; len];
+                bytes.read_exact(&mut param)?;
+                Ok(Self::NotImplemented {
+                    typ: vdaf_type,
+                    param,
+                })
+            }
+            // draft02 compatibility: We don't recognize the VDAF type, which means the rest of
+            // this message is not decodable. We must abort.
             _ => Err(CodecError::UnexpectedValue),
-        }
-    }
-}
-
-impl From<VdafTypeVar> for VdafType {
-    fn from(var: VdafTypeVar) -> Self {
-        match var {
-            VdafTypeVar::Prio2 { .. } => VdafType::Prio2,
-            #[cfg(test)]
-            VdafTypeVar::NotImplemented(x) => VdafType::NotImplemented(x),
         }
     }
 }
@@ -94,20 +83,51 @@ impl From<VdafTypeVar> for VdafType {
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum DpConfig {
     None,
+    NotImplemented { typ: u8, param: Vec<u8> },
 }
 
-impl Encode for DpConfig {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+impl ParameterizedEncode<DapVersion> for DpConfig {
+    fn encode_with_param(&self, version: &DapVersion, bytes: &mut Vec<u8>) {
         match self {
-            Self::None => DP_MECHANISM_NONE.encode(bytes),
+            Self::None => {
+                DP_MECHANISM_NONE.encode(bytes);
+                if *version != DapVersion::Draft02 {
+                    0_u16.encode(bytes);
+                }
+            }
+            Self::NotImplemented { typ, param } => {
+                typ.encode(bytes);
+                if *version != DapVersion::Draft02 {
+                    u16::try_from(param.len()).unwrap().encode(bytes);
+                }
+                bytes.extend_from_slice(param);
+            }
         }
     }
 }
 
-impl Decode for DpConfig {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
-        match u8::decode(bytes)? {
-            DP_MECHANISM_NONE => Ok(Self::None),
+impl ParameterizedDecode<DapVersion> for DpConfig {
+    fn decode_with_param(
+        version: &DapVersion,
+        bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
+        let dp_mechanism = u8::decode(bytes)?;
+        let dp_mechanism_param_len = match version {
+            DapVersion::Draft07 => Some(u16::decode(bytes)?.try_into().unwrap()),
+            DapVersion::Draft02 => None,
+        };
+        match (dp_mechanism, dp_mechanism_param_len) {
+            (DP_MECHANISM_NONE, _) => Ok(Self::None),
+            (_, Some(len)) => {
+                let mut param = vec![0; len];
+                bytes.read_exact(&mut param)?;
+                Ok(Self::NotImplemented {
+                    typ: dp_mechanism,
+                    param,
+                })
+            }
+            // draft02 compatibility: We must abort because unimplemented DP mechansims can't be
+            // decoded.
             _ => Err(CodecError::UnexpectedValue),
         }
     }
@@ -121,18 +141,21 @@ pub struct VdafConfig {
     pub var: VdafTypeVar,
 }
 
-impl Encode for VdafConfig {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        self.dp_config.encode(bytes);
-        self.var.encode(bytes);
+impl ParameterizedEncode<DapVersion> for VdafConfig {
+    fn encode_with_param(&self, version: &DapVersion, bytes: &mut Vec<u8>) {
+        self.dp_config.encode_with_param(version, bytes);
+        self.var.encode_with_param(version, bytes);
     }
 }
 
-impl Decode for VdafConfig {
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+impl ParameterizedDecode<DapVersion> for VdafConfig {
+    fn decode_with_param(
+        version: &DapVersion,
+        bytes: &mut Cursor<&[u8]>,
+    ) -> Result<Self, CodecError> {
         Ok(Self {
-            dp_config: DpConfig::decode(bytes)?,
-            var: VdafTypeVar::decode(bytes)?,
+            dp_config: DpConfig::decode_with_param(version, bytes)?,
+            var: VdafTypeVar::decode_with_param(version, bytes)?,
         })
     }
 }
@@ -309,7 +332,7 @@ impl ParameterizedEncode<DapVersion> for TaskConfig {
         }
         self.query_config.encode_with_param(version, bytes);
         self.task_expiration.encode(bytes);
-        self.vdaf_config.encode(bytes);
+        self.vdaf_config.encode_with_param(version, bytes);
     }
 }
 
@@ -332,7 +355,7 @@ impl ParameterizedDecode<DapVersion> for TaskConfig {
             helper_url,
             query_config: QueryConfig::decode_with_param(version, bytes)?,
             task_expiration: Time::decode(bytes)?,
-            vdaf_config: VdafConfig::decode(bytes)?,
+            vdaf_config: VdafConfig::decode_with_param(version, bytes)?,
         })
     }
 }
@@ -416,6 +439,103 @@ mod tests {
         assert!(QueryConfig::get_decoded_with_param(
             &DapVersion::Draft02,
             &query_config.get_encoded_with_param(&DapVersion::Draft02)
+        )
+        .is_err());
+    }
+
+    fn roundtrip_dp_config(version: DapVersion) {
+        let dp_config = DpConfig::None;
+        assert_eq!(
+            DpConfig::get_decoded_with_param(&version, &dp_config.get_encoded_with_param(&version))
+                .unwrap(),
+            dp_config
+        );
+    }
+
+    test_versions! { roundtrip_dp_config }
+
+    #[test]
+    fn roundtrip_dp_config_not_implemented_draft07() {
+        let dp_config = DpConfig::NotImplemented {
+            typ: 0,
+            param: b"dp mechanism param".to_vec(),
+        };
+        assert_eq!(
+            DpConfig::get_decoded_with_param(
+                &DapVersion::Draft07,
+                &dp_config.get_encoded_with_param(&DapVersion::Draft07)
+            )
+            .unwrap(),
+            dp_config
+        );
+    }
+
+    #[test]
+    fn roundtrip_dp_config_not_implemented_draft02() {
+        let dp_config = DpConfig::NotImplemented {
+            typ: 0,
+            param: b"dp mechanism param".to_vec(),
+        };
+
+        // Expect error because unimplemented query types aren't decodable.
+        assert!(DpConfig::get_decoded_with_param(
+            &DapVersion::Draft02,
+            &dp_config.get_encoded_with_param(&DapVersion::Draft02)
+        )
+        .is_err());
+    }
+
+    fn roundtrip_vdaf_config(version: DapVersion) {
+        let vdaf_config = VdafConfig {
+            dp_config: DpConfig::None,
+            var: VdafTypeVar::Prio2 { dimension: 1337 },
+        };
+        assert_eq!(
+            VdafConfig::get_decoded_with_param(
+                &version,
+                &vdaf_config.get_encoded_with_param(&version)
+            )
+            .unwrap(),
+            vdaf_config
+        );
+    }
+
+    test_versions! { roundtrip_vdaf_config }
+
+    #[test]
+    fn roundtrip_vdaf_config_not_implemented_draft07() {
+        let vdaf_config = VdafConfig {
+            dp_config: DpConfig::None,
+            var: VdafTypeVar::NotImplemented {
+                typ: 1337,
+                param: b"vdaf type param".to_vec(),
+            },
+        };
+
+        assert_eq!(
+            VdafConfig::get_decoded_with_param(
+                &DapVersion::Draft07,
+                &vdaf_config.get_encoded_with_param(&DapVersion::Draft07)
+            )
+            .unwrap(),
+            vdaf_config
+        );
+    }
+
+    #[test]
+    fn roundtrip_vdaf_config_not_implemented_draft02() {
+        let vdaf_config = VdafConfig {
+            dp_config: DpConfig::None,
+            var: VdafTypeVar::NotImplemented {
+                typ: 1337,
+                param: b"vdaf type param".to_vec(),
+            },
+        };
+
+        // Expect error because unimplemented query types aren't decodable.
+        assert!(VdafConfig::get_decoded_with_param(
+            &DapVersion::Draft02,
+            &vdaf_config.get_encoded_with_param(&DapVersion::Draft02)
         )
         .is_err());
     }


### PR DESCRIPTION
Partially addresses #350.
Stacked on #438.

Align serialization of `VdafConfig` with the latest draft. Along the way, remove the `VdafType` and simplify. This struct is used only for aligning the VDAF verify key derivation with `ring`'s HKDF API. It's sufficient (and simpler) to implement the necessary trait on our own `VdafVerifyKey` type.