### PR TITLE
Split DaphneWorkerConfig into DaphneWorkerConfig and DaphneWorkerDoConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "daphne",
+ "hex",
  "http 1.0.0",
  "prometheus",
  "ring",

--- a/daphne_server/examples/configuration.toml
+++ b/daphne_server/examples/configuration.toml
@@ -1,9 +1,28 @@
+storage = "http://localhost:4000"
 port = 3000
-#role = "helper"
 
-[global]
+[service]
+env = "oxy"
+role = "helper"
 max_batch_duration = 360000
 min_batch_interval_start = 259200
 max_batch_interval_end = 259200
 supported_hpke_kems = ["x25519_hkdf_sha256"]
+report_shard_key = "2e0a99e5a047510243e08289811db0386c620644ae53bafdd50604678f3ec537" # SECRET
+report_shard_count = 4
+default_version = "v09"
+report_storage_epoch_duration = 300000
+base_url = "http://127.0.0.1:8787"
 allow_taskprov = true
+
+[service.taskprov]
+vdaf_verify_key_init = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
+leader_auth.bearer_token = "I am the leader!" # SECRET
+collector_auth.bearer_token = "I am the collector!" # SECRET
+
+[service.taskprov.hpke_collector_config]
+id = 23
+kem_id = "p256_hkdf_sha256"
+kdf_id = "hkdf_sha256"
+aead_id = "aes128_gcm"
+public_key = "047dab625e0d269abcc28c611bebf5a60987ddf7e23df0e0aa343e5774ad81a1d0160d9252b82b4b5c52354205f5ec945645cb79facff8d85c9c31b490cdf35466"

--- a/daphne_server/src/roles/aggregator.rs
+++ b/daphne_server/src/roles/aggregator.rs
@@ -72,7 +72,7 @@ impl<S: Sync> DapAggregator<S> for crate::App {
     }
 
     fn get_global_config(&self) -> &DapGlobalConfig {
-        &self.global_config
+        &self.service_config.global
     }
 
     fn taskprov_vdaf_verify_key_init(&self) -> Option<&[u8; 32]> {

--- a/daphne_service_utils/Cargo.toml
+++ b/daphne_service_utils/Cargo.toml
@@ -18,6 +18,7 @@ readme = "../README.md"
 [dependencies]
 capnp.workspace = true
 daphne = { path = "../daphne", default-features = false }
+hex.workspace = true
 http.workspace = true
 prometheus.workspace = true
 ring.workspace = true

--- a/daphne_service_utils/src/auth.rs
+++ b/daphne_service_utils/src/auth.rs
@@ -90,7 +90,7 @@ impl AsRef<BearerToken> for DaphneAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(try_from = "SerializedDaphneWorkerAuthMethod")]
 pub struct DaphneWorkerAuthMethod {
     /// Expected bearer token.

--- a/daphne_service_utils/src/config.rs
+++ b/daphne_service_utils/src/config.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use daphne::{
+    hpke::{HpkeConfig, HpkeReceiverConfig},
+    DapGlobalConfig, DapVersion,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{auth::DaphneWorkerAuthMethod, DapRole};
+
+/// draft-wang-ppm-dap-taskprov: Long-lived parameters for the taskprov extension.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TaskprovConfig {
+    /// HPKE collector configuration for all taskprov tasks.
+    pub hpke_collector_config: HpkeConfig,
+
+    /// VDAF verify key init secret, used to generate the VDAF verification key for a taskprov task.
+    #[serde(with = "hex")]
+    pub vdaf_verify_key_init: [u8; 32],
+
+    /// Leader, Helper: Method for authorizing Leader requests.
+    pub leader_auth: DaphneWorkerAuthMethod,
+
+    /// Leader: Method for authorizing Collector requests.
+    pub collector_auth: Option<DaphneWorkerAuthMethod>,
+}
+
+pub type HpkeRecieverConfigList = Vec<HpkeReceiverConfig>;
+
+/// Daphne service configuration, including long-lived parameters used across DAP tasks.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DaphneServiceConfig {
+    pub env: String,
+
+    /// Indicates if DaphneWorker is used as the Leader.
+    pub role: DapRole,
+
+    /// Global DAP configuration.
+    #[serde(flatten)]
+    pub global: DapGlobalConfig,
+
+    /// Sharding key, used to compute the ReportsPending or ReportsProcessed shard to map a report
+    /// to (based on the report ID).
+    #[serde(with = "hex")]
+    pub report_shard_key: [u8; 32],
+
+    /// Shard count, the number of report storage shards. This should be a power of 2.
+    pub report_shard_count: u64,
+
+    /// draft-dcook-ppm-dap-interop-test-design: Base URL of the Aggregator (unversioned). If set,
+    /// this field is used for endpoint configuration for interop testing.
+    pub base_url: Option<Url>,
+
+    /// draft-wang-ppm-dap-taskprov: Long-lived parameters for the taskprov extension. If not set,
+    /// then taskprov will be disabled.
+    pub taskprov: Option<TaskprovConfig>,
+
+    /// Default DAP version to use if not specified by the API URL
+    pub default_version: DapVersion,
+
+    /// The report storage epoch duration. This value is used to control the period of time for
+    /// which an Aggregator guarantees storage of reports and/or report metadata.
+    ///
+    /// A report will be accepted if its timestamp is no more than the specified number of seconds
+    /// before the current time.
+    pub report_storage_epoch_duration: daphne::messages::Duration,
+}
+
+/// Deployment types for Daphne-Worker. This defines overrides used to control inter-Aggregator
+/// communication.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum DaphneWorkerDeployment {
+    /// Daphne-Worker is running in a production environment. No behavior overrides are applied.
+    #[default]
+    Prod,
+    /// Daphne-Worker is running in a development environment. Any durable objects that are created
+    /// will be registered by the garbage collector so that they can be deleted manually using the
+    /// internal test API.
+    Dev,
+}

--- a/daphne_service_utils/src/lib.rs
+++ b/daphne_service_utils/src/lib.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 pub mod auth;
+pub mod config;
 pub mod durable_requests;
 pub mod metrics;
 pub mod test_route_types;
@@ -29,7 +30,7 @@ pub struct DaphneServiceReportSelector {
     pub max_reports: u64,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DapRole {
     Leader,

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashSet, mem::size_of, ops::ControlFlow};
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{create_span_from_request, state_get_or_default},
     initialize_tracing, int_err,
 };
@@ -13,8 +13,11 @@ use daphne::{
     vdaf::VdafAggregateShare,
     DapAggregateShare,
 };
-use daphne_service_utils::durable_requests::bindings::{
-    self, AggregateStoreMergeReq, AggregateStoreMergeResp, DurableMethod,
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{
+        self, AggregateStoreMergeReq, AggregateStoreMergeResp, DurableMethod,
+    },
 };
 use prio::{
     codec::{Decode, Encode},
@@ -54,7 +57,7 @@ pub struct AggregateStore {
     #[allow(dead_code)]
     state: State,
     env: Env,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     touched: bool,
     collected: Option<bool>,
 }
@@ -267,7 +270,7 @@ impl DurableObject for AggregateStore {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
@@ -411,7 +414,7 @@ impl DapDurableObject for AggregateStore {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/durable/helper_state_store.rs
+++ b/daphne_worker/src/durable/helper_state_store.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{create_span_from_request, state_get, state_set_if_not_exists},
     initialize_tracing, int_err,
 };
-use daphne_service_utils::durable_requests::bindings::{self, DurableMethod};
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{self, DurableMethod},
+};
 use tracing::{trace, Instrument};
 use worker::{
     async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
@@ -27,7 +30,7 @@ use super::{req_parse, Alarmed, DapDurableObject};
 #[durable_object]
 pub struct HelperStateStore {
     state: State,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     alarmed: bool,
 }
 
@@ -36,7 +39,7 @@ impl DurableObject for HelperStateStore {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             config,
@@ -112,7 +115,7 @@ impl DapDurableObject for HelperStateStore {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -4,11 +4,14 @@
 use std::ops::ControlFlow;
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{create_span_from_request, req_parse, DurableOrdered},
     initialize_tracing, int_err,
 };
-use daphne_service_utils::durable_requests::bindings::{self, DurableMethod};
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{self, DurableMethod},
+};
 use tracing::{debug, Instrument};
 use worker::{
     async_trait, durable_object, js_sys, wasm_bindgen, wasm_bindgen_futures, worker_sys, Env,
@@ -41,7 +44,7 @@ pub struct LeaderAggregationJobQueue {
     #[allow(dead_code)]
     state: State,
     env: Env,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     touched: bool,
 }
 
@@ -50,7 +53,7 @@ impl DurableObject for LeaderAggregationJobQueue {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
@@ -133,7 +136,7 @@ impl DapDurableObject for LeaderAggregationJobQueue {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -4,13 +4,14 @@
 use std::ops::ControlFlow;
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{create_span_from_request, state_get, DurableOrdered},
     initialize_tracing, int_err,
 };
 use daphne::messages::BatchId;
-use daphne_service_utils::durable_requests::bindings::{
-    self, BatchCount, DurableMethod, LeaderBatchQueueResult,
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{self, BatchCount, DurableMethod, LeaderBatchQueueResult},
 };
 use rand::prelude::*;
 use tracing::{debug, Instrument};
@@ -47,7 +48,7 @@ pub struct LeaderBatchQueue {
     #[allow(dead_code)]
     state: State,
     env: Env,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     touched: bool,
 }
 
@@ -84,7 +85,7 @@ impl DurableObject for LeaderBatchQueue {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
@@ -205,7 +206,7 @@ impl DapDurableObject for LeaderBatchQueue {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -4,7 +4,7 @@
 use std::ops::ControlFlow;
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{create_span_from_request, state_get, state_get_or_default, DurableOrdered},
     initialize_tracing, int_err,
 };
@@ -12,7 +12,10 @@ use daphne::{
     messages::{Base64Encode, Collection, CollectionJobId, CollectionReq, TaskId},
     DapCollectJob, DapVersion,
 };
-use daphne_service_utils::durable_requests::bindings::{self, CollectQueueRequest, DurableMethod};
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{self, CollectQueueRequest, DurableMethod},
+};
 use prio::codec::ParameterizedEncode;
 use tracing::Instrument;
 use worker::{
@@ -52,7 +55,7 @@ pub struct LeaderCollectionJobQueue {
     #[allow(dead_code)]
     state: State,
     env: Env,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     touched: bool,
 }
 
@@ -61,7 +64,7 @@ impl DurableObject for LeaderCollectionJobQueue {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
@@ -254,7 +257,7 @@ impl DapDurableObject for LeaderCollectionJobQueue {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{
-    config::DaphneWorkerConfig,
+    config::DaphneWorkerDurableConfig,
     durable::{
         create_span_from_request, req_parse, state_get, state_set_if_not_exists, DurableConnector,
         DurableOrdered, MAX_KEYS,
     },
     initialize_tracing, int_err,
 };
-use daphne_service_utils::durable_requests::bindings::{
-    self, DurableMethod, LeaderAggJobQueue, PendingReport, ReportsPendingResult,
+use daphne_service_utils::{
+    config::DaphneWorkerDeployment,
+    durable_requests::bindings::{
+        self, DurableMethod, LeaderAggJobQueue, PendingReport, ReportsPendingResult,
+    },
 };
 use std::{cmp::min, ops::ControlFlow};
 use tracing::{debug, Instrument};
@@ -49,7 +52,7 @@ pub struct ReportsPending {
     #[allow(dead_code)]
     state: State,
     env: Env,
-    config: DaphneWorkerConfig,
+    config: DaphneWorkerDurableConfig,
     touched: bool,
 }
 
@@ -58,7 +61,7 @@ impl DurableObject for ReportsPending {
     fn new(state: State, env: Env) -> Self {
         initialize_tracing(&env);
         let config =
-            DaphneWorkerConfig::from_worker_env(&env).expect("failed to load configuration");
+            DaphneWorkerDurableConfig::from_worker_env(&env).expect("failed to load configuration");
         Self {
             state,
             env,
@@ -214,7 +217,7 @@ impl DapDurableObject for ReportsPending {
     }
 
     #[inline(always)]
-    fn deployment(&self) -> crate::config::DaphneWorkerDeployment {
+    fn deployment(&self) -> DaphneWorkerDeployment {
         self.config.deployment
     }
 }

--- a/daphne_worker/src/roles/aggregator.rs
+++ b/daphne_worker/src/roles/aggregator.rs
@@ -190,7 +190,7 @@ impl<'srv> DapAggregator<DaphneAuth> for DaphneWorker<'srv> {
             .as_ref()
             .ok_or_else(|| fatal_error!(err = "taskprov configuration not found"))?;
 
-        if !self.config().is_leader && req.taskprov.is_some() {
+        if !self.config().role.is_leader() && req.taskprov.is_some() {
             // Store the task config in Worker memory, but don't write it through to KV.
             let mut guarded_tasks = self
                 .isolate_state()

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::inline_always)]
 
-use daphne_worker::{initialize_tracing, DaphneWorkerRouter};
+use daphne_worker::{config, initialize_tracing, DaphneWorkerRouter};
 use tracing::info;
 use worker::{event, Env, Request, Response, Result};
 
@@ -47,7 +47,7 @@ pub async fn main(req: Request, env: Env, ctx: worker::Context) -> Result<Respon
 
     log_request(&req);
 
-    if matches!(env.var("DAP_PROXY").map(|v| v.to_string()), Ok(v) if v == "true") {
+    if config::is_running_as_storage_proxy(&env) {
         info!("starting storage proxy");
         daphne_worker::storage_proxy::handle_request(req, env, ctx).await
     } else {


### PR DESCRIPTION
To run exclusively DOs we don't need to load all the configuration values needed for a full worker. As such we split these two in order to make configuring the storage proxy worker simpler.