### PR TITLE
Rename `DapVersion::Latest` to `DapVersion::DraftLatest`

### DIFF
--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -68,31 +68,33 @@ impl DapMediaType {
     pub fn from_str_for_version(version: DapVersion, content_type: Option<&str>) -> Self {
         match (version, content_type) {
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)) => {
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)) => {
                 Self::AggregationJobContinueReq
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)) => {
                 Self::Draft02AggregateContinueResp
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)) => {
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)) => {
                 Self::AggregationJobInitReq
             }
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_AGG_JOB_RESP)) => Self::AggregationJobResp,
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_AGG_JOB_RESP)) => Self::AggregationJobResp,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_AGG_SHARE)) => Self::AggregateShare,
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_AGG_SHARE)) => Self::AggregateShare,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_COLLECTION)) => Self::Collection,
             (DapVersion::Draft02, Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG))
-            | (DapVersion::Latest, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
-            (DapVersion::Draft02 | DapVersion::Latest, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => {
+            | (DapVersion::DraftLatest, Some(MEDIA_TYPE_HPKE_CONFIG_LIST)) => Self::HpkeConfigList,
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Some(MEDIA_TYPE_AGG_SHARE_REQ)) => {
                 Self::AggregateShareReq
             }
-            (DapVersion::Draft02 | DapVersion::Latest, Some(MEDIA_TYPE_COLLECT_REQ)) => {
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Some(MEDIA_TYPE_COLLECT_REQ)) => {
                 Self::CollectReq
             }
-            (DapVersion::Draft02 | DapVersion::Latest, Some(MEDIA_TYPE_REPORT)) => Self::Report,
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Some(MEDIA_TYPE_REPORT)) => {
+                Self::Report
+            }
             (_, Some(content_type)) => Self::Invalid(content_type.to_string()),
             (_, None) => Self::Missing,
         }
@@ -104,33 +106,37 @@ impl DapMediaType {
             (DapVersion::Draft02, Self::AggregationJobInitReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
             }
-            (DapVersion::Latest, Self::AggregationJobInitReq) => Some(MEDIA_TYPE_AGG_JOB_INIT_REQ),
+            (DapVersion::DraftLatest, Self::AggregationJobInitReq) => {
+                Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)
+            }
             (DapVersion::Draft02, Self::AggregationJobResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
             }
-            (DapVersion::Latest, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
+            (DapVersion::DraftLatest, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
             (DapVersion::Draft02, Self::AggregationJobContinueReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
             }
-            (DapVersion::Latest, Self::AggregationJobContinueReq) => {
+            (DapVersion::DraftLatest, Self::AggregationJobContinueReq) => {
                 Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)
             }
             (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
             }
-            (DapVersion::Draft02 | DapVersion::Latest, Self::AggregateShareReq) => {
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::AggregateShareReq) => {
                 Some(MEDIA_TYPE_AGG_SHARE_REQ)
             }
             (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-            (DapVersion::Latest, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
-            (DapVersion::Draft02 | DapVersion::Latest, Self::CollectReq) => {
+            (DapVersion::DraftLatest, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::CollectReq) => {
                 Some(MEDIA_TYPE_COLLECT_REQ)
             }
             (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-            (DapVersion::Latest, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
+            (DapVersion::DraftLatest, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
             (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
-            (DapVersion::Latest, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
-            (DapVersion::Draft02 | DapVersion::Latest, Self::Report) => Some(MEDIA_TYPE_REPORT),
+            (DapVersion::DraftLatest, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
+            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::Report) => {
+                Some(MEDIA_TYPE_REPORT)
+            }
             (_, Self::Draft02AggregateContinueResp | Self::Missing) => None,
             (_, Self::Invalid(ref content_type)) => Some(content_type),
         }
@@ -141,7 +147,7 @@ impl DapMediaType {
     pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
         match version {
             DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
-            DapVersion::Latest => Self::AggregationJobResp,
+            DapVersion::DraftLatest => Self::AggregationJobResp,
         }
     }
 }
@@ -220,56 +226,56 @@ mod test {
 
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-hpke-config-list")
             ),
             DapMediaType::HpkeConfigList
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-aggregation-job-init-req")
             ),
             DapMediaType::AggregationJobInitReq,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-aggregation-job-resp")
             ),
             DapMediaType::AggregationJobResp,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-aggregation-job-continue-req")
             ),
             DapMediaType::AggregationJobContinueReq,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-aggregate-share-req")
             ),
             DapMediaType::AggregateShareReq,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-aggregate-share")
             ),
             DapMediaType::AggregateShare,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-collect-req")
             ),
             DapMediaType::CollectReq,
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Latest,
+                DapVersion::DraftLatest,
                 Some("application/dap-collection")
             ),
             DapMediaType::Collection,
@@ -277,13 +283,13 @@ mod test {
 
         // Invalid media type
         assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::Latest, Some("blah-blah-blah")),
+            DapMediaType::from_str_for_version(DapVersion::DraftLatest, Some("blah-blah-blah")),
             DapMediaType::Invalid("blah-blah-blah".into()),
         );
 
         // Missing media type
         assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::Latest, None),
+            DapMediaType::from_str_for_version(DapVersion::DraftLatest, None),
             DapMediaType::Missing,
         );
     }
@@ -292,27 +298,30 @@ mod test {
     fn round_trip() {
         for (version, media_type) in [
             (DapVersion::Draft02, DapMediaType::AggregationJobInitReq),
-            (DapVersion::Latest, DapMediaType::AggregationJobInitReq),
+            (DapVersion::DraftLatest, DapMediaType::AggregationJobInitReq),
             (DapVersion::Draft02, DapMediaType::AggregationJobResp),
-            (DapVersion::Latest, DapMediaType::AggregationJobResp),
+            (DapVersion::DraftLatest, DapMediaType::AggregationJobResp),
             (DapVersion::Draft02, DapMediaType::AggregationJobContinueReq),
-            (DapVersion::Latest, DapMediaType::AggregationJobContinueReq),
+            (
+                DapVersion::DraftLatest,
+                DapMediaType::AggregationJobContinueReq,
+            ),
             (
                 DapVersion::Draft02,
                 DapMediaType::Draft02AggregateContinueResp,
             ),
             (DapVersion::Draft02, DapMediaType::AggregateShareReq),
-            (DapVersion::Latest, DapMediaType::AggregateShareReq),
+            (DapVersion::DraftLatest, DapMediaType::AggregateShareReq),
             (DapVersion::Draft02, DapMediaType::AggregateShare),
-            (DapVersion::Latest, DapMediaType::AggregateShare),
+            (DapVersion::DraftLatest, DapMediaType::AggregateShare),
             (DapVersion::Draft02, DapMediaType::CollectReq),
-            (DapVersion::Latest, DapMediaType::CollectReq),
+            (DapVersion::DraftLatest, DapMediaType::CollectReq),
             (DapVersion::Draft02, DapMediaType::Collection),
-            (DapVersion::Latest, DapMediaType::Collection),
+            (DapVersion::DraftLatest, DapMediaType::Collection),
             (DapVersion::Draft02, DapMediaType::HpkeConfigList),
-            (DapVersion::Latest, DapMediaType::HpkeConfigList),
+            (DapVersion::DraftLatest, DapMediaType::HpkeConfigList),
             (DapVersion::Draft02, DapMediaType::Report),
-            (DapVersion::Latest, DapMediaType::Report),
+            (DapVersion::DraftLatest, DapMediaType::Report),
         ] {
             assert_eq!(
                 DapMediaType::from_str_for_version(version, media_type.as_str_for_version(version)),
@@ -333,7 +342,7 @@ mod test {
 
         assert_eq!(
             DapMediaType::AggregationJobResp,
-            DapMediaType::agg_job_cont_resp_for_version(DapVersion::Latest)
+            DapMediaType::agg_job_cont_resp_for_version(DapVersion::DraftLatest)
         );
     }
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -108,7 +108,7 @@ pub enum DapVersion {
 
     #[serde(rename = "v09")]
     #[default]
-    Latest,
+    DraftLatest,
 }
 
 impl FromStr for DapVersion {
@@ -116,7 +116,7 @@ impl FromStr for DapVersion {
     fn from_str(version: &str) -> Result<Self, Self::Err> {
         match version {
             "v02" => Ok(DapVersion::Draft02),
-            "v09" => Ok(DapVersion::Latest),
+            "v09" => Ok(DapVersion::DraftLatest),
             _ => Err(DapAbort::version_unknown()),
         }
     }
@@ -126,7 +126,7 @@ impl AsRef<str> for DapVersion {
     fn as_ref(&self) -> &str {
         match self {
             DapVersion::Draft02 => "v02",
-            DapVersion::Latest => "v09",
+            DapVersion::DraftLatest => "v09",
         }
     }
 }
@@ -496,7 +496,9 @@ impl DapTaskParameters {
         .unwrap();
 
         let (taskprov_advertisement, taskprov_report_extension_payload) = match self.version {
-            DapVersion::Latest => (Some(encode_base64url(&encoded_taskprov_config)), Vec::new()),
+            DapVersion::DraftLatest => {
+                (Some(encode_base64url(&encoded_taskprov_config)), Vec::new())
+            }
             // draft02 compatibility: The taskprov config is advertised in an HTTP header in
             // the latest draft. In draft02, it is carried by a report extension.
             DapVersion::Draft02 => (None, encoded_taskprov_config),
@@ -1124,7 +1126,7 @@ pub struct DapRequest<S> {
 impl<S> Default for DapRequest<S> {
     fn default() -> Self {
         Self {
-            version: DapVersion::Latest,
+            version: DapVersion::DraftLatest,
             media_type: Default::default(),
             task_id: Default::default(),
             resource: Default::default(),
@@ -1218,7 +1220,7 @@ pub struct DapLeaderProcessTelemetry {
 #[derive(Clone, Debug)]
 pub enum MetaAggregationJobId {
     Draft02(Draft02AggregationJobId),
-    Latest(AggregationJobId),
+    DraftLatest(AggregationJobId),
 }
 
 impl MetaAggregationJobId {
@@ -1227,7 +1229,7 @@ impl MetaAggregationJobId {
         let mut rng = thread_rng();
         match version {
             DapVersion::Draft02 => Self::Draft02(Draft02AggregationJobId(rng.gen())),
-            DapVersion::Latest => Self::Latest(AggregationJobId(rng.gen())),
+            DapVersion::DraftLatest => Self::DraftLatest(AggregationJobId(rng.gen())),
         }
     }
 
@@ -1236,7 +1238,7 @@ impl MetaAggregationJobId {
     pub(crate) fn for_request_payload(&self) -> Option<Draft02AggregationJobId> {
         match self {
             Self::Draft02(agg_job_id) => Some(*agg_job_id),
-            Self::Latest(..) => None,
+            Self::DraftLatest(..) => None,
         }
     }
 
@@ -1246,7 +1248,7 @@ impl MetaAggregationJobId {
         match self {
             // In draft02, the aggregation job ID is not determined until the payload is parsed.
             Self::Draft02(..) => DapResource::Undefined,
-            Self::Latest(agg_job_id) => DapResource::AggregationJob(*agg_job_id),
+            Self::DraftLatest(agg_job_id) => DapResource::AggregationJob(*agg_job_id),
         }
     }
 
@@ -1254,7 +1256,7 @@ impl MetaAggregationJobId {
     pub fn to_hex(&self) -> String {
         match self {
             Self::Draft02(agg_job_id) => agg_job_id.to_hex(),
-            Self::Latest(agg_job_id) => agg_job_id.to_hex(),
+            Self::DraftLatest(agg_job_id) => agg_job_id.to_hex(),
         }
     }
 
@@ -1262,7 +1264,7 @@ impl MetaAggregationJobId {
     pub fn to_base64url(&self) -> String {
         match self {
             Self::Draft02(agg_job_id) => agg_job_id.to_base64url(),
-            Self::Latest(agg_job_id) => agg_job_id.to_base64url(),
+            Self::DraftLatest(agg_job_id) => agg_job_id.to_base64url(),
         }
     }
 }

--- a/daphne/src/messages/taskprov.rs
+++ b/daphne/src/messages/taskprov.rs
@@ -38,7 +38,7 @@ impl ParameterizedEncode<DapVersion> for VdafTypeVar {
             Self::NotImplemented { typ, param } => {
                 typ.encode(bytes);
                 match version {
-                    DapVersion::Latest => encode_u16_bytes(bytes, param),
+                    DapVersion::DraftLatest => encode_u16_bytes(bytes, param),
                     DapVersion::Draft02 => bytes.extend_from_slice(param),
                 }
             }
@@ -56,7 +56,7 @@ impl ParameterizedDecode<DapVersion> for VdafTypeVar {
             (.., VDAF_TYPE_PRIO2) => Ok(Self::Prio2 {
                 dimension: decode_u16_item_for_version(*version, bytes)?,
             }),
-            (DapVersion::Latest, ..) => Ok(Self::NotImplemented {
+            (DapVersion::DraftLatest, ..) => Ok(Self::NotImplemented {
                 typ: vdaf_type,
                 param: decode_u16_bytes(bytes)?,
             }),
@@ -85,7 +85,7 @@ impl ParameterizedEncode<DapVersion> for DpConfig {
             Self::NotImplemented { typ, param } => {
                 typ.encode(bytes);
                 match version {
-                    DapVersion::Latest => encode_u16_bytes(bytes, param),
+                    DapVersion::DraftLatest => encode_u16_bytes(bytes, param),
                     DapVersion::Draft02 => bytes.extend_from_slice(param),
                 }
             }
@@ -104,7 +104,7 @@ impl ParameterizedDecode<DapVersion> for DpConfig {
                 decode_u16_item_for_version::<()>(*version, bytes)?;
                 Ok(Self::None)
             }
-            (DapVersion::Latest, ..) => Ok(Self::NotImplemented {
+            (DapVersion::DraftLatest, ..) => Ok(Self::NotImplemented {
                 typ: dp_mechanism,
                 param: decode_u16_bytes(bytes)?,
             }),
@@ -216,7 +216,7 @@ impl ParameterizedEncode<DapVersion> for QueryConfig {
             QueryConfigVar::NotImplemented { typ, param } => {
                 typ.encode(bytes);
                 match version {
-                    DapVersion::Latest => encode_u16_bytes(bytes, param),
+                    DapVersion::DraftLatest => encode_u16_bytes(bytes, param),
                     DapVersion::Draft02 => bytes.extend_from_slice(param),
                 }
             }
@@ -230,7 +230,7 @@ impl ParameterizedDecode<DapVersion> for QueryConfig {
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         let query_type = match version {
-            DapVersion::Latest => None,
+            DapVersion::DraftLatest => None,
             DapVersion::Draft02 => Some(u8::decode(bytes)?),
         };
         let time_precision = Duration::decode(bytes)?;
@@ -245,7 +245,7 @@ impl ParameterizedDecode<DapVersion> for QueryConfig {
             (.., QUERY_TYPE_FIXED_SIZE) => QueryConfigVar::FixedSize {
                 max_batch_size: decode_u16_item_for_version(*version, bytes)?,
             },
-            (DapVersion::Latest, ..) => QueryConfigVar::NotImplemented {
+            (DapVersion::DraftLatest, ..) => QueryConfigVar::NotImplemented {
                 typ: query_type,
                 param: decode_u16_bytes(bytes)?,
             },
@@ -283,7 +283,7 @@ impl ParameterizedEncode<DapVersion> for TaskConfig {
                 &(),
                 &[self.leader_url.clone(), self.helper_url.clone()],
             ),
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 self.leader_url.encode(bytes);
                 self.helper_url.encode(bytes);
             }
@@ -304,7 +304,7 @@ impl ParameterizedDecode<DapVersion> for TaskConfig {
             DapVersion::Draft02 => decode_u16_items(&(), bytes)?
                 .try_into()
                 .map_err(|_| CodecError::UnexpectedValue)?, // Expect exactly two Aggregator endpoints.
-            DapVersion::Latest => [UrlBytes::decode(bytes)?, UrlBytes::decode(bytes)?],
+            DapVersion::DraftLatest => [UrlBytes::decode(bytes)?, UrlBytes::decode(bytes)?],
         };
 
         Ok(TaskConfig {
@@ -373,8 +373,8 @@ mod tests {
         };
         assert_eq!(
             QueryConfig::get_decoded_with_param(
-                &DapVersion::Latest,
-                &query_config.get_encoded_with_param(&DapVersion::Latest)
+                &DapVersion::DraftLatest,
+                &query_config.get_encoded_with_param(&DapVersion::DraftLatest)
             )
             .unwrap(),
             query_config
@@ -420,8 +420,8 @@ mod tests {
         };
         assert_eq!(
             DpConfig::get_decoded_with_param(
-                &DapVersion::Latest,
-                &dp_config.get_encoded_with_param(&DapVersion::Latest)
+                &DapVersion::DraftLatest,
+                &dp_config.get_encoded_with_param(&DapVersion::DraftLatest)
             )
             .unwrap(),
             dp_config
@@ -472,8 +472,8 @@ mod tests {
 
         assert_eq!(
             VdafConfig::get_decoded_with_param(
-                &DapVersion::Latest,
-                &vdaf_config.get_encoded_with_param(&DapVersion::Latest)
+                &DapVersion::DraftLatest,
+                &vdaf_config.get_encoded_with_param(&DapVersion::DraftLatest)
             )
             .unwrap(),
             vdaf_config

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -177,7 +177,7 @@ pub trait DapAggregator<S>: HpkeDecrypter + DapReportInitializer + Sized {
 
         let payload = match req.version {
             DapVersion::Draft02 => hpke_config.as_ref().get_encoded(),
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 let hpke_config_list = HpkeConfigList {
                     hpke_configs: vec![hpke_config.as_ref().clone()],
                 };

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -164,7 +164,7 @@ pub trait DapHelper<S>: DapAggregator<S> {
                 agg_job_resp
             }
 
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 let agg_job_resp = finish_agg_job_and_aggregate(
                     self,
                     task_id,
@@ -458,10 +458,10 @@ fn resolve_agg_job_id<'id, S>(
         (DapVersion::Draft02, DapResource::Undefined, Some(agg_job_id)) => {
             Ok(MetaAggregationJobId::Draft02(*agg_job_id))
         }
-        (DapVersion::Latest, DapResource::AggregationJob(agg_job_id), None) => {
-            Ok(MetaAggregationJobId::Latest(*agg_job_id))
+        (DapVersion::DraftLatest, DapResource::AggregationJob(agg_job_id), None) => {
+            Ok(MetaAggregationJobId::DraftLatest(*agg_job_id))
         }
-        (DapVersion::Latest, DapResource::Undefined, None) => {
+        (DapVersion::DraftLatest, DapResource::Undefined, None) => {
             Err(DapAbort::BadRequest("undefined resource".into()))
         }
         _ => unreachable!("unhandled resource {:?}", req.resource),

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -283,10 +283,10 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         // from the request path.
         let collect_job_id = match (req.version, &req.resource) {
             (DapVersion::Draft02, DapResource::Undefined) => None,
-            (DapVersion::Latest, DapResource::CollectionJob(ref collect_job_id)) => {
+            (DapVersion::DraftLatest, DapResource::CollectionJob(ref collect_job_id)) => {
                 Some(*collect_job_id)
             }
-            (DapVersion::Latest, DapResource::Undefined) => {
+            (DapVersion::DraftLatest, DapResource::Undefined) => {
                 return Err(DapAbort::BadRequest("undefined resource".into()).into());
             }
             _ => unreachable!("unhandled resource {:?}", req.resource),
@@ -533,9 +533,9 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
         // In the latest draft, the Collection message includes the smallest quantized time
         // interval containing all reports in the batch.
-        let draft09_interval = match task_config.version {
+        let draft_latest_interval = match task_config.version {
             DapVersion::Draft02 => None,
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 let low = task_config.quantized_time_lower_bound(leader_agg_share.min_time);
                 let high = task_config.quantized_time_upper_bound(leader_agg_share.max_time);
                 Some(Interval {
@@ -554,7 +554,7 @@ pub trait DapLeader<S>: DapAuthorizedSender<S> + DapAggregator<S> {
         let collection = Collection {
             part_batch_sel: batch_selector.into(),
             report_count: leader_agg_share.report_count,
-            draft09_interval,
+            draft_latest_interval,
             encrypted_agg_shares: [leader_enc_agg_share, agg_share_resp.encrypted_agg_share],
         };
         self.finish_collect_job(task_id, collect_id, &collection)

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -197,7 +197,7 @@ mod test {
     fn empty_report_extensions_for_version(version: DapVersion) -> Option<Vec<Extension>> {
         match version {
             DapVersion::Draft02 => Some(Vec::new()),
-            DapVersion::Latest => None,
+            DapVersion::DraftLatest => None,
         }
     }
 
@@ -1364,7 +1364,7 @@ mod test {
         let collect_resp = Collection {
             part_batch_sel: PartialBatchSelector::TimeInterval,
             report_count: 0,
-            draft09_interval: if version == DapVersion::Draft02 {
+            draft_latest_interval: if version == DapVersion::Draft02 {
                 None
             } else {
                 Some(Interval {
@@ -1692,7 +1692,7 @@ mod test {
 
         let agg_job_req_count = match version {
             DapVersion::Draft02 => 2,
-            DapVersion::Latest => 1,
+            DapVersion::DraftLatest => 1,
         };
 
         assert_metrics_include!(t.helper_registry, {
@@ -1733,7 +1733,7 @@ mod test {
 
         let agg_job_req_count = match version {
             DapVersion::Draft02 => 2,
-            DapVersion::Latest => 1,
+            DapVersion::DraftLatest => 1,
         };
 
         assert_metrics_include!(t.helper_registry, {
@@ -1795,7 +1795,7 @@ mod test {
                     DapMeasurement::U32Vec(vec![1; 10]),
                     vec![Extension::Taskprov {
                         draft02_payload: match version {
-                            DapVersion::Latest => None,
+                            DapVersion::DraftLatest => None,
                             DapVersion::Draft02 => Some(taskprov_report_extension_payload.clone()),
                         },
                     }],
@@ -1833,7 +1833,7 @@ mod test {
 
         let agg_job_req_count = match version {
             DapVersion::Draft02 => 2,
-            DapVersion::Latest => 1,
+            DapVersion::DraftLatest => 1,
         };
 
         assert_metrics_include!(t.helper_registry, {

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -147,7 +147,7 @@ fn get_taskprov_task_config<S>(
             )
         })?)
     } else if let Some(metadata) = report_metadata_advertisement {
-        if req.version == DapVersion::Latest {
+        if req.version == DapVersion::DraftLatest {
             return Ok(None);
         }
         let taskprovs: Vec<&Extension> = metadata
@@ -621,7 +621,7 @@ mod test {
             (DapVersion::Draft02, Err(DapAbort::InvalidMessage { detail, .. })) => {
                 assert_eq!(detail, "codec error: unexpected value");
             }
-            (DapVersion::Latest, Err(DapAbort::InvalidTask { detail, .. })) => {
+            (DapVersion::DraftLatest, Err(DapAbort::InvalidTask { detail, .. })) => {
                 assert_eq!(detail, "unimplemented VDAF type (1337)");
             }
             (_, r) => panic!("unexpected result: {r:?} ({version})"),

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -524,7 +524,7 @@ macro_rules! test_versions {
     ($($fname:ident),*) => {
         $(
             $crate::test_version! { $fname, Draft02 }
-            $crate::test_version! { $fname, Latest }
+            $crate::test_version! { $fname, DraftLatest }
         )*
     };
 }
@@ -546,7 +546,7 @@ macro_rules! async_test_versions {
     ($($fname:ident),*) => {
         $(
             $crate::async_test_version! { $fname, Draft02 }
-            $crate::async_test_version! { $fname, Latest }
+            $crate::async_test_version! { $fname, DraftLatest }
         )*
     };
 }
@@ -555,14 +555,14 @@ macro_rules! async_test_versions {
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub(crate) enum MetaAggregationJobIdOwned {
     Draft02(Draft02AggregationJobId),
-    Latest(AggregationJobId),
+    DraftLatest(AggregationJobId),
 }
 
 impl From<&MetaAggregationJobId> for MetaAggregationJobIdOwned {
     fn from(agg_job_id: &MetaAggregationJobId) -> Self {
         match agg_job_id {
             MetaAggregationJobId::Draft02(agg_job_id) => Self::Draft02(*agg_job_id),
-            MetaAggregationJobId::Latest(agg_job_id) => Self::Latest(*agg_job_id),
+            MetaAggregationJobId::DraftLatest(agg_job_id) => Self::DraftLatest(*agg_job_id),
         }
     }
 }

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -1136,7 +1136,7 @@ impl<'srv> DaphneWorker<'srv> {
                 let mut r = Cursor::new(payload.as_ref());
                 (TaskId::decode(&mut r).ok(), DapResource::Undefined)
             }
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 let task_id = ctx.param("task_id").and_then(TaskId::try_from_base64url);
                 let resource = match media_type {
                     DapMediaType::AggregationJobInitReq

--- a/daphne_worker/src/durable/mod.rs
+++ b/daphne_worker/src/durable/mod.rs
@@ -728,7 +728,7 @@ mod test {
                 time: rng.gen(),
                 draft02_extensions: match version {
                     DapVersion::Draft02 => Some(Vec::new()),
-                    DapVersion::Latest => None,
+                    DapVersion::DraftLatest => None,
                 },
             },
             public_share: Vec::default(),

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -51,7 +51,7 @@ impl PendingReport {
     pub(crate) fn report_id_hex(&self) -> Option<&str> {
         match self.version {
             DapVersion::Draft02 if self.report_hex.len() >= 96 => Some(&self.report_hex[64..96]),
-            DapVersion::Latest if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
+            DapVersion::DraftLatest if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
             _ => None,
         }
     }

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -301,7 +301,7 @@ async fn leader_upload(version: DapVersion) {
     );
     let builder = match t.version {
         DapVersion::Draft02 => client.post(url.as_str()),
-        DapVersion::Latest => client.put(url.as_str()),
+        DapVersion::DraftLatest => client.put(url.as_str()),
     };
     let resp = builder
         .body(
@@ -312,7 +312,7 @@ async fn leader_upload(version: DapVersion) {
                     time: t.now,
                     draft02_extensions: match version {
                         DapVersion::Draft02 => Some(Vec::default()),
-                        DapVersion::Latest => None,
+                        DapVersion::DraftLatest => None,
                     },
                 },
                 public_share: b"public share".to_vec(),
@@ -665,7 +665,7 @@ async fn leader_collect_ok(version: DapVersion) {
 
     if version != DapVersion::Draft02 {
         // Check that the time interval for the reports is correct.
-        let interval = collection.draft09_interval.as_ref().unwrap();
+        let interval = collection.draft_latest_interval.as_ref().unwrap();
         let low = t.task_config.quantized_time_lower_bound(time_min);
         let high = t.task_config.quantized_time_upper_bound(time_max);
         assert!(low < high);
@@ -1312,7 +1312,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     for _ in 0..t.task_config.min_batch_size {
         let extensions = vec![Extension::Taskprov {
             draft02_payload: match version {
-                DapVersion::Latest => None,
+                DapVersion::DraftLatest => None,
                 DapVersion::Draft02 => Some(taskprov_report_extension_payload.clone()),
             },
         }];

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -78,7 +78,7 @@ impl TestRunner {
         // aggregator URL with 127.0.0.1.
         let version_path = match version {
             DapVersion::Draft02 => "v02",
-            DapVersion::Latest => "v09",
+            DapVersion::DraftLatest => "v09",
         };
         let mut leader_url = Url::parse(&format!("http://leader:8787/{}/", version_path)).unwrap();
         let mut helper_url = Url::parse(&format!("http://helper:8788/{}/", version_path)).unwrap();
@@ -693,14 +693,14 @@ impl TestRunner {
     pub fn upload_path_for_task(&self, id: &TaskId) -> String {
         match self.version {
             DapVersion::Draft02 => "upload".to_string(),
-            DapVersion::Latest => format!("tasks/{}/reports", id.to_base64url()),
+            DapVersion::DraftLatest => format!("tasks/{}/reports", id.to_base64url()),
         }
     }
 
     pub fn collect_path_for_task(&self, task_id: &TaskId) -> String {
         match self.version {
             DapVersion::Draft02 => "collect".to_string(),
-            DapVersion::Latest => {
+            DapVersion::DraftLatest => {
                 let collection_job_id = CollectionJobId(thread_rng().gen());
                 format!(
                     "tasks/{}/collection_jobs/{}",


### PR DESCRIPTION
A little bike-sheddy, but this allows us to align some variable names with the term "latest" more nicely (e.g., `draft09_payload` -> `draft_latest_payload`).