### PR TITLE
Remove lifetimes from EarlyReportState{Consumed,Initialized}

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -671,7 +671,7 @@ impl DapTaskConfig {
     pub fn batch_span_for_meta<'sel, 'rep>(
         &self,
         part_batch_sel: &'sel PartialBatchSelector,
-        consumed_reports: impl Iterator<Item = &'rep EarlyReportStateConsumed<'rep>>,
+        consumed_reports: impl Iterator<Item = &'rep EarlyReportStateConsumed>,
     ) -> Result<DapAggregateSpan<()>, DapError> {
         if !self.query.is_valid_part_batch_sel(part_batch_sel) {
             return Err(fatal_error!(

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -33,8 +33,8 @@ pub trait DapReportInitializer {
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         part_batch_sel: &PartialBatchSelector,
-        consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
-    ) -> Result<Vec<EarlyReportStateInitialized<'req>>, DapError>;
+        consumed_reports: Vec<EarlyReportStateConsumed>,
+    ) -> Result<Vec<EarlyReportStateInitialized>, DapError>;
 }
 
 #[derive(Debug)]

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -83,8 +83,8 @@ impl DapReportInitializer for AggregationJobTest {
         _task_id: &TaskId,
         task_config: &DapTaskConfig,
         _part_batch_sel: &PartialBatchSelector,
-        consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
-    ) -> Result<Vec<EarlyReportStateInitialized<'req>>, DapError> {
+        consumed_reports: Vec<EarlyReportStateConsumed>,
+    ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {
         let mut reports_processed = if is_leader {
             self.leader_reports_processed.lock().unwrap()
         } else {
@@ -916,8 +916,8 @@ impl DapReportInitializer for MockAggregator {
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         part_batch_sel: &PartialBatchSelector,
-        consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
-    ) -> Result<Vec<EarlyReportStateInitialized<'req>>, DapError> {
+        consumed_reports: Vec<EarlyReportStateConsumed>,
+    ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {
         let span = task_config.batch_span_for_meta(
             part_batch_sel,
             consumed_reports.iter().filter(|report| report.is_ready()),

--- a/daphne_server/src/roles/aggregator.rs
+++ b/daphne_server/src/roles/aggregator.rs
@@ -153,8 +153,8 @@ impl DapReportInitializer for crate::App {
         task_id: &TaskId,
         task_config: &DapTaskConfig,
         part_batch_sel: &PartialBatchSelector,
-        consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
-    ) -> Result<Vec<EarlyReportStateInitialized<'req>>, DapError> {
+        consumed_reports: Vec<EarlyReportStateConsumed>,
+    ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {
         todo!()
     }
 }

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -39,8 +39,8 @@ impl DapReportInitializer for DaphneWorker<'_> {
         _task_id: &TaskId,
         task_config: &DapTaskConfig,
         _part_batch_sel: &PartialBatchSelector,
-        consumed_reports: Vec<EarlyReportStateConsumed<'req>>,
-    ) -> Result<Vec<EarlyReportStateInitialized<'req>>, DapError> {
+        consumed_reports: Vec<EarlyReportStateConsumed>,
+    ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {
         let min_time = self.least_valid_report_time(self.get_current_time());
         let max_time = self.greatest_valid_report_time(self.get_current_time());
 


### PR DESCRIPTION
These lifetimes make working with these types harder so moving the data around is a better option.

I introduced a TODO item on a few clones that I'm confident can be avoided, but due to time constraints and because they require a bigger refactor of the system, I have left them as future improvements.