### PR TITLE
Correctly extract the kv key out of the uri

### DIFF
--- a/daphne_worker/src/storage_proxy.rs
+++ b/daphne_worker/src/storage_proxy.rs
@@ -126,7 +126,10 @@ pub async fn handle_request(
     }
 
     let path = req.path();
-    if let Some(uri) = path.strip_prefix(KV_PATH_PREFIX) {
+    if let Some(uri) = path
+        .strip_prefix(KV_PATH_PREFIX)
+        .and_then(|s| s.strip_prefix('/'))
+    {
         handle_kv_request(req, env, uri).await
     } else if let Some(uri) = path.strip_prefix(DO_PATH_PREFIX) {
         handle_do_request(req, env, uri).await


### PR DESCRIPTION
The uri will look like `/v1/kv/path/to/key`, the previous code extracted
`/path/to/key` instead of `path/to/key` which is what the calling
service would expect
