### PR TITLE
Add deepsize to test deps do daphne

### DIFF
--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -39,6 +39,7 @@ url.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+deepsize.workspace = true
 futures.workspace = true
 matchit.workspace = true
 paste.workspace = true


### PR DESCRIPTION
This worked but was tecnically incorrect and caused `cargo check -p daphne --tests` to fail
