### PR TITLE
taskprov: Improve extension payload handling

### DIFF
--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -55,7 +55,7 @@ impl ParameterizedDecode<DapVersion> for VdafTypeVar {
         let vdaf_type = u32::decode(bytes)?;
         match (version, vdaf_type) {
             (.., VDAF_TYPE_PRIO2) => Ok(Self::Prio2 {
-                dimension: decode_u16_item_for_version(version, bytes)?,
+                dimension: decode_u16_item_for_version(*version, bytes)?,
             }),
             (DapVersion::Draft07, ..) => Ok(Self::NotImplemented {
                 typ: vdaf_type,
@@ -102,7 +102,7 @@ impl ParameterizedDecode<DapVersion> for DpConfig {
         let dp_mechanism = u8::decode(bytes)?;
         match (version, dp_mechanism) {
             (.., DP_MECHANISM_NONE) => {
-                decode_u16_item_for_version::<()>(version, bytes)?;
+                decode_u16_item_for_version::<()>(*version, bytes)?;
                 Ok(Self::None)
             }
             (DapVersion::Draft07, ..) => Ok(Self::NotImplemented {
@@ -240,11 +240,11 @@ impl ParameterizedDecode<DapVersion> for QueryConfig {
         let query_type = query_type.unwrap_or(u8::decode(bytes)?);
         let var = match (version, query_type) {
             (.., QUERY_TYPE_TIME_INTERVAL) => {
-                decode_u16_item_for_version::<()>(version, bytes)?;
+                decode_u16_item_for_version::<()>(*version, bytes)?;
                 QueryConfigVar::TimeInterval
             }
             (.., QUERY_TYPE_FIXED_SIZE) => QueryConfigVar::FixedSize {
-                max_batch_size: decode_u16_item_for_version(version, bytes)?,
+                max_batch_size: decode_u16_item_for_version(*version, bytes)?,
             },
             (DapVersion::Draft07, ..) => QueryConfigVar::NotImplemented {
                 typ: query_type,

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -1794,7 +1794,10 @@ mod test {
                     &task_id,
                     DapMeasurement::U32Vec(vec![1; 10]),
                     vec![Extension::Taskprov {
-                        payload: taskprov_report_extension_payload.clone(),
+                        draft02_payload: match version {
+                            DapVersion::Draft07 => None,
+                            DapVersion::Draft02 => Some(taskprov_report_extension_payload.clone()),
+                        },
                     }],
                     version,
                 )


### PR DESCRIPTION
Partially addresses #350.
Stacked on #441.

* If taskprov is disabled for the task, then handle the extension as unrecognized.
* If taskprov is enabled, then assert that the extension payload is empty (in draft07).
* Fence the payload consistency check to draft02.