### PR TITLE
daphne_server: Plumb registered metrics through `App::new()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ wasm-pack.log
 build/
 dist
 .wrangler
+.idea
+.secrets
+.vscode
+.rusty-hook.toml

--- a/daphne/src/metrics.rs
+++ b/daphne/src/metrics.rs
@@ -9,6 +9,7 @@ use prometheus::{
     register_int_counter_with_registry, Histogram, IntCounter, IntCounterVec, Registry,
 };
 
+#[derive(Clone)]
 pub struct DaphneMetrics {
     /// Inbound request metrics: Successful requests served, broken down by type.
     inbound_request_counter: IntCounterVec,

--- a/daphne_server/examples/service.rs
+++ b/daphne_server/examples/service.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use daphne_server::{router, App};
-use daphne_service_utils::{config::DaphneServiceConfig, DapRole};
+use daphne_service_utils::{config::DaphneServiceConfig, metrics::DaphneServiceMetrics, DapRole};
 use serde::Deserialize;
 use tracing_subscriber::EnvFilter;
 use url::Url;
@@ -91,10 +91,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
 
     // Create a new prometheus registry where metrics will be registered and measured
     let registry = prometheus::Registry::new();
+    let daphne_service_metrics = DaphneServiceMetrics::register(&registry)?;
 
     let role = config.service.role;
     // Configure the application
-    let app = App::new(config.storage_proxy, &registry, config.service)?;
+    let app = App::new(config.storage_proxy, daphne_service_metrics, config.service)?;
 
     // create the router that will handle the protocol's http requests
     let router = router::new(role, app);

--- a/daphne_service_utils/src/metrics.rs
+++ b/daphne_service_utils/src/metrics.rs
@@ -6,6 +6,7 @@
 use daphne::{fatal_error, metrics::DaphneMetrics, DapError};
 use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
 
+#[derive(Clone)]
 pub struct DaphneServiceMetrics {
     /// Daphne metrics.
     pub daphne: DaphneMetrics,


### PR DESCRIPTION
In the downstream repo, the Oxy app will have two routers, both of which try to register to the default prometheus registry. This causes a runtime bug. To fix this, register the metrics once, then clone the structure into each router.

While at it, align .gitignore with the downstream repo.