### PR TITLE
Add collection_job_id to DapRequest

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1099,8 +1099,10 @@ pub enum DapResource {
     /// The resource of a DAP request is undetermined if its identifier could not be parsed from
     /// request path.
     ///
-    /// draft02 compatibility: In draft02, the resource of a DAP request is undetermined until the
-    /// request payload is parsed. Defer detrmination of the resource until then.
+    /// draft02 compatibility: In draft02, the resource of a DAP request is usually undetermined
+    /// until the request payload is parsed, so defer determination of the resource until then. The
+    /// exception is the GET request to the collection URI. The format of this endpoint is
+    /// unspecified, but we use a version that matches the latest draft.
     #[default]
     Undefined,
 }
@@ -1173,7 +1175,7 @@ impl<S> DapRequest<S> {
     /// the version in use is not draft02. If the caller is not the Collector, or draft02 is in
     /// use, we exepct the collection job ID to be missing.
     pub fn collection_job_id(&self) -> Result<&CollectionJobId, DapAbort> {
-        if let DapResource::CollectionJob(ref collection_job_id) = self.resource {
+        if let DapResource::CollectionJob(collection_job_id) = &self.resource {
             Ok(collection_job_id)
         } else {
             Err(DapAbort::BadRequest(

--- a/daphne/src/roles/leader.rs
+++ b/daphne/src/roles/leader.rs
@@ -295,10 +295,12 @@ pub async fn handle_collect_job_req<S: Sync, A: DapLeader<S>>(
         (DapVersion::DraftLatest, DapResource::CollectionJob(ref collect_job_id)) => {
             Some(*collect_job_id)
         }
-        (DapVersion::DraftLatest, DapResource::Undefined) => {
-            return Err(DapAbort::BadRequest("undefined resource".into()).into());
+        (_, DapResource::Undefined) => {
+            return Err(DapAbort::BadRequest("missing collection ID".into()).into())
         }
-        _ => unreachable!("unhandled resource {:?}", req.resource),
+        (_, resource) => {
+            return Err(DapAbort::BadRequest(format!("unexpected resource {resource:?}")).into())
+        }
     };
 
     let collect_job_uri = aggregator

--- a/daphne_server/src/router/mod.rs
+++ b/daphne_server/src/router/mod.rs
@@ -230,7 +230,13 @@ where
         let (task_id, resource) = match version {
             DapVersion::Draft02 => {
                 let mut r = Cursor::new(payload.as_ref());
-                (TaskId::decode(&mut r).ok(), DapResource::Undefined)
+                let task_id = TaskId::decode(&mut r).ok();
+
+                // If the collection job ID was found in the request path, then this must be a
+                // request for a collection job result from the Collector.
+                let resource =
+                    collect_job_id.map_or(DapResource::Undefined, DapResource::CollectionJob);
+                (task_id, resource)
             }
             DapVersion::DraftLatest => {
                 let resource = match media_type {


### PR DESCRIPTION
This is needed in order for the `DapRequestExtractor` to provide a way for draft02 requests to access the collection_job_id, this is because [this route](https://github.com/cloudflare/daphne/blob/890f8a0170cd24c10f90f829cfd4b2a0b9d1f8de/daphne_worker/src/router/leader.rs#L83-L90) manually parses the collection job id for draft 02.

By adding this field we can make remove some duplicate code in the server implementation.