### PR TITLE
Remove storage related settings from global config

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -141,17 +141,6 @@ impl std::fmt::Display for DapVersion {
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub struct DapGlobalConfig {
-    /// The report storage epoch duration. This value is used to control the period of time for
-    /// which an Aggregator guarantees storage of reports and/or report metadata.
-    ///
-    /// A report will be accepted if its timestamp is no more than the specified number of seconds
-    /// before the current time.
-    pub report_storage_epoch_duration: Duration,
-
-    /// The report storage maximum future time skew. Reports with timestamps greater than the
-    /// current time plus this value will be rejected.
-    pub report_storage_max_future_time_skew: Duration,
-
     /// Maximum interval duration permitted in CollectReq.
     /// Prevents Collectors from requesting wide range or reports.
     pub max_batch_duration: Duration,

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -260,8 +260,6 @@ mod test {
             // Global config. In a real deployment, the Leader and Helper may make different choices
             // here.
             let global_config = DapGlobalConfig {
-                report_storage_epoch_duration: 604_800,   // one week
-                report_storage_max_future_time_skew: 300, // 5 minutes
                 max_batch_duration: 360_000,
                 min_batch_interval_start: 259_200,
                 max_batch_interval_end: 259_200,

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -111,8 +111,6 @@ impl TestRunner {
 
         // This block needs to be kept in-sync with daphne_worker_test/wrangler.toml.
         let global_config = DapGlobalConfig {
-            report_storage_epoch_duration: 604800,
-            report_storage_max_future_time_skew: 300,
             max_batch_duration: 360000,
             min_batch_interval_start: 259200,
             max_batch_interval_end: 259200,
@@ -276,9 +274,10 @@ impl TestRunner {
     }
 
     pub fn report_interval(&self, interval: &Interval) -> Range<u64> {
+        const REPORT_STORAGE_MAX_FUTURE_TIME_SKEW: u64 = 300;
         // This is a portion of the interval which is guaranteed to be a valid report time
         // provided that the interval start time is valid.
-        interval.start..interval.start + self.global_config.report_storage_max_future_time_skew
+        interval.start..interval.start + REPORT_STORAGE_MAX_FUTURE_TIME_SKEW
     }
 
     pub async fn get_hpke_configs(

--- a/daphne_worker_test/wrangler.toml
+++ b/daphne_worker_test/wrangler.toml
@@ -27,9 +27,9 @@ DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 DAP_COLLECTION_JOB_ID_KEY = "12da249b0e3b1a9b5936d6ff6cdd2fa09964e2e11f5450e04eef11dc5e64daf1" # SECRET
 DAP_REPORT_SHARD_KEY = "b6e5736df46d9dd7dc087cad1cd4f03c1ff399160a8eb30c5e7841aa696e737f" # SECRET
 DAP_REPORT_SHARD_COUNT = "2"
+DAP_REPORT_STORAGE_EPOCH_DURATION = "604800"
+DAP_REPORT_STORAGE_MAX_FUTURE_TIME_SKEW = "300"
 DAP_GLOBAL_CONFIG = """{
-     "report_storage_epoch_duration": 604800,
-     "report_storage_max_future_time_skew": 300,
      "max_batch_duration": 360000,
      "min_batch_interval_start": 259200,
      "max_batch_interval_end": 259200,
@@ -105,9 +105,9 @@ DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 DAP_REPORT_SHARD_KEY = "896eccc5e89474dd656d490408226fdd4ce5b34d2d1349147c6fcbb1741ddb2d" # SECRET
 DAP_REPORT_SHARD_COUNT = "2"
 DAP_HELPER_STATE_STORE_GARBAGE_COLLECT_AFTER_SECS = "10"
+DAP_REPORT_STORAGE_EPOCH_DURATION = "604800"
+DAP_REPORT_STORAGE_MAX_FUTURE_TIME_SKEW = "300"
 DAP_GLOBAL_CONFIG = """{
-  "report_storage_epoch_duration": 604800,
-  "report_storage_max_future_time_skew": 300,
   "max_batch_duration": 360000,
   "min_batch_interval_start": 259200,
   "max_batch_interval_end": 259200,

--- a/docker/wrangler.toml
+++ b/docker/wrangler.toml
@@ -27,9 +27,9 @@ DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 DAP_COLLECTION_JOB_ID_KEY = "b416a85d280591d6da14e5b75a7d6e31" # SECRET
 DAP_REPORT_SHARD_KEY = "61cd9685547370cfea76c2eb8d156ad9" # SECRET
 DAP_REPORT_SHARD_COUNT = "2"
+DAP_REPORT_STORAGE_EPOCH_DURATION = "604800"
+DAP_REPORT_STORAGE_MAX_FUTURE_TIME_SKEW = "300"
 DAP_GLOBAL_CONFIG = """{
-     "report_storage_epoch_duration": 604800,
-     "report_storage_max_future_time_skew": 300,
      "max_batch_duration": 360000,
      "min_batch_interval_start": 259200,
      "max_batch_interval_end": 259200,
@@ -105,9 +105,9 @@ DAP_ISSUE73_DISABLE_AGG_JOB_QUEUE_GARBAGE_COLLECTION = "true"
 DAP_REPORT_SHARD_KEY = "f79c352056982bae1737e34bdac24d63" # SECRET
 DAP_REPORT_SHARD_COUNT = "2"
 DAP_HELPER_STATE_STORE_GARBAGE_COLLECT_AFTER_SECS = "10"
+DAP_REPORT_STORAGE_EPOCH_DURATION = "604800"
+DAP_REPORT_STORAGE_MAX_FUTURE_TIME_SKEW = "300"
 DAP_GLOBAL_CONFIG = """{
-  "report_storage_epoch_duration": 604800,
-  "report_storage_max_future_time_skew": 300,
   "max_batch_duration": 360000,
   "min_batch_interval_start": 259200,
   "max_batch_interval_end": 259200,


### PR DESCRIPTION
These fields are unused by the `daphne` crate, hence they shouldn't be required
by it.
