### PR TITLE
Fix a bug in `VdafVerifyKey` decoding

### DIFF
--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -170,7 +170,7 @@ mod test {
         },
         test_versions,
         testing::{AggStore, MockAggregator, MockAggregatorReportSelector},
-        vdaf::{Prio3Config, VdafConfig, VdafVerifyKey},
+        vdaf::{Prio3Config, VdafConfig},
         DapAbort, DapAggregateShare, DapAggregationJobState, DapBatchBucket, DapCollectJob,
         DapError, DapGlobalConfig, DapLeaderAggregationJobTransition, DapMeasurement,
         DapQueryConfig, DapRequest, DapResource, DapTaskConfig, DapTaskParameters, DapVersion,
@@ -291,7 +291,7 @@ mod test {
                     min_batch_size: 1,
                     query: DapQueryConfig::TimeInterval,
                     vdaf: vdaf_config,
-                    vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                    vdaf_verify_key: vdaf_config.gen_verify_key(),
                     method: Default::default(),
                 },
             );
@@ -309,7 +309,7 @@ mod test {
                         max_batch_size: Some(2),
                     },
                     vdaf: vdaf_config,
-                    vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                    vdaf_verify_key: vdaf_config.gen_verify_key(),
                     method: Default::default(),
                 },
             );
@@ -325,7 +325,7 @@ mod test {
                     min_batch_size: 1,
                     query: DapQueryConfig::TimeInterval,
                     vdaf: vdaf_config,
-                    vdaf_verify_key: VdafVerifyKey::Prio3(rng.gen()),
+                    vdaf_verify_key: vdaf_config.gen_verify_key(),
                     method: Default::default(),
                 },
             );
@@ -391,10 +391,7 @@ mod test {
                     expiration: self.now + Self::TASK_TIME_PRECISION,
                     min_batch_size: 1,
                     query: DapQueryConfig::TimeInterval,
-                    vdaf_verify_key: match vdaf {
-                        VdafConfig::Prio2 { .. } => VdafVerifyKey::Prio2(rng.gen()),
-                        VdafConfig::Prio3(_) => VdafVerifyKey::Prio3(rng.gen()),
-                    },
+                    vdaf_verify_key: vdaf.gen_verify_key(),
                     vdaf,
                     method: Default::default(),
                 },

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -506,8 +506,8 @@ mod test {
             204, 49, 124, 7, 97, 221, 4, 232, 53, 194, 171, 19, 51,
         ];
         match &vk {
-            VdafVerifyKey::Prio2(bytes) => assert_eq!(*bytes, expected),
-            _ => unreachable!(),
+            VdafVerifyKey::L32(bytes) => assert_eq!(*bytes, expected),
+            VdafVerifyKey::L16(..) => unreachable!(),
         }
     }
 

--- a/daphne/src/vdaf/prio2.rs
+++ b/daphne/src/vdaf/prio2.rs
@@ -48,7 +48,7 @@ pub(crate) fn prio2_prep_init(
     public_share_data: &[u8],
     input_share_data: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
-    let VdafVerifyKey::Prio2(verify_key) = verify_key else {
+    let VdafVerifyKey::L32(verify_key) = verify_key else {
         panic!("unhandled verify key type");
     };
 

--- a/daphne/src/vdaf/prio3.rs
+++ b/daphne/src/vdaf/prio3.rs
@@ -147,7 +147,7 @@ pub(crate) fn prio3_prep_init(
     input_share_data: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
     return match (&config, verify_key) {
-        (Prio3Config::Count, VdafVerifyKey::Prio3(verify_key)) => {
+        (Prio3Config::Count, VdafVerifyKey::L16(verify_key)) => {
             let vdaf = Prio3::new_count(2)?;
             let (state, share) = prep_init(
                 vdaf,
@@ -167,7 +167,7 @@ pub(crate) fn prio3_prep_init(
                 length,
                 chunk_length,
             },
-            VdafVerifyKey::Prio3(verify_key),
+            VdafVerifyKey::L16(verify_key),
         ) => {
             let vdaf = Prio3::new_histogram(2, *length, *chunk_length)?;
             let (state, share) = prep_init(
@@ -183,7 +183,7 @@ pub(crate) fn prio3_prep_init(
                 VdafPrepMessage::Prio3ShareField128(share),
             ))
         }
-        (Prio3Config::Sum { bits }, VdafVerifyKey::Prio3(verify_key)) => {
+        (Prio3Config::Sum { bits }, VdafVerifyKey::L16(verify_key)) => {
             let vdaf = Prio3::new_sum(2, *bits)?;
             let (state, share) = prep_init(
                 vdaf,
@@ -204,7 +204,7 @@ pub(crate) fn prio3_prep_init(
                 length,
                 chunk_length,
             },
-            VdafVerifyKey::Prio3(verify_key),
+            VdafVerifyKey::L16(verify_key),
         ) => {
             let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)?;
             let (state, share) = prep_init(
@@ -227,7 +227,7 @@ pub(crate) fn prio3_prep_init(
                 chunk_length,
                 num_proofs,
             },
-            VdafVerifyKey::Prio3HmacSha256Aes128(verify_key),
+            VdafVerifyKey::L32(verify_key),
         ) => {
             let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
                 *bits,


### PR DESCRIPTION
Based on #498 (merge that first).

`VdafConfig::get_decoded_verify_key()` has a bug that causes decoding to fail for `Prio3SumVecField64MultiproofHmacSha256Aes128`. This was due to an incorrectly handled enum variant.

To prevent this class of bug in the future, change the variants to `L16` and `L32` for the 16-byte variant (Prio3 with the standard XOF) and the 32-byte variant (Prio2 and Prio3 with the non-standard XOF).