### PR TITLE
Remove invalid from DapMediaType

### DIFF
--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -64,7 +64,7 @@ async fn leader_send_http_request<S: Sync>(
 
     let req = DapRequest {
         version: task_config.version,
-        media_type: req_media_type.clone(),
+        media_type: req_media_type,
         task_id: Some(*task_id),
         resource,
         sender_auth: Some(

--- a/daphne_server/src/router/mod.rs
+++ b/daphne_server/src/router/mod.rs
@@ -204,7 +204,8 @@ where
                 .headers
                 .get(CONTENT_TYPE)
                 .and_then(|v| v.to_str().ok()),
-        );
+        )
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "invalid media type".into()))?;
 
         let taskprov = parts
             .headers

--- a/daphne_worker/src/config.rs
+++ b/daphne_worker/src/config.rs
@@ -1145,7 +1145,8 @@ impl<'srv> DaphneWorker<'srv> {
             .headers()
             .get("Content-Type")
             .map_err(|e| fatal_error!(err = ?e))?;
-        let media_type = DapMediaType::from_str_for_version(version, content_type.as_deref());
+        let media_type = DapMediaType::from_str_for_version(version, content_type.as_deref())
+            .unwrap_or(DapMediaType::Missing);
 
         let payload = req.bytes().await.map_err(|e| fatal_error!(err = ?e))?;
 
@@ -1290,7 +1291,8 @@ impl<'srv> DaphneWorker<'srv> {
                 .ok_or_else(|| fatal_error!(err = INT_ERR_PEER_RESP_MISSING_MEDIA_TYPE))?
                 .to_str()
                 .map_err(|e| fatal_error!(err = ?e))?;
-            let media_type = DapMediaType::from_str_for_version(req.version, Some(content_type));
+            let media_type = DapMediaType::from_str_for_version(req.version, Some(content_type))
+                .ok_or_else(|| fatal_error!(err = "invalid media type"))?;
 
             let payload = reqwest_resp
                 .bytes()


### PR DESCRIPTION
Having an "Invalid" variant in an enum is an anti pattern as it allows invalid data to travel through the system for longer than it needs to. Instead we should aim to fail fast when validating inputs to the system.