### PR TITLE
Add skeleton for Mastic integration

### DIFF
--- a/daphne/src/error/mod.rs
+++ b/daphne/src/error/mod.rs
@@ -65,9 +65,10 @@ impl FatalDapError {
 impl From<VdafError> for DapError {
     fn from(e: VdafError) -> Self {
         match e {
-            VdafError::Codec(..) | VdafError::Vdaf(..) | VdafError::Uncategorized(..) => {
+            VdafError::Codec(..) | VdafError::Vdaf(..) => {
                 Self::Transition(TransitionFailure::VdafPrepError)
             }
+            VdafError::Uncategorized(s) => Self::Fatal(FatalDapError(s)),
         }
     }
 }

--- a/daphne/src/error/mod.rs
+++ b/daphne/src/error/mod.rs
@@ -68,7 +68,7 @@ impl From<VdafError> for DapError {
             VdafError::Codec(..) | VdafError::Vdaf(..) => {
                 Self::Transition(TransitionFailure::VdafPrepError)
             }
-            VdafError::Uncategorized(s) => Self::Fatal(FatalDapError(s)),
+            VdafError::Dap(e) => e,
         }
     }
 }

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -83,6 +83,8 @@ use std::{
     str::FromStr,
 };
 use url::Url;
+#[cfg(any(test, feature = "test-utils"))]
+use vdaf::mastic::MasticWeight;
 
 pub use protocol::aggregator::{
     EarlyReportState, EarlyReportStateConsumed, EarlyReportStateInitialized,
@@ -773,6 +775,20 @@ pub enum DapMeasurement {
     U32Vec(Vec<u32>),
     U64Vec(Vec<u64>),
     U128Vec(Vec<u128>),
+    #[cfg(any(test, feature = "test-utils"))]
+    Mastic {
+        input: Vec<u8>,
+        weight: MasticWeight,
+    },
+}
+
+/// An aggregation parameter.
+pub enum DapAggregationParam {
+    Empty,
+    #[cfg(any(test, feature = "test-utils"))]
+    Mastic {
+        paths: Vec<Vec<u8>>,
+    },
 }
 
 /// The aggregate result computed by the Collector.

--- a/daphne/src/protocol/client.rs
+++ b/daphne/src/protocol/client.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#[cfg(any(test, feature = "test-utils"))]
+use crate::vdaf::mastic::mastic_shard;
 use crate::{
     fatal_error,
     hpke::HpkeConfig,
@@ -168,6 +170,11 @@ impl VdafConfig {
         match self {
             Self::Prio3(prio3_config) => Ok(prio3_shard(prio3_config, measurement, nonce)?),
             Self::Prio2 { dimension } => Ok(prio2_shard(*dimension, measurement, nonce)?),
+            #[cfg(any(test, feature = "test-utils"))]
+            VdafConfig::Mastic {
+                input_size,
+                weight_config,
+            } => Ok(mastic_shard(*input_size, *weight_config, measurement)?),
         }
     }
 

--- a/daphne/src/protocol/collector.rs
+++ b/daphne/src/protocol/collector.rs
@@ -8,6 +8,8 @@ use crate::{
     vdaf::{prio2::prio2_unshard, prio3::prio3_unshard},
     DapAggregateResult, DapError, DapVersion, VdafConfig,
 };
+#[cfg(any(test, feature = "test-utils"))]
+use crate::{vdaf::mastic::mastic_unshard, DapAggregationParam};
 use prio::codec::Encode;
 
 use super::{
@@ -93,6 +95,18 @@ impl VdafConfig {
             Self::Prio2 { dimension } => {
                 Ok(prio2_unshard(*dimension, num_measurements, agg_shares)?)
             }
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Mastic {
+                input_size: _,
+                weight_config,
+            } => Ok(mastic_unshard(
+                *weight_config,
+                // TODO(cjpatton) Plumb the agg param specified by the Collector.
+                &DapAggregationParam::Mastic {
+                    paths: vec![b"cool".to_vec(), b"trip".to_vec()],
+                },
+                agg_shares,
+            )?),
         }
     }
 }

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -366,6 +366,10 @@ impl TryFrom<&VdafConfig> for messages::taskprov::VdafTypeVar {
             VdafConfig::Prio3(..) => Err(fatal_error!(
                 err = format!("{vdaf_config} is not currently supported for taskprov")
             )),
+            #[cfg(any(test, feature = "test-utils"))]
+            VdafConfig::Mastic { .. } => Err(fatal_error!(
+                err = format!("{vdaf_config} is not currently supported for taskprov")
+            )),
         }
     }
 }

--- a/daphne/src/vdaf/mastic.rs
+++ b/daphne/src/vdaf/mastic.rs
@@ -1,0 +1,281 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Dummy Mastic [[draft-mouris-cfrg-mastic]], a 2-party, 1-round VDAF for (weighted) heavy hitters
+//! and attribute-based metrics. This module implements an insecure, "dummy" version of Mastic
+//! intended for testing and prototyping heavy hitters in daphne. Eventually it will be replaced by
+//! a production-quality implementation.
+//!
+//! [draft-mouris-cfrg-mastic]: https://datatracker.ietf.org/doc/draft-mouris-cfrg-mastic/
+
+use crate::{DapAggregateResult, DapAggregationParam, DapMeasurement};
+
+use super::{
+    decode_field_vec, VdafAggregateShare, VdafError, VdafPrepMessage, VdafPrepState, VdafVerifyKey,
+};
+
+use prio::{
+    codec::Decode,
+    field::{Field64, FieldElement},
+    vdaf::AggregateShare,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    deepsize::DeepSizeOf,
+)]
+/// The type of each input's weight.
+pub enum MasticWeightConfig {
+    /// Each weight is a `0` or `1`.
+    Count,
+}
+
+impl std::fmt::Display for MasticWeightConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MasticWeightConfig::Count => write!(f, "Count"),
+        }
+    }
+}
+
+/// A weight.
+#[derive(Clone, Deserialize, Serialize)]
+pub enum MasticWeight {
+    Bool(bool),
+}
+
+pub(crate) fn mastic_shard(
+    input_size: usize,
+    weight_config: MasticWeightConfig,
+    measurement: DapMeasurement,
+) -> Result<(Vec<u8>, Vec<Vec<u8>>), VdafError> {
+    match (weight_config, measurement) {
+        (
+            MasticWeightConfig::Count,
+            DapMeasurement::Mastic {
+                input,
+                weight: MasticWeight::Bool(counter),
+            },
+        ) if input.len() == input_size => {
+            // Simulate Mastic, insecurely. Set the public share to the input and each input share
+            // to the weight.
+            Ok((input, vec![vec![u8::from(counter)]; 2]))
+        }
+        _ => Err(VdafError::Uncategorized(
+            "mastic: unexpected measurement type".into(),
+        )),
+    }
+}
+
+pub(crate) fn mastic_prep_init(
+    input_size: usize,
+    weight_config: MasticWeightConfig,
+    verify_key: &VdafVerifyKey,
+    agg_param: &DapAggregationParam,
+    public_share_bytes: &[u8],
+    input_share_bytes: &[u8],
+) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
+    let VdafVerifyKey::L16(_verify_key) = verify_key else {
+        return Err(VdafError::Uncategorized(
+            "mastic: unexpected verify key type".into(),
+        ));
+    };
+
+    match (weight_config, agg_param) {
+        (MasticWeightConfig::Count, DapAggregationParam::Mastic { paths }) => {
+            // Simulate Mastic, insecurely. The public share encodes the plaintext input; the input
+            // share encodes the plaintext weight.
+            if public_share_bytes.len() != input_size {
+                return Err(VdafError::Codec(prio::codec::CodecError::Other(
+                    "mastic: malformed public share".into(),
+                )));
+            }
+
+            if input_share_bytes.len() != 1 {
+                return Err(VdafError::Codec(prio::codec::CodecError::Other(
+                    "mastic: malformed input share".into(),
+                )));
+            }
+
+            let weight = Field64::from(u64::from(input_share_bytes[0]));
+            let out_share = paths
+                .iter()
+                .map(|path| {
+                    if path.len() > input_size {
+                        return Err(VdafError::Codec(prio::codec::CodecError::Other(
+                            "mastic: malformed agg param: path with invalid length".into(),
+                        )));
+                    }
+
+                    // If the path is a prefix of the input, then the value is the
+                    // weight; otherwise the value is 0.
+                    let value = if path == &public_share_bytes[..path.len()] {
+                        weight
+                    } else {
+                        Field64::zero()
+                    };
+
+                    // Each Aggregator computes a share of the value, so divide by 2.
+                    Ok(value / Field64::from(2))
+                })
+                .collect::<Result<Vec<Field64>, _>>()?;
+
+            Ok((
+                VdafPrepState::Mastic { out_share },
+                VdafPrepMessage::MasticShare(weight),
+            ))
+        }
+        _ => Err(VdafError::Uncategorized(
+            "mastic: unexpected agg param type".into(),
+        )),
+    }
+}
+
+pub(crate) fn mastic_prep_finish_from_shares(
+    weight_config: MasticWeightConfig,
+    host_state: VdafPrepState,
+    host_share: VdafPrepMessage,
+    peer_share_bytes: &[u8],
+) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
+    match (weight_config, host_state, host_share) {
+        (
+            MasticWeightConfig::Count,
+            VdafPrepState::Mastic { out_share },
+            VdafPrepMessage::MasticShare(host_weight),
+        ) => {
+            // Simulate Mastic. Check that both Aggregators got the same weight, and the weight is
+            // valid. This is not secure because the weight is revealed to the caller.
+            let peer_weight = Field64::get_decoded(peer_share_bytes)?;
+            if peer_weight != host_weight {
+                return Err(VdafError::Vdaf(prio::vdaf::VdafError::Uncategorized(
+                    "mastic: weights do not match".into(),
+                )));
+            }
+
+            if peer_weight != Field64::one() && peer_weight != Field64::zero() {
+                return Err(VdafError::Vdaf(prio::vdaf::VdafError::Uncategorized(
+                    "mastic: weight is out of range".into(),
+                )));
+            }
+
+            Ok((
+                VdafAggregateShare::Field64(AggregateShare::from(out_share)),
+                // Empty prep message for now.
+                Vec::new(),
+            ))
+        }
+        _ => Err(VdafError::Uncategorized(
+            "mastic: unexpected prep state".into(),
+        )),
+    }
+}
+
+pub(crate) fn mastic_prep_finish(
+    host_state: VdafPrepState,
+    peer_message_bytes: &[u8],
+) -> Result<VdafAggregateShare, VdafError> {
+    match host_state {
+        VdafPrepState::Mastic { out_share } => {
+            // Simulate Mastic: If the prep message is empty, then accept the output share.
+            if !peer_message_bytes.is_empty() {
+                return Err(VdafError::Vdaf(prio::vdaf::VdafError::Uncategorized(
+                    "mastic: invalid prep message".into(),
+                )));
+            }
+
+            Ok(VdafAggregateShare::Field64(AggregateShare::from(out_share)))
+        }
+        _ => Err(VdafError::Uncategorized(
+            "mastic: unexpected prep state".into(),
+        )),
+    }
+}
+
+pub(crate) fn mastic_unshard<M: IntoIterator<Item = Vec<u8>>>(
+    weight_config: MasticWeightConfig,
+    agg_param: &DapAggregationParam,
+    agg_share_bytes: M,
+) -> Result<DapAggregateResult, VdafError> {
+    match (weight_config, agg_param) {
+        (MasticWeightConfig::Count, DapAggregationParam::Mastic { paths }) => {
+            let agg: Vec<Field64> = agg_share_bytes
+                .into_iter()
+                .map(|bytes| decode_field_vec(&bytes, paths.len()))
+                .reduce(|r, agg_share| {
+                    let mut agg = r?;
+                    for (x, y) in agg.iter_mut().zip(agg_share?.into_iter()) {
+                        *x += y;
+                    }
+                    Ok(agg)
+                })
+                .ok_or_else(|| {
+                    VdafError::Uncategorized("mastic: unexpected number of agg shares".into())
+                })??;
+
+            Ok(DapAggregateResult::U64Vec(
+                agg.into_iter().map(u64::from).collect(),
+            ))
+        }
+        _ => Err(VdafError::Uncategorized(
+            "mastic: unexpected agg param type".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        hpke::HpkeKemId, testing::AggregationJobTest, vdaf::VdafConfig, DapAggregateResult,
+        DapMeasurement, DapVersion,
+    };
+
+    #[tokio::test]
+    async fn roundtrip_count() {
+        let mut t = AggregationJobTest::new(
+            &VdafConfig::Mastic {
+                input_size: 4,
+                weight_config: MasticWeightConfig::Count,
+            },
+            HpkeKemId::X25519HkdfSha256,
+            DapVersion::DraftLatest,
+        );
+        let got = t
+            .roundtrip(vec![
+                DapMeasurement::Mastic {
+                    input: b"cool".to_vec(),
+                    weight: MasticWeight::Bool(false),
+                },
+                DapMeasurement::Mastic {
+                    input: b"cool".to_vec(),
+                    weight: MasticWeight::Bool(true),
+                },
+                DapMeasurement::Mastic {
+                    input: b"trip".to_vec(),
+                    weight: MasticWeight::Bool(true),
+                },
+                DapMeasurement::Mastic {
+                    input: b"trip".to_vec(),
+                    weight: MasticWeight::Bool(true),
+                },
+                DapMeasurement::Mastic {
+                    input: b"cool".to_vec(),
+                    weight: MasticWeight::Bool(false),
+                },
+            ])
+            .await;
+
+        // For the moment, we hard-code `b"cool"` and `b"trip"` as the prefixes of interest.
+        assert_eq!(got, DapAggregateResult::U64Vec(vec![1, 2]));
+    }
+}

--- a/daphne/src/vdaf/mastic.rs
+++ b/daphne/src/vdaf/mastic.rs
@@ -8,7 +8,7 @@
 //!
 //! [draft-mouris-cfrg-mastic]: https://datatracker.ietf.org/doc/draft-mouris-cfrg-mastic/
 
-use crate::{DapAggregateResult, DapAggregationParam, DapMeasurement};
+use crate::{fatal_error, DapAggregateResult, DapAggregationParam, DapMeasurement};
 
 use super::{
     decode_field_vec, VdafAggregateShare, VdafError, VdafPrepMessage, VdafPrepState, VdafVerifyKey,
@@ -71,9 +71,9 @@ pub(crate) fn mastic_shard(
             // to the weight.
             Ok((input, vec![vec![u8::from(counter)]; 2]))
         }
-        _ => Err(VdafError::Uncategorized(
-            "mastic: unexpected measurement type".into(),
-        )),
+        _ => Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected measurement type"
+        ))),
     }
 }
 
@@ -86,9 +86,9 @@ pub(crate) fn mastic_prep_init(
     input_share_bytes: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
     let VdafVerifyKey::L16(_verify_key) = verify_key else {
-        return Err(VdafError::Uncategorized(
-            "mastic: unexpected verify key type".into(),
-        ));
+        return Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected verify key type"
+        )));
     };
 
     match (weight_config, agg_param) {
@@ -135,9 +135,9 @@ pub(crate) fn mastic_prep_init(
                 VdafPrepMessage::MasticShare(weight),
             ))
         }
-        _ => Err(VdafError::Uncategorized(
-            "mastic: unexpected agg param type".into(),
-        )),
+        _ => Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected agg param type"
+        ))),
     }
 }
 
@@ -174,9 +174,9 @@ pub(crate) fn mastic_prep_finish_from_shares(
                 Vec::new(),
             ))
         }
-        _ => Err(VdafError::Uncategorized(
-            "mastic: unexpected prep state".into(),
-        )),
+        _ => Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected prep state"
+        ))),
     }
 }
 
@@ -195,9 +195,9 @@ pub(crate) fn mastic_prep_finish(
 
             Ok(VdafAggregateShare::Field64(AggregateShare::from(out_share)))
         }
-        _ => Err(VdafError::Uncategorized(
-            "mastic: unexpected prep state".into(),
-        )),
+        _ => Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected prep state"
+        ))),
     }
 }
 
@@ -219,16 +219,18 @@ pub(crate) fn mastic_unshard<M: IntoIterator<Item = Vec<u8>>>(
                     Ok(agg)
                 })
                 .ok_or_else(|| {
-                    VdafError::Uncategorized("mastic: unexpected number of agg shares".into())
+                    VdafError::Dap(fatal_error!(
+                        err = "mastic: unexpected number of agg shares"
+                    ))
                 })??;
 
             Ok(DapAggregateResult::U64Vec(
                 agg.into_iter().map(u64::from).collect(),
             ))
         }
-        _ => Err(VdafError::Uncategorized(
-            "mastic: unexpected agg param type".into(),
-        )),
+        _ => Err(VdafError::Dap(fatal_error!(
+            err = "mastic: unexpected agg param type"
+        ))),
     }
 }
 

--- a/daphne/src/vdaf/mod.rs
+++ b/daphne/src/vdaf/mod.rs
@@ -40,7 +40,7 @@ pub(crate) enum VdafError {
     #[error("{0}")]
     Vdaf(#[from] prio::vdaf::VdafError),
     #[error("{0}")]
-    Uncategorized(String),
+    Dap(DapError),
 }
 
 /// Specification of a concrete VDAF.


### PR DESCRIPTION
Based on #499 (merge that first).

Add a new `VdafConfig` variant for the Mastic VDAF: https://datatracker.ietf.org/doc/draft-mouris-cfrg-mastic/

We don't yet have a production-ready implementation of Mastic, so implement a "dummy" (i.e., insecure) version that is only enabled for tests and with feature "test-utils".

Mastic will be the first VDAF in Daphne that makes use of DAP's "aggregation parameter". The aggregation parameter is used to refine the input shares in a way required by the application. In case of Mastic, the aggregation parameter defines the "candidate prefixes" in the case of (weighted) heavy hitters or the "attributes" in case of attribute-based metrics.

Because neither Prio2 nor Prio3 uses this feature, Daphne does not plumb the aggregation parameter through the code the way we need to for Mastic. This will require some refactoring. In the meantime, we stub this code out in a way that let's us to test the `VdafConfig` variant end-to-end.