### PR TITLE
Enable Prio3SumVecField64MultiproofHmacSha256Aes128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "prio"
 version = "0.15.3"
-source = "git+https://github.com/divviup/libprio-rs?rev=46e8b8bd3c9aed1a1b674e95c49fefeae737e06b#46e8b8bd3c9aed1a1b674e95c49fefeae737e06b"
+source = "git+https://github.com/divviup/libprio-rs?rev=4ca547f35ebedf36fce45108ff8a29e14d51d048#4ca547f35ebedf36fce45108ff8a29e14d51d048"
 dependencies = [
  "aes 0.8.3",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hpke-rs-crypto = "=0.1.1"
 hpke-rs-rust-crypto = "=0.1.1"
 matchit = "0.7.3"
 paste = "1.0.14"
-prio = { git = "https://github.com/divviup/libprio-rs", rev = "46e8b8bd3c9aed1a1b674e95c49fefeae737e06b" }
+prio = { git = "https://github.com/divviup/libprio-rs", rev = "4ca547f35ebedf36fce45108ff8a29e14d51d048" }
 prometheus = "0.13.3"
 rand = "0.8.5"
 rand_core = "0.6.4"

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -775,6 +775,7 @@ impl AsRef<DapTaskConfig> for DapTaskConfig {
 pub enum DapMeasurement {
     U64(u64),
     U32Vec(Vec<u32>),
+    U64Vec(Vec<u64>),
     U128Vec(Vec<u128>),
 }
 
@@ -784,6 +785,7 @@ pub enum DapMeasurement {
 pub enum DapAggregateResult {
     U32Vec(Vec<u32>),
     U64(u64),
+    U64Vec(Vec<u64>),
     U128(u128),
     U128Vec(Vec<u128>),
 }
@@ -1038,6 +1040,15 @@ pub enum Prio3Config {
         length: usize,
         chunk_length: usize,
     },
+
+    /// A variant of `SumVec` that uses a smaller field (`Field64`), multiple proofs, and a custom
+    /// XOF (`XofHmacSha256Aes128`).
+    SumVecField64MultiproofHmacSha256Aes128 {
+        bits: usize,
+        length: usize,
+        chunk_length: usize,
+        num_proofs: u8,
+    },
 }
 
 impl Display for Prio3Config {
@@ -1054,6 +1065,12 @@ impl Display for Prio3Config {
                 length,
                 chunk_length,
             } => write!(f, "SumVec({bits},{length},{chunk_length})"),
+            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                bits,
+                length,
+                chunk_length,
+                num_proofs,
+            } => write!(f, "SumVecField64MultiproofHmacSha256Aes128({bits},{length},{chunk_length},{num_proofs})"),
         }
     }
 }

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -458,7 +458,7 @@ mod test {
         ];
         match &vk {
             VdafVerifyKey::Prio2(bytes) => assert_eq!(*bytes, expected),
-            VdafVerifyKey::Prio3(_) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 

--- a/daphne/src/vdaf/prio2.rs
+++ b/daphne/src/vdaf/prio2.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     vdaf::VdafError, DapAggregateResult, DapMeasurement, VdafAggregateShare, VdafPrepMessage,
-    VdafPrepState,
+    VdafPrepState, VdafVerifyKey,
 };
 use prio::{
     codec::{Decode, Encode, ParameterizedDecode},
@@ -42,12 +42,16 @@ pub(crate) fn prio2_shard(
 /// Consume an input share and return the corresponding prep state and share.
 pub(crate) fn prio2_prep_init(
     dimension: usize,
-    verify_key: &[u8; 32],
+    verify_key: &VdafVerifyKey,
     agg_id: usize,
     nonce: &[u8; 16],
     public_share_data: &[u8],
     input_share_data: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
+    let VdafVerifyKey::Prio2(verify_key) = verify_key else {
+        panic!("unhandled verify key type");
+    };
+
     let vdaf = Prio2::new(dimension)?;
     <()>::get_decoded_with_param(&vdaf, public_share_data)?;
     let input_share: Share<FieldPrio2, 32> =


### PR DESCRIPTION
Stacked on #444.

Define and enable a variant of Prio3SumVec variant that uses `Field64` for the field, `XofHmacSha265Aes128` as the XOF, and allows an arbitrary number of proofs.

The custom XOF uses a larger seed size than the standard one (`XofTurboShake128`), so it is necessary to define a new variant of `VdafVerifyKey` and other related structures.

This change also improves the unit tests in for the `vdaf::prio3` module by replacing the Prio3-specific test code with the `AggregationJobTest` runner.