### PR TITLE
Re-export ErrorReporting

### DIFF
--- a/daphne_worker/src/dap_prototype/mod.rs
+++ b/daphne_worker/src/dap_prototype/mod.rs
@@ -11,6 +11,7 @@ mod router;
 use super::initialize_tracing;
 use config::{DaphneWorkerIsolateState, DaphneWorkerRequestState};
 use daphne::audit_log::{AuditLog, NoopAuditLog};
+pub use error_reporting::ErrorReporter;
 use once_cell::sync::OnceCell;
 use std::str;
 use tracing::debug;


### PR DESCRIPTION
This was a breaking change made in #478 that needs to be reverted.
