### PR TITLE
Downgrade Axum to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,19 +172,18 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.7.2"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "http-body-util",
- "hyper 1.1.0",
- "hyper-util",
+ "http",
+ "http-body",
+ "hyper",
  "itoa",
  "matchit 0.7.3",
  "memchr",
@@ -205,20 +204,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "http-body-util",
+ "http",
+ "http-body",
  "mime",
- "pin-project-lite",
  "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -696,6 +692,8 @@ dependencies = [
  "daphne_service_utils",
  "futures",
  "hex",
+ "http",
+ "hyper",
  "prio",
  "prometheus",
  "rand",
@@ -719,7 +717,7 @@ dependencies = [
  "capnpc",
  "daphne",
  "hex",
- "http 1.0.0",
+ "http",
  "prometheus",
  "ring",
  "serde",
@@ -1062,26 +1060,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 1.0.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1195,47 +1174,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http 1.0.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
-dependencies = [
- "bytes",
- "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1261,9 +1206,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
- "http 0.2.11",
- "http-body 0.4.6",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1276,33 +1221,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.0",
- "http 1.0.0",
- "http-body 1.0.0",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
- "hyper 0.14.28",
+ "http",
+ "hyper",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1315,30 +1241,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "hyper 1.1.0",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2095,10 +2001,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -2139,10 +2045,10 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3189,7 +3095,7 @@ dependencies = [
  "chrono-tz",
  "futures-channel",
  "futures-util",
- "http 0.2.11",
+ "http",
  "js-sys",
  "matchit 0.4.6",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.2.0"
 hpke-rs-crypto = "0.2.0"
 hpke-rs-rust-crypto = "0.2.0"
-http = "1.0.0"
+http = "0.2"
 matchit = "0.7.3"
 paste = "1.0.14"
 prio = { git = "https://github.com/divviup/libprio-rs", rev = "d0168336bbad1805231a69181b329e37ee962203" }

--- a/daphne_server/Cargo.toml
+++ b/daphne_server/Cargo.toml
@@ -17,7 +17,9 @@ repository = "https://github.com/cloudflare/daphne"
 readme = "../README.md"
 
 [dependencies]
-axum = "0.7"
+axum = "0.6"
+http.workspace = true
+hyper = "0.14.27"
 bincode.workspace = true
 daphne = { path = "../daphne", features = ["send-traits"] }
 daphne_service_utils = { path = "../daphne_service_utils" }

--- a/daphne_server/examples/service.rs
+++ b/daphne_server/examples/service.rs
@@ -105,12 +105,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
         .init();
 
     // hand the router to axum for it to run
-    axum::serve(
-        tokio::net::TcpListener::bind(("0.0.0.0", config.port))
-            .await
-            .unwrap(),
-        router,
-    )
+    axum::Server::bind(&std::net::SocketAddr::new(
+        "0.0.0.0".parse().unwrap(),
+        config.port,
+    ))
+    .serve(router.into_make_service())
     .await?;
 
     Ok(())

--- a/daphne_server/src/lib.rs
+++ b/daphne_server/src/lib.rs
@@ -80,6 +80,8 @@ mod storage_proxy_connection;
 ///
 /// let router = router::new(DapRole::Helper, app);
 ///
+/// # // this is so I don't have to annotate the types of `router::new`
+/// # let router: axum::Router<(), axum::body::Body> = router;
 /// # Ok::<(), daphne::DapError>(())
 /// ```
 pub struct App {

--- a/daphne_server/src/router/helper.rs
+++ b/daphne_server/src/router/helper.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use axum::{extract::State, routing::post};
+use axum::{body::HttpBody, extract::State, routing::post};
 use daphne::{
     constants::DapMediaType,
     error::DapAbort,
@@ -13,11 +13,14 @@ use daphne_service_utils::auth::DaphneAuth;
 
 use super::{AxumDapResponse, DapRequestExtractor, DaphneService};
 
-pub(super) fn add_helper_routes<A: DapHelper<DaphneAuth>>(
-    router: super::Router<A>,
-) -> super::Router<A>
+pub(super) fn add_helper_routes<A: DapHelper<DaphneAuth>, B>(
+    router: super::Router<A, B>,
+) -> super::Router<A, B>
 where
     A: DapHelper<DaphneAuth> + DaphneService + Send + Sync + 'static,
+    B: Send + HttpBody + 'static,
+    B::Data: Send,
+    B::Error: Send + Sync,
 {
     router
         .route("/:version/aggregate", post(agg_job))

--- a/daphne_server/src/router/test_routes.rs
+++ b/daphne_server/src/router/test_routes.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use axum::{
+    body::HttpBody,
     extract::{Path, State},
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -27,7 +28,12 @@ use crate::App;
 
 use super::{AxumDapResponse, DaphneService};
 
-pub fn add_test_routes(router: super::Router<App>, role: DapRole) -> super::Router<App> {
+pub fn add_test_routes<B>(router: super::Router<App, B>, role: DapRole) -> super::Router<App, B>
+where
+    B: Send + HttpBody + 'static,
+    B::Data: Send,
+    B::Error: Send + Sync + Into<Box<dyn std::error::Error + Send + Sync>>,
+{
     let router = if role == DapRole::Leader {
         router
             .route("/internal/process", post(leader_process))

--- a/daphne_server/src/storage_proxy_connection/mod.rs
+++ b/daphne_server/src/storage_proxy_connection/mod.rs
@@ -24,8 +24,8 @@ pub(crate) enum Error {
     Serde(#[from] serde_json::Error),
     #[error("network error: {0}")]
     Reqwest(#[from] reqwest::Error),
-    #[error("http error. request returned status code was {status} with the body {body}")]
-    HttpError { status: StatusCode, body: String },
+    #[error("http error. request returned status code {status} with the body {body}")]
+    Http { status: StatusCode, body: String },
 }
 
 pub(crate) struct Do<'h> {
@@ -83,7 +83,7 @@ impl<'d, B: DurableMethod + Debug, P: AsRef<[u8]>> RequestBuilder<'d, B, P> {
         if resp.status().is_success() {
             Ok(resp.json().await?)
         } else {
-            Err(Error::HttpError {
+            Err(Error::Http {
                 status: status_reqwest_0_11_to_http_1_0(resp.status()),
                 body: resp.text().await?,
             })


### PR DESCRIPTION
Because the ecosystem has yet not caught up with [http 1.0.0](https://docs.rs/http/1.0.0/) we should keep using axum 0.6 (which uses [http 0.2](https://docs.rs/http/0.2.11/)) for now.

