### PR TITLE
Refactor DO Bindings and extract them to utils

### DIFF
--- a/.github/workflows/daphneci.yml
+++ b/.github/workflows/daphneci.yml
@@ -20,6 +20,8 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
           override: true
+      - name: Cap'n'proto
+        run: sudo apt install capnproto
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
       - name: Format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f125eb85b84a24c36b02ed1d22c9dd8632f53b3cde6e4d23512f94021030003"
 
 [[package]]
+name = "capnp"
+version = "0.18.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e78424967d6d4c8e295a3b5114ae6d849052e9dbbed3e62589a76acda54e3f0"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f3c8ee94d993d03150153e9a57a6ff330127b1c1ad76475051e1cef79c2d"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "daphne_server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "clap",
@@ -658,10 +676,14 @@ dependencies = [
 
 [[package]]
 name = "daphne_service_utils"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
+ "capnp",
+ "capnpc",
  "daphne",
+ "http 1.0.0",
  "prometheus",
+ "ring",
  "serde",
  "serde_json",
  "url",
@@ -761,6 +783,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ assert_matches = "1.5.0"
 async-trait = "0.1.74"
 base64 = "0.21.5"
 cap = "0.1.2"
+capnp = "0.18.10"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 deepsize = { version = "0.2.0" }
 futures = "0.3.29"
@@ -32,6 +33,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.2.0"
 hpke-rs-crypto = "0.2.0"
 hpke-rs-rust-crypto = "0.2.0"
+http = "1.0.0"
 matchit = "0.7.3"
 paste = "1.0.14"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "d0168336bbad1805231a69181b329e37ee962203" }

--- a/check-all.sh
+++ b/check-all.sh
@@ -27,6 +27,7 @@ case "$mode" in
     test)
         r cargo test -p daphne
         r cargo test -p daphne --features send-traits
+        r cargo test -p daphne_service_utils
         r cargo test -p daphne_worker
         r cargo test -p daphne-worker-test
         r cargo test -p daphne_server

--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -1239,7 +1239,7 @@ impl ParameterizedDecode<DapVersion> for PlaintextInputShare {
 
 // NOTE ring provides a similar function, but as of version 0.16.20, it doesn't compile to
 // wasm32-unknown-unknown.
-pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+pub fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
     if left.len() != right.len() {
         return false;
     }

--- a/daphne_service_utils/Cargo.toml
+++ b/daphne_service_utils/Cargo.toml
@@ -16,10 +16,17 @@ repository = "https://github.com/cloudflare/daphne"
 readme = "../README.md"
 
 [dependencies]
+capnp.workspace = true
 daphne = { path = "../daphne", default-features = false }
-serde.workspace = true
+http.workspace = true
 prometheus.workspace = true
+ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 url.workspace = true
 
-[dev-dependencies]
-serde_json.workspace = true
+[build-dependencies]
+capnpc = "0.18.0"
+
+[features]
+test-utils = []

--- a/daphne_service_utils/build.rs
+++ b/daphne_service_utils/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    ::capnpc::CompilerCommand::new()
+        .file("./src/durable_requests/durable_request.capnp")
+        .run()
+        .expect("compiling schema");
+}

--- a/daphne_service_utils/src/durable_requests/bindings.rs
+++ b/daphne_service_utils/src/durable_requests/bindings.rs
@@ -1,0 +1,357 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! This module defines the durable objects' binding and methods as implementors of the
+//! [`DurableMethod`] trait.
+//!
+//! It also defines types that are used as the body of requests sent to these objects.
+
+use std::collections::HashSet;
+
+use daphne::{
+    messages::{BatchId, CollectionJobId, CollectionReq, Duration, ReportId, TaskId, Time},
+    DapAggregateShare, DapBatchBucket, DapTaskConfig, DapVersion, MetaAggregationJobId,
+};
+use serde::{Deserialize, Serialize};
+
+use super::ObjectIdFrom;
+
+/// A durable object method.
+pub trait DurableMethod {
+    /// The binding of the object this method belongs to as configured in the wrangler.toml
+    const BINDING: &'static str;
+
+    type NameParameters<'n>;
+
+    /// Try to parse a uri into one of methods of this object.
+    fn try_from_uri(s: &str) -> Option<Self>
+    where
+        Self: Sized;
+
+    /// Convert this method into a uri.
+    fn to_uri(&self) -> &'static str;
+
+    /// Generate the durable object name
+    fn name(params: Self::NameParameters<'_>) -> ObjectIdFrom;
+}
+
+macro_rules! define_do_binding {
+    (
+        const BINDING = $binding:literal;
+        enum $name:ident {
+            $($op:ident = $route:literal),*$(,)?
+        }
+
+        fn name($params:tt : $params_ty:ty) -> ObjectIdFrom $name_impl:block
+
+    ) => {
+        #[derive(
+            serde::Serialize,
+            serde::Deserialize,
+            Debug,
+            Clone,
+            Copy,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Hash
+        )]
+        pub enum $name {
+            $($op),*
+        }
+
+        impl DurableMethod for $name {
+            const BINDING: &'static str = $binding;
+
+            type NameParameters<'n> = $params_ty;
+
+            fn try_from_uri(s: &str) -> Option<Self> {
+                match (s) {
+                    $($route => Some(Self::$op),)*
+                    _ => return None,
+                }
+            }
+
+            fn to_uri(&self) -> &'static str {
+                match self {
+                    $(Self::$op => $route,)*
+                }
+            }
+
+            fn name($params: Self::NameParameters<'_>) -> ObjectIdFrom {
+                $name_impl
+            }
+        }
+    };
+}
+
+define_do_binding! {
+    const BINDING = "DAP_AGGREGATE_STORE";
+    enum AggregateStore {
+        GetMerged = "/internal/do/aggregate_store/get_merged",
+        Get = "/internal/do/aggregate_store/get",
+        Merge = "/internal/do/aggregate_store/merge",
+        MarkCollected = "/internal/do/aggregate_store/mark_collected",
+        CheckCollected = "/internal/do/aggregate_store/check_collected",
+    }
+
+    fn name((version, task_id_hex, bucket): (DapVersion, &'n str, &'n DapBatchBucket)) -> ObjectIdFrom {
+        fn durable_name_bucket(bucket: &DapBatchBucket) -> String {
+            match bucket {
+                DapBatchBucket::TimeInterval { batch_window } => {
+                    format!("window/{batch_window}")
+                }
+                DapBatchBucket::FixedSize { batch_id } => {
+                    format!("batch/{}", batch_id.to_hex())
+                }
+            }
+        }
+        ObjectIdFrom::Name(format!(
+            "{}/{}",
+            durable_name_task(version, task_id_hex),
+            durable_name_bucket(bucket),
+        ))
+    }
+}
+
+fn durable_name_task(version: DapVersion, task_id_hex: &str) -> String {
+    format!("{}/task/{}", version.as_ref(), task_id_hex)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AggregateStoreMergeReq {
+    pub contained_reports: Vec<ReportId>,
+    pub agg_share_delta: DapAggregateShare,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AggregateStoreMergeResp {
+    Ok,
+    ReplaysDetected(HashSet<ReportId>),
+    AlreadyCollected,
+}
+
+define_do_binding! {
+    const BINDING = "DAP_GARBAGE_COLLECTOR";
+    enum GarbageCollector {
+        Put = "/internal/do/garbage_collector/put",
+        DeleteAll = "/internal/do/delete_all",
+    }
+
+    fn name(_: ()) -> ObjectIdFrom {
+        ObjectIdFrom::Name(Self::NAME_STR.into())
+    }
+}
+
+impl GarbageCollector {
+    pub const NAME_STR: &'static str = "garbage_collector";
+}
+
+define_do_binding! {
+    const BINDING = "DAP_HELPER_STATE_STORE";
+    enum HelperState {
+        PutIfNotExists = "/internal/do/helper_state/put_if_not_exists",
+        Get = "/internal/do/helper_state/get",
+    }
+
+    fn name((version, task_id, agg_job_id): (DapVersion, &'n TaskId, &'n MetaAggregationJobId)) -> ObjectIdFrom {
+        ObjectIdFrom::Name(format!(
+            "{}/task/{}/agg_job/{}",
+            version.as_ref(),
+            task_id.to_hex(),
+            agg_job_id.to_hex()
+        ))
+    }
+
+}
+
+define_do_binding! {
+    const BINDING = "DAP_LEADER_AGG_JOB_QUEUE";
+    enum LeaderAggJobQueue {
+        Put = "/internal/do/agg_job_queue/put",
+        Get = "/internal/do/agg_job_queue/get",
+        Finish = "/internal/do/agg_job_queue/finish",
+    }
+
+    fn name(shard: u64) -> ObjectIdFrom {
+        ObjectIdFrom::Name(format!("queue/{shard}"))
+    }
+}
+
+define_do_binding! {
+    const BINDING = "DAP_LEADER_BATCH_QUEUE";
+    enum LeaderBatchQueue {
+        Assign = "/internal/do/leader_batch_queue/assign",
+        Current = "/internal/do/leader_batch_queue/current",
+        Remove = "/internal/do/leader_batch_queue/remove",
+    }
+
+    fn name((version, task_id_hex): (DapVersion, &'n str)) -> ObjectIdFrom {
+        ObjectIdFrom::Name(format!("{}/task/{}", version.as_ref(), task_id_hex))
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LeaderBatchQueueResult {
+    Ok(BatchId),
+    EmptyQueue,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BatchCount {
+    pub batch_id: BatchId,
+    pub report_count: usize,
+}
+
+define_do_binding! {
+    const BINDING = "DAP_LEADER_COL_JOB_QUEUE";
+    enum LeaderColJobQueue {
+        Put = "/internal/do/leader_col_job_queue/put",
+        Get = "/internal/do/leader_col_job_queue/get",
+        Finish = "/internal/do/leader_col_job_queue/finish",
+        GetResult = "/internal/do/leader_col_job_queue/get_result",
+    }
+
+    fn name(shard: u64) -> ObjectIdFrom {
+        LeaderAggJobQueue::name(shard)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct CollectQueueRequest {
+    pub collect_req: CollectionReq,
+    pub task_id: TaskId,
+    pub collect_job_id: Option<CollectionJobId>,
+}
+
+define_do_binding! {
+    const BINDING = "DAP_REPORTS_PENDING";
+    enum ReportsPending {
+        Get = "/internal/do/reports_pending/get",
+        Put = "/internal/do/reports_pending/put",
+    }
+
+    fn name(
+        (
+            task_config,
+            task_id_hex,
+            report_id,
+            report_time,
+            report_shard_key,
+            report_shard_count,
+            report_storage_epoch_duration,
+        ): (
+            &'n DapTaskConfig,
+            &'n str,
+            &'n ReportId,
+            Time,
+            &'n [u8; 32],
+            u64,
+            Duration,
+        )
+    ) -> ObjectIdFrom {
+        let key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, report_shard_key);
+        let tag = ring::hmac::sign(&key, report_id.as_ref());
+        let shard = u64::from_be_bytes(
+            tag.as_ref()[..std::mem::size_of::<u64>()]
+                .try_into()
+                .unwrap(),
+        ) % report_shard_count;
+        let epoch = report_time - (report_time % report_storage_epoch_duration);
+        durable_name_report_store(task_config.version, task_id_hex, epoch, shard)
+    }
+}
+
+pub fn durable_name_report_store(
+    version: DapVersion,
+    task_id_hex: &str,
+    epoch: u64,
+    shard: u64,
+) -> ObjectIdFrom {
+    ObjectIdFrom::Name(format!(
+        "{}/epoch/{:020}/shard/{}",
+        durable_name_task(version, task_id_hex),
+        epoch,
+        shard
+    ))
+}
+
+pub fn durable_name_queue(shard: u64) -> String {
+    format!("queue/{shard}")
+}
+
+impl ReportsPending {}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PendingReport {
+    pub task_id: TaskId,
+    pub version: DapVersion,
+
+    /// Hex-encdoed, serialized report.
+    //
+    // TODO(cjpatton) Consider changing the type to `Report`. If I recall correctly, this triggers
+    // the serde-wasm-bindgen bug we saw in workers-rs 0.0.12, which should be fixed as of 0.0.15.
+    pub report_hex: String,
+}
+
+impl PendingReport {
+    pub fn report_id_hex(&self) -> Option<&str> {
+        match self.version {
+            DapVersion::Draft02 if self.report_hex.len() >= 96 => Some(&self.report_hex[64..96]),
+            DapVersion::DraftLatest if self.report_hex.len() >= 32 => Some(&self.report_hex[..32]),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportsPendingResult {
+    Ok,
+    ErrReportExists,
+}
+
+#[cfg(test)]
+mod test {
+    use super::{durable_name_queue, durable_name_report_store, AggregateStore, DurableMethod};
+    use crate::durable_requests::ObjectIdFrom;
+    use daphne::{
+        messages::{BatchId, TaskId},
+        DapBatchBucket, DapVersion,
+    };
+
+    #[test]
+    fn durable_name() {
+        let time = 1_664_850_074;
+        let id1 = TaskId([17; 32]);
+        let id2 = BatchId([34; 32]);
+        let shard = 1234;
+
+        assert_eq!(durable_name_queue(shard), "queue/1234");
+
+        assert_eq!(
+            durable_name_report_store(DapVersion::Draft02, &id1.to_hex(), time, shard),
+            ObjectIdFrom::Name(
+                "v02/task/1111111111111111111111111111111111111111111111111111111111111111/epoch/00000000001664850074/shard/1234".into(),
+            )
+        );
+
+        assert_eq!(
+            AggregateStore::name((DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::FixedSize{ batch_id: id2 })),
+            ObjectIdFrom::Name(
+                "v02/task/1111111111111111111111111111111111111111111111111111111111111111/batch/2222222222222222222222222222222222222222222222222222222222222222".into(),
+            )
+        );
+
+        assert_eq!(
+            AggregateStore::name((DapVersion::Draft02, &id1.to_hex(), &DapBatchBucket::TimeInterval{ batch_window: time })),
+            ObjectIdFrom::Name(
+                "v02/task/1111111111111111111111111111111111111111111111111111111111111111/window/1664850074".into(),
+            )
+        );
+    }
+}

--- a/daphne_service_utils/src/durable_requests/durable_request.capnp
+++ b/daphne_service_utils/src/durable_requests/durable_request.capnp
@@ -1,0 +1,21 @@
+@0xd076f8051f8de41a;
+
+enum Method {
+    get @0;
+    post @1;
+    put @2;
+    patch @3;
+    delete @4;
+    options @5;
+    head @6;
+    trace @7;
+    connect @8;
+}
+
+struct DurableRequest @0xfbd55b93d47690b9 {
+    binding @0 :Text;
+    id :union {
+        name @1 :Text;
+        hex @2 :Text;
+    }
+}

--- a/daphne_service_utils/src/durable_requests/mod.rs
+++ b/daphne_service_utils/src/durable_requests/mod.rs
@@ -1,0 +1,294 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! This module implements the communication between the daphne service and the storage proxy.
+//!
+//! Communication with the storage proxy happens through HTTP. The URI of the request is the URI
+//! to use when talking to the durable object, prefixed by [`DO_PATH_PREFIX`]. The body of this
+//! request will contain the metadata necessary for the storage proxy to locate the appropriate
+//! durable object, followed by the opaque body that should be forwarded to the durable object
+//! itself.
+//!
+//! # Metadata encoding
+//!
+//! The metadata is encoded using capnproto as the binary protocol, it contains:
+//! - The `binding` which identifies the durable object implementation to target.
+//! - The `id` which identifies the specific instance of the durable object.
+//!
+//! # Body encoding
+//!
+//! The body that follows this piece of metadata is opaque and to be understood by the Durable
+//! Object itself. So the proxy simply forwards it along without any processing.
+//!
+//! # The response
+//!
+//! The HTTP response is simply forwarded back from the Durable Object to the daphne service.
+//!
+//!```text
+//! +----------------+                 +---------------+            +----------------+
+//! | Native Service |                 | Storage Proxy |            | Durable Object |
+//! +----------------+                 +---------------+            +----------------+
+//!    | Http Request:                         |                            |
+//!    | POST /v1/`DO_PATH_PREFIX`/path/to/call   |                            |
+//!    | DurableRequest:                       |                            |
+//!    |   {binding, id}[body]                 |                            |
+//!    |-------------------------------------->| use `binding` and `id`     |
+//!    |                                       | to locate the durable      |
+//!    |                                       | object.                    |
+//!    |                                       |--------+                   |
+//!    |                                       |        |                   |
+//!    |                                       |        |                   |
+//!    |                                       |<-------+                   |
+//!    |                                       |                            |
+//!    |                                       |                            |
+//!    |                                       | Http Request:              |
+//!    |                                       | POST `/path/to/call`       | do some
+//!    |                                       | `body`                     | storage work
+//!    |                                       |--------------------------> |---------+
+//!    |                                       |                            |         |
+//!    |                                       |              Http Response |         |
+//!    |<--------------------------------------|<---------------------------|<--------+
+//!```
+
+pub mod bindings;
+
+use std::io;
+
+use bindings::DurableMethod;
+use daphne::messages::constant_time_eq;
+use durable_request_capnp::durable_request;
+use serde::{Deserialize, Serialize};
+
+use crate::durable_request_capnp;
+
+/// The base of a request path that points to a key in KV.
+pub const KV_PATH_PREFIX: &str = "/v1/kv";
+/// The base of a request path that points to a durable object.
+pub const DO_PATH_PREFIX: &str = "/v1/do";
+#[cfg(feature = "test-utils")]
+/// The path of the purge request, which wipes all storage. This is meant for tests only.
+pub const PURGE_STORAGE: &str = "/v1/purge";
+
+/// The way the target object's id will be obtained.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ObjectIdFrom {
+    /// Derive a unique id from a name string.
+    ///
+    /// [see also](https://docs.rs/worker/latest/worker/durable/struct.ObjectNamespace.html#method.id_from_name)
+    Name(String),
+
+    /// Parse a previously stringified id from a hex string.
+    ///
+    /// [see also](https://docs.rs/worker/latest/worker/durable/struct.ObjectNamespace.html#method.id_from_string)
+    Hex(String),
+}
+
+impl ObjectIdFrom {
+    /// Assert that the object is being referenced by name.
+    ///
+    /// # Note
+    /// This is here for convenience of the daphne_worker and can be removed in the future.
+    pub fn unwrap_from_name(self) -> String {
+        let Self::Name(name) = self else {
+            panic!("unwraped a {self:?} when a Name was expected");
+        };
+        name
+    }
+
+    /// Assert that the object is being referenced by id.
+    ///
+    /// # Note
+    /// This is here for convenience of the daphne_worker and can be removed in the future.
+    pub fn unwrap_from_hex(self) -> String {
+        let Self::Hex(name) = self else {
+            panic!("unwraped a {self:?} when a Hex was expected");
+        };
+        name
+    }
+}
+
+/// A durable object request meant for the storage proxy.
+///
+/// It's generic over the payload which can be any type that implements AsRef<[u8]>. This payload
+/// is what is ultimately passed to the durable object.
+#[derive(Debug, Clone)]
+pub struct DurableRequest<P: AsRef<[u8]>> {
+    /// A binding name, as configured in the wrangler.toml.
+    ///
+    /// [see also](https://developers.cloudflare.com/durable-objects/get-started/#5-configure-durable-object-bindings)
+    pub binding: String,
+
+    /// The method by which the object id will be obtained in the storage proxy.
+    ///
+    /// [see also](https://developers.cloudflare.com/durable-objects/get-started/#4-instantiate-and-communicate-with-a-durable-object)
+    pub id: ObjectIdFrom,
+
+    /// The body of the request.
+    body: P,
+}
+
+// This needs to be very general to facilitate tests.
+impl<T, U> PartialEq<DurableRequest<U>> for DurableRequest<T>
+where
+    T: AsRef<[u8]>,
+    U: AsRef<[u8]>,
+{
+    fn eq(&self, other: &DurableRequest<U>) -> bool {
+        let Self { binding, id, body } = self;
+        *binding == other.binding
+            && *id == other.id
+            && constant_time_eq(body.as_ref(), other.body.as_ref())
+    }
+}
+
+impl DurableRequest<[u8; 0]> {
+    /// Create a new [`DurableRequest`] with an empty body.
+    pub fn new<B: DurableMethod>(
+        durable_method: B,
+        params: B::NameParameters<'_>,
+    ) -> (Self, &'static str) {
+        (
+            Self {
+                binding: B::BINDING.to_owned(),
+                id: B::name(params),
+                body: [],
+            },
+            durable_method.to_uri(),
+        )
+    }
+
+    /// Create a new [`DurableRequest`] with a specific id.
+    pub fn new_with_id<B: DurableMethod>(
+        durable_method: B,
+        obj_id_from: ObjectIdFrom,
+    ) -> (Self, &'static str) {
+        (
+            Self {
+                binding: B::BINDING.to_owned(),
+                id: obj_id_from,
+                body: [],
+            },
+            durable_method.to_uri(),
+        )
+    }
+
+    /// Add a body to the request.
+    pub fn with_body<T: AsRef<[u8]>>(self, body: T) -> DurableRequest<T> {
+        DurableRequest {
+            binding: self.binding,
+            id: self.id,
+            body,
+        }
+    }
+}
+
+impl<'s> TryFrom<&'s Vec<u8>> for DurableRequest<&'s [u8]> {
+    type Error = capnp::Error;
+
+    fn try_from(bytes: &'s Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl<'s> TryFrom<&'s [u8]> for DurableRequest<&'s [u8]> {
+    type Error = capnp::Error;
+
+    fn try_from(bytes: &'s [u8]) -> Result<Self, Self::Error> {
+        let mut cursor = io::Cursor::new(bytes);
+        let (binding, id) = {
+            let message_reader = capnp::serialize_packed::read_message(
+                &mut cursor,
+                capnp::message::ReaderOptions::new(),
+            )?;
+
+            let request = message_reader.get_root::<durable_request::Reader>()?;
+
+            let binding = request.get_binding()?.to_string()?;
+            let id = match request.get_id().which()? {
+                durable_request::id::Which::Name(name) => ObjectIdFrom::Name(name?.to_string()?),
+                durable_request::id::Which::Hex(hex) => ObjectIdFrom::Hex(hex?.to_string()?),
+            };
+            (binding, id)
+        };
+
+        Ok(Self {
+            binding,
+            id,
+            body: &bytes[cursor.position() as usize..],
+        })
+    }
+}
+
+impl<P> DurableRequest<P>
+where
+    P: AsRef<[u8]>,
+{
+    /// Return a reference to the body.
+    pub fn body(&self) -> &[u8] {
+        self.body.as_ref()
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        let Self { binding, id, body } = self;
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut request = message.init_root::<durable_request::Builder>();
+            request.set_binding(binding.as_str().into());
+            {
+                let mut id_builder = request.init_id();
+                match id {
+                    ObjectIdFrom::Name(n) => id_builder.set_name(n.as_str().into()),
+                    ObjectIdFrom::Hex(h) => id_builder.set_hex(h.as_str().into()),
+                }
+            }
+        }
+        let mut vec = Vec::new();
+        capnp::serialize_packed::write_message(&mut vec, &message).unwrap();
+        vec.extend_from_slice(body.as_ref());
+        vec
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use daphne::{DapBatchBucket, DapVersion};
+
+    use crate::durable_requests::bindings::AggregateStore;
+
+    use super::{bindings, DurableRequest};
+
+    #[test]
+    fn roundrip_without_body() {
+        let (want, _) = DurableRequest::new(
+            AggregateStore::Merge,
+            (
+                DapVersion::Draft02,
+                "some-task-id-hex",
+                &DapBatchBucket::TimeInterval { batch_window: 0 },
+            ),
+        );
+
+        let req_bytes = want.clone().into_bytes();
+        let got = DurableRequest::try_from(&req_bytes).unwrap();
+        assert_eq!(want, got);
+    }
+
+    #[test]
+    fn roundrip_with_body() {
+        let binary_body = b"really cool body".to_vec();
+        let (want, _) = DurableRequest::new(
+            bindings::AggregateStore::Merge,
+            (
+                DapVersion::Draft02,
+                "some-task-id-hex",
+                &DapBatchBucket::TimeInterval { batch_window: 0 },
+            ),
+        );
+
+        let want = want.with_body(binary_body);
+
+        let req_bytes = want.clone().into_bytes();
+        let got = DurableRequest::try_from(&req_bytes).unwrap();
+        assert_eq!(want, got);
+    }
+}

--- a/daphne_service_utils/src/lib.rs
+++ b/daphne_service_utils/src/lib.rs
@@ -6,8 +6,18 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 pub mod auth;
+pub mod durable_requests;
 pub mod metrics;
 pub mod test_route_types;
+
+// the generated code expects this module to be defined at the root of the library.
+mod durable_request_capnp {
+    #![allow(dead_code)]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/src/durable_requests/durable_request_capnp.rs"
+    ));
+}
 
 /// Parameters used by the Leader to select a set of reports for aggregation.
 #[derive(Debug, Deserialize, Serialize)]

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -45,3 +45,6 @@ worker.workspace = true
 [dev-dependencies]
 daphne = { path = "../daphne", features = ["test-utils"] }
 paste.workspace = true
+
+[features]
+test-utils = ["daphne_service_utils/test-utils"]

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -170,11 +170,12 @@
 //! | `DAP_REPORT_SHARD_COUNT` | `u64` | no | Number of report shards per storage epoch. |
 //! | `DAP_REPORT_SHARD_KEY` | `String` | yes | Hex-encoded key used to hash a report into one of the report shards. |
 
-mod config;
+pub mod config;
 mod durable;
 mod error_reporting;
 mod roles;
 mod router;
+pub mod storage_proxy;
 mod tracing_utils;
 
 use crate::config::{DaphneWorkerIsolateState, DaphneWorkerRequestState};

--- a/daphne_worker/src/storage_proxy.rs
+++ b/daphne_worker/src/storage_proxy.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! This is a Worker that proxies requests to the storage that Workers has access to, i.e., KV and
+//! Durable Objects.
+//!
+//! Comunication with this Worker is done via HTTP.
+//!
+//! # KV
+//!
+//! The prefix of all KV request URIs is [`KV_PATH_BASE`].
+//!
+//! ## Getting a key
+//!
+//! Make a `GET` request with uri `{KV_PATH_BASE}/path/to/key`.
+//!
+//! ## Putting a key
+//!
+//! Make a `POST` request with uri `{KV_PATH_BASE}/path/to/key`. The body of the request will be
+//! stored in kv as is, without any processing.
+//!
+//! ## Putting a key if it doesn't exist
+//!
+//! Make a `PUT` request with uri `{KV_PATH_BASE}/path/to/key`. The body of the request will be
+//! stored in kv as is, without any processing, if this key is not already present in KV.
+//!
+//! ## Deleting a key
+//!
+//! Make a `DELETE` request with uri `{KV_PATH_BASE}/path/to/key`.
+//!
+//!
+//! # Durable Objects
+//!
+//! The prefix of all durable object request URIs is [`DO_PATH_BASE`].
+//!
+//! To interact with a durable object, create an instance of [`DurableRequest`], which will be the
+//! body of a `POST` request to `{DO_PATH_BASE}/{DURABLE_OBJECT_METHOD}` where
+//! `DURABLE_OBJECT_METHOD` is defined by the [`DurableMethod::to_uri`][to_uri] trait method of the
+//! binding used to create the [`DurableRequest`].
+//!
+//! ```
+//! # // hack so we don't need to depend on reqwest just for this example.
+//! # use reqwest_wasm as reqwest;
+//! use url::Url;
+//! use daphne_service_utils::durable_requests::{
+//!     DurableRequest,
+//!     bindings::{self, DurableMethod}
+//! };
+//!
+//! let (durable_request, uri) = DurableRequest::new(
+//!     bindings::AggregateStore::Merge,
+//!     // some mock data here
+//!     (
+//!         daphne::DapVersion::DraftLatest,
+//!         "some-task-id-in-hex",
+//!         &daphne::DapBatchBucket::TimeInterval { batch_window: 50 }
+//!     ),
+//! );
+//!
+//! let worker_url = Url::parse("https://example-worker.com")
+//!     .unwrap()
+//!     .join(uri)
+//!     .unwrap();
+//!
+//!
+//! let _send_future = reqwest::Client::new()
+//!     .post(worker_url)
+//!     .body(durable_request.into_bytes())
+//!     .send();
+//! ```
+//!
+//! [to_uri]: daphne_service_utils::durable_requests::bindings::DurableMethod::to_uri
+
+use daphne_service_utils::durable_requests::{
+    DurableRequest, ObjectIdFrom, DO_PATH_PREFIX, KV_PATH_PREFIX,
+};
+use url::Url;
+use worker::{js_sys::Uint8Array, Env, Request, RequestInit, Response};
+
+const KV_BINDING_DAP_CONFIG: &str = "DAP_CONFIG";
+
+/// Handle a proxy request. This is the entry point of the Worker.
+pub async fn handle_request(
+    req: Request,
+    env: Env,
+    _ctx: worker::Context,
+) -> worker::Result<Response> {
+    let path = req.path();
+    if let Some(uri) = path.strip_prefix(KV_PATH_PREFIX) {
+        handle_kv_request(req, env, uri).await
+    } else if let Some(uri) = path.strip_prefix(DO_PATH_PREFIX) {
+        handle_do_request(req, env, uri).await
+    } else {
+        #[cfg(feature = "test-utils")]
+        if let Some("") = path.strip_prefix(daphne_service_utils::durable_requests::PURGE_STORAGE) {
+            return storage_purge(env).await;
+        }
+        tracing::error!("path {path:?} was invalid");
+        Response::error("invalid base path", 400)
+    }
+}
+
+#[cfg(feature = "test-utils")]
+/// Clear all storage. Only available to tests
+async fn storage_purge(env: Env) -> worker::Result<Response> {
+    use daphne_service_utils::durable_requests::bindings::{DurableMethod, GarbageCollector};
+
+    let kv_delete = async {
+        let kv = env.kv(KV_BINDING_DAP_CONFIG)?;
+        for key in kv.list().execute().await?.keys {
+            kv.delete(&key.name).await?;
+            tracing::trace!("deleted KV item {}", key.name);
+        }
+        Ok(())
+    };
+
+    let do_delete = async {
+        let req = Request::new_with_init(
+            &format!("https://fake-host{}", GarbageCollector::DeleteAll.to_uri(),),
+            RequestInit::new().with_method(worker::Method::Post),
+        )?;
+
+        env.durable_object(GarbageCollector::BINDING)?
+            .id_from_name(GarbageCollector::NAME_STR)?
+            .get_stub()?
+            .fetch_with_request(req)
+            .await
+    };
+
+    futures::try_join!(kv_delete, do_delete)?;
+    Response::empty()
+}
+
+/// Handle a kv request.
+async fn handle_kv_request(mut req: Request, env: Env, key: &str) -> worker::Result<Response> {
+    match req.method() {
+        worker::Method::Get => {
+            let bytes = env.kv(KV_BINDING_DAP_CONFIG)?.get(key).bytes().await?;
+
+            match bytes {
+                Some(bytes) => Response::from_bytes(bytes),
+                None => Response::error("value not found", 404),
+            }
+        }
+        worker::Method::Post => {
+            env.kv(KV_BINDING_DAP_CONFIG)?
+                .put_bytes(key, &req.bytes().await?)?
+                .execute()
+                .await?;
+
+            Response::empty()
+        }
+        worker::Method::Put => {
+            let kv = env.kv(KV_BINDING_DAP_CONFIG)?;
+            if kv
+                .list()
+                .prefix(key.into())
+                .execute()
+                .await?
+                .keys
+                .into_iter()
+                .any(|k| k.name == key)
+            {
+                Response::error(String::new(), 409 /* Conflict */)
+            } else {
+                kv.put_bytes(key, &req.bytes().await?)?.execute().await?;
+
+                Response::empty()
+            }
+        }
+        worker::Method::Delete => {
+            env.kv(KV_BINDING_DAP_CONFIG)?.delete(key).await?;
+
+            Response::empty()
+        }
+        _ => Response::error(String::new(), 405 /* Method not allowed */),
+    }
+}
+
+/// Handle a durable object request
+async fn handle_do_request(mut req: Request, env: Env, uri: &str) -> worker::Result<Response> {
+    let buf = req.bytes().await.map_err(|e| {
+        tracing::error!(error = ?e, "failed to get bytes");
+        e
+    })?;
+    tracing::debug!(len = buf.len(), "deserializing do request");
+    let parsed_req = DurableRequest::try_from(&buf)
+        .map_err(|e| worker::Error::RustError(format!("invalid format: {e:?}")))?;
+
+    let binding = env.durable_object(&parsed_req.binding)?;
+    let obj = match &parsed_req.id {
+        ObjectIdFrom::Name(name) => binding.id_from_name(name)?,
+        ObjectIdFrom::Hex(hex) => binding.id_from_string(hex)?,
+    };
+
+    let mut do_req = RequestInit::new();
+    do_req.with_method(worker::Method::Post);
+    do_req.with_headers(req.headers().clone());
+    if let body @ [_a, ..] = parsed_req.body() {
+        let buffer =
+            Uint8Array::new_with_length(body.len().try_into().map_err(|_| {
+                worker::Error::RustError(format!("buffer is too long {}", body.len()))
+            })?);
+        buffer.copy_from(body);
+        do_req.with_body(Some(buffer.into()));
+    }
+    let url = Url::parse("https://fake-host/").unwrap().join(uri).unwrap();
+    let do_req = Request::new_with_init(url.as_str(), &do_req)?;
+
+    let stub = obj.get_stub()?;
+
+    stub.fetch_with_request(do_req).await
+}

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -27,7 +27,7 @@ cfg-if = "1.0.0"
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
-daphne_worker = { path = "../daphne_worker" }
+daphne_worker = { path = "../daphne_worker", features = ["test-utils"] }
 getrandom = { workspace = true, features = ["js", "std"] }
 tracing.workspace = true
 worker.workspace = true

--- a/daphne_worker_test/docker-compose.yaml
+++ b/daphne_worker_test/docker-compose.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+---
+version: "3.3"
+services:
+  leader_storage:
+    ports:
+      - 4000:4000
+    build:
+      context: ..
+      dockerfile: daphne_worker_test/docker/storage_proxy.Dockerfile
+    command:
+      - "--port=4000"
+      - "--global-random"
+  helper_storage:
+    ports:
+      - 4001:4001
+    build:
+      context: ..
+      dockerfile: daphne_worker_test/docker/storage_proxy.Dockerfile
+    command:
+      - "--port=4001"
+      - "--global-random"

--- a/daphne_worker_test/docker/runtests.Dockerfile
+++ b/daphne_worker_test/docker/runtests.Dockerfile
@@ -1,11 +1,12 @@
-FROM rust:1.73-bullseye
+FROM rust:1.73-bookworm
 
 WORKDIR /tmp/dap_test
 
 RUN apt-get update && \
     apt-get install -y \
         libssl-dev \
-        pkg-config
+        pkg-config \
+        capnproto
 
 RUN rustup component add clippy-preview
 

--- a/daphne_worker_test/docker/storage_proxy.Dockerfile
+++ b/daphne_worker_test/docker/storage_proxy.Dockerfile
@@ -1,0 +1,34 @@
+FROM rust:1.73-alpine AS builder
+WORKDIR /tmp/dap_test
+RUN apk add --update \
+    bash \
+    g++ \
+    make \
+    npm \
+    openssl-dev \
+    wasm-pack \
+    capnproto
+RUN npm install -g wrangler@2.19.0
+
+# Pre-install worker-build and Rust's wasm32 target to speed up our custom build command
+RUN cargo install --git https://github.com/cloudflare/workers-rs
+RUN rustup target add wasm32-unknown-unknown
+
+COPY Cargo.toml Cargo.lock ./
+COPY daphne_worker_test ./daphne_worker_test
+COPY daphne_worker ./daphne_worker
+COPY daphne_service_utils ./daphne_service_utils
+COPY daphne ./daphne
+RUN cargo new --lib daphne_server
+WORKDIR /tmp/dap_test/daphne_worker_test
+COPY daphne_worker_test/wrangler.storage_proxy.toml ./wrangler.toml
+RUN wrangler publish --dry-run
+
+FROM alpine:3.16 AS test
+RUN apk add --update npm bash
+RUN npm install -g miniflare@2.14.0
+COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
+COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
+EXPOSE 8080
+# `-B ""` to skip build command.
+ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", ""]

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -37,7 +37,7 @@ fn log_request(req: &Request) {
 static CAP: cap::Cap<std::alloc::System> = cap::Cap::new(std::alloc::System, 65_000_000);
 
 #[event(fetch, respond_with_errors)]
-pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Response> {
+pub async fn main(req: Request, env: Env, ctx: worker::Context) -> Result<Response> {
     // Optionally, get more helpful error messages written to the console in the case of a panic.
     utils::set_panic_hook();
 
@@ -47,10 +47,16 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
 
     log_request(&req);
 
-    let router = DaphneWorkerRouter {
-        enable_internal_test: true,
-        enable_default_response: false,
-        ..Default::default()
-    };
-    router.handle_request(req, env).await
+    if matches!(env.var("DAP_PROXY").map(|v| v.to_string()), Ok(v) if v == "true") {
+        info!("starting storage proxy");
+        daphne_worker::storage_proxy::handle_request(req, env, ctx).await
+    } else {
+        info!("starting normal worker");
+        let router = DaphneWorkerRouter {
+            enable_internal_test: true,
+            enable_default_response: false,
+            ..Default::default()
+        };
+        router.handle_request(req, env).await
+    }
 }

--- a/daphne_worker_test/wrangler.storage_proxy.toml
+++ b/daphne_worker_test/wrangler.storage_proxy.toml
@@ -1,0 +1,65 @@
+name = "daphne_storage_proxy"
+main = "build/worker/shim.mjs"
+compatibility_date = "2023-12-21"
+
+[build]
+command = "cargo install --git https://github.com/cloudflare/workers-rs && worker-build --dev"
+
+[[rules]]
+globs = ["**/*.wasm"]
+type = "CompiledWasm"
+fallthrough = false
+
+# NOTE: Variables marked as SECRET need to be provisioned securely in
+# production. In particular, they will not be passed as environment variables
+# as they are here. See
+# https://developers.cloudflare.com/workers/wrangler/commands/#secret.
+[vars]
+DAP_PROXY = "true"
+DAP_REPORT_STORAGE_MAX_FUTURE_TIME_SKEW = "300"
+DAP_DEPLOYMENT = "dev"
+DAP_HELPER_STATE_STORE_GARBAGE_COLLECT_AFTER_SECS = "10"
+DAP_COLLECTION_JOB_ID_KEY = "12da249b0e3b1a9b5936d6ff6cdd2fa09964e2e11f5450e04eef11dc5e64daf1" # SECRET
+
+[durable_objects]
+bindings = [
+    { name = "DAP_AGGREGATE_STORE", class_name = "AggregateStore" },
+    { name = "DAP_GARBAGE_COLLECTOR", class_name = "GarbageCollector" },
+    { name = "DAP_HELPER_STATE_STORE", class_name = "HelperStateStore" },
+    { name = "DAP_LEADER_AGG_JOB_QUEUE", class_name = "LeaderAggregationJobQueue" },
+    { name = "DAP_LEADER_BATCH_QUEUE", class_name = "LeaderBatchQueue" },
+    { name = "DAP_LEADER_COL_JOB_QUEUE", class_name = "LeaderCollectionJobQueue" },
+    { name = "DAP_REPORTS_PENDING", class_name = "ReportsPending" },
+]
+
+
+[[kv_namespaces]]
+binding = "DAP_CONFIG"
+# KV bindings are in a looked up in a namespace identified by a 16-byte id number.
+# This number is assigned by calling
+#
+#    wrangler kv:namespace create <NAME>
+#
+# for some unique name you specify, and it returns a unique id number to use.
+# Here we should use something like "leader" for the <NAME>.
+id = "<assign-one-for-the-leader>"
+# A "preview id" is an id used when running in "wrangler dev" mode locally, and
+# can just be made up.  We generated the number below with the following python
+# code:
+#
+#    import secrets
+#    print(secrets.token_hex(16))
+#
+preview_id = "24c4dc92d5cf4680e508fe18eb8f0281"
+
+[[migrations]]
+tag = "v1"
+new_classes = [
+    "AggregateStore",
+    "HelperStateStore",
+    "LeaderAggregationJobQueue",
+    "LeaderBatchQueue",
+    "LeaderCollectionJobQueue",
+    "GarbageCollector",
+    "ReportsPending",
+]

--- a/docker/miniflare.Dockerfile
+++ b/docker/miniflare.Dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1.73-alpine AS builder
+FROM rust:1.73-bookworm AS builder
 WORKDIR /tmp/dap_test
-RUN apk add --update \
-    bash \
+RUN apt update && \
+    apt install -y \
     clang \
     make \
     npm \
-    openssl-dev \
-    wasm-pack
+    capnproto
+
 RUN npm install -g wrangler@2.19.0
 
 # Pre-install worker-build and Rust's wasm32 target to speed up our custom build command
@@ -21,6 +21,7 @@ COPY daphne ./daphne
 RUN cargo new --lib daphne_server
 WORKDIR /tmp/dap_test/daphne_worker_test
 COPY docker/wrangler.toml ./daphne_worker_test/wrangler.toml
+RUN capnp --version
 RUN wrangler publish --dry-run
 
 FROM alpine:3.16 AS test


### PR DESCRIPTION
Instead of using global constants to encode the various bindings and methods, define a more intuitive and typesafe api for interacting with DOs.

Also add an abstraction that makes use of these types to implement the communication with the future storage proxy
