### PR TITLE
Move lints to Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,22 +744,18 @@ name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
  "assert_matches",
- "async-trait",
  "cap",
  "cfg-if",
  "console_error_panic_hook",
  "daphne",
  "daphne_service_utils",
  "daphne_worker",
- "getrandom",
  "hex",
  "hpke-rs",
  "paste",
  "prio",
- "prometheus",
  "rand",
  "reqwest",
- "ring",
  "serde",
  "serde_json",
  "tokio",
@@ -805,7 +801,6 @@ dependencies = [
  "capnpc",
  "daphne",
  "hex",
- "http",
  "prometheus",
  "ring",
  "serde",
@@ -817,7 +812,6 @@ dependencies = [
 name = "daphne_worker"
 version = "0.3.0"
 dependencies = [
- "async-trait",
  "bincode",
  "chrono",
  "daphne",
@@ -1087,10 +1081,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,24 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = { version = "2.5.0", features = ["serde"] }
 worker = "0.0.18"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "warn"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_panics_doc = "allow"
+missing_errors_doc = "allow"
+cast_precision_loss = "allow"
+too_many_lines = "allow"
+needless_pass_by_value = "allow"
+if_not_else = "allow"
+default_trait_access = "allow"
+items_after_statements = "allow"
+redundant_closure_for_method_calls = "allow"
+inconsistent_struct_constructor = "allow"
+similar_names = "allow"
+inline_always = "allow"
+no_effect_underscore_binding = "allow"

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -58,3 +58,6 @@ prometheus = ["dep:prometheus"]
 [[bench]]
 name = "vdaf"
 harness = false
+
+[lints]
+workspace = true

--- a/daphne/benches/vdaf.rs
+++ b/daphne/benches/vdaf.rs
@@ -14,6 +14,8 @@ use prio::{
 fn count_vec(c: &mut Criterion) {
     for dimension in [100, 1_000, 10_000, 100_000] {
         let nonce = [0; 16];
+        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_sign_loss)]
         let chunk_length = (dimension as f64).sqrt() as usize; // asymptotically optimal
 
         // Prio2

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1,24 +1,6 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![warn(unused_crate_dependencies)]
-#![warn(rustdoc::broken_intra_doc_links)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::default_trait_access)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::inconsistent_struct_constructor)]
-#![allow(clippy::similar_names)]
-#![allow(clippy::inline_always)]
-
 //! This crate implements the core protocol logic for the Distributed Aggregation Protocol
 //! ([DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/)) standard under development in the
 //! PPM working group of the IETF. See [`VdafConfig`] for a listing of supported
@@ -101,13 +83,6 @@ use std::{
     str::FromStr,
 };
 use url::Url;
-
-// there is a bug in cargo where if a dependency is only used in tests/examples but not in the
-// library you get unused_crate_dependencies warnings when compiling the them.
-#[cfg(test)]
-mod silence_unused_crate_warning {
-    use criterion as _;
-}
 
 pub use protocol::aggregator::{
     EarlyReportState, EarlyReportStateConsumed, EarlyReportStateInitialized,

--- a/daphne_server/Cargo.toml
+++ b/daphne_server/Cargo.toml
@@ -48,3 +48,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 test-utils = ["daphne/test-utils", "daphne_service_utils/test-utils"]
+
+[lints]
+workspace = true

--- a/daphne_server/examples/configuration-helper.toml
+++ b/daphne_server/examples/configuration-helper.toml
@@ -1,6 +1,6 @@
 port = 8788
 
-[storage_proxy_config]
+[storage_proxy]
 url = "http://localhost:4001"
 # SECRET: This is a test secret. In production, we'll generate and securely provision the token.
 auth_token = 'this-is-the-storage-proxy-auth-token'

--- a/daphne_server/examples/configuration-leader.toml
+++ b/daphne_server/examples/configuration-leader.toml
@@ -1,6 +1,6 @@
 port = 8787
 
-[storage_proxy_config]
+[storage_proxy]
 url = "http://localhost:4000"
 # SECRET: This is a test secret. In production, we'll generate and securely provision the token.
 auth_token = 'this-is-the-storage-proxy-auth-token'

--- a/daphne_server/examples/service.rs
+++ b/daphne_server/examples/service.rs
@@ -16,7 +16,7 @@ use url::Url;
 struct Config {
     service: DaphneServiceConfig,
     port: u16,
-    storage_proxy_config: StorageProxyConfig,
+    storage_proxy: StorageProxyConfig,
 }
 
 impl TryFrom<Args> for Config {
@@ -97,11 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
 
     let role = config.service.role;
     // Configure the application
-    let app = App::new(
-        config.storage_proxy_config,
-        daphne_service_metrics,
-        config.service,
-    )?;
+    let app = App::new(config.storage_proxy, daphne_service_metrics, config.service)?;
 
     // create the router that will handle the protocol's http requests
     let router = router::new(role, app);

--- a/daphne_server/src/lib.rs
+++ b/daphne_server/src/lib.rs
@@ -1,33 +1,8 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::ignored_unit_patterns)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::default_trait_access)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::inconsistent_struct_constructor)]
-#![allow(clippy::similar_names)]
-#![allow(clippy::inline_always)]
-
 use daphne::{auth::BearerToken, DapError};
 use daphne_service_utils::{config::DaphneServiceConfig, metrics::DaphneServiceMetrics};
-// there is a bug in cargo where if a dependency is only used in tests/examples but not in the
-// library you get unused_crate_dependencies warnings when compiling the them.
-#[cfg(test)]
-mod silence_unused_crate_warning {
-    use clap as _;
-    use config as _;
-    use tracing_subscriber as _;
-}
 use serde::{Deserialize, Serialize};
 use storage_proxy_connection::{kv, Do, Kv};
 use tokio::sync::RwLock;

--- a/daphne_service_utils/Cargo.toml
+++ b/daphne_service_utils/Cargo.toml
@@ -36,3 +36,6 @@ capnpc = "0.18.1"
 [features]
 test-utils = ["dep:prometheus", "daphne/prometheus", "daphne/test-utils"]
 prometheus = ["dep:prometheus", "daphne/prometheus"]
+
+[lints]
+workspace = true

--- a/daphne_service_utils/Cargo.toml
+++ b/daphne_service_utils/Cargo.toml
@@ -19,7 +19,6 @@ readme = "../README.md"
 capnp.workspace = true
 daphne = { path = "../daphne", default-features = false }
 hex.workspace = true
-http.workspace = true
 prometheus = { workspace = true, optional = true }
 ring.workspace = true
 serde.workspace = true

--- a/daphne_service_utils/src/durable_requests/bindings.rs
+++ b/daphne_service_utils/src/durable_requests/bindings.rs
@@ -139,7 +139,7 @@ define_do_binding! {
         DeleteAll = "/internal/do/delete_all",
     }
 
-    fn name(_: ()) -> ObjectIdFrom {
+    fn name((): ()) -> ObjectIdFrom {
         ObjectIdFrom::Name(Self::NAME_STR.into())
     }
 }

--- a/daphne_service_utils/src/durable_requests/mod.rs
+++ b/daphne_service_utils/src/durable_requests/mod.rs
@@ -90,7 +90,7 @@ impl ObjectIdFrom {
     /// Assert that the object is being referenced by name.
     ///
     /// # Note
-    /// This is here for convenience of the daphne_worker and can be removed in the future.
+    /// This is here for convenience of the `daphne_worker` and can be removed in the future.
     pub fn unwrap_from_name(self) -> String {
         let Self::Name(name) = self else {
             panic!("unwraped a {self:?} when a Name was expected");
@@ -101,7 +101,7 @@ impl ObjectIdFrom {
     /// Assert that the object is being referenced by id.
     ///
     /// # Note
-    /// This is here for convenience of the daphne_worker and can be removed in the future.
+    /// This is here for convenience of the `daphne_worker` and can be removed in the future.
     pub fn unwrap_from_hex(self) -> String {
         let Self::Hex(name) = self else {
             panic!("unwraped a {self:?} when a Hex was expected");
@@ -112,7 +112,7 @@ impl ObjectIdFrom {
 
 /// A durable object request meant for the storage proxy.
 ///
-/// It's generic over the payload which can be any type that implements AsRef<[u8]>. This payload
+/// It's generic over the payload which can be any type that implements [`AsRef]`<[u8]>. This payload
 /// is what is ultimately passed to the durable object.
 #[derive(Debug, Clone)]
 pub struct DurableRequest<P: AsRef<[u8]>> {
@@ -232,7 +232,7 @@ impl<'s> TryFrom<&'s [u8]> for DurableRequest<&'s [u8]> {
             binding,
             id,
             retry,
-            body: &bytes[cursor.position() as usize..],
+            body: &bytes[cursor.position().try_into().unwrap_or(usize::MAX)..],
         })
     }
 }
@@ -241,6 +241,7 @@ impl<P> DurableRequest<P>
 where
     P: AsRef<[u8]>,
 {
+    #[must_use]
     pub fn with_retry(self) -> Self {
         Self {
             retry: true,

--- a/daphne_service_utils/src/lib.rs
+++ b/daphne_service_utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod test_route_types;
 // the generated code expects this module to be defined at the root of the library.
 mod durable_request_capnp {
     #![allow(dead_code)]
+    #![allow(clippy::pedantic)]
     include!(concat!(
         env!("OUT_DIR"),
         "/src/durable_requests/durable_request_capnp.rs"

--- a/daphne_service_utils/src/metrics.rs
+++ b/daphne_service_utils/src/metrics.rs
@@ -23,39 +23,39 @@ mod prometheus {
 
     impl DaphneMetrics for DaphnePromServiceMetrics {
         fn report_inc_by(&self, status: &str, val: u64) {
-            self.daphne.report_inc_by(status, val)
+            self.daphne.report_inc_by(status, val);
         }
 
         fn inbound_req_inc(&self, request_type: daphne::metrics::DaphneRequestType) {
-            self.daphne.inbound_req_inc(request_type)
+            self.daphne.inbound_req_inc(request_type);
         }
 
         fn agg_job_started_inc(&self) {
-            self.daphne.agg_job_started_inc()
+            self.daphne.agg_job_started_inc();
         }
 
         fn agg_job_completed_inc(&self) {
-            self.daphne.agg_job_completed_inc()
+            self.daphne.agg_job_completed_inc();
         }
 
         fn agg_job_observe_batch_size(&self, val: usize) {
-            self.daphne.agg_job_observe_batch_size(val)
+            self.daphne.agg_job_observe_batch_size(val);
         }
 
         fn agg_job_put_span_retry_inc(&self) {
-            self.daphne.agg_job_put_span_retry_inc()
+            self.daphne.agg_job_put_span_retry_inc();
         }
     }
 
     impl DaphneServiceMetrics for DaphnePromServiceMetrics {
         fn abort_count_inc(&self, label: &str) {
-            self.dap_abort_counter.with_label_values(&[label]).inc()
+            self.dap_abort_counter.with_label_values(&[label]).inc();
         }
 
         fn count_http_status_code(&self, status_code: u16) {
             self.http_status_code_counter
                 .with_label_values(&[&status_code.to_string()])
-                .inc()
+                .inc();
         }
 
         fn daphne(&self) -> &dyn DaphneMetrics {

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -44,3 +44,6 @@ paste.workspace = true
 
 [features]
 test-utils = ["daphne_service_utils/test-utils"]
+
+[lints]
+workspace = true

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -19,12 +19,11 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait.workspace = true
 bincode.workspace = true
 chrono = { version = "0.4.33", default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne", features = ["prometheus"] }
 daphne_service_utils = { path = "../daphne_service_utils", features = ["prometheus"] }
-futures.workspace = true
+futures = { workspace = true, optional = true }
 hex.workspace = true
 prio.workspace = true
 rand.workspace = true
@@ -43,7 +42,7 @@ daphne = { path = "../daphne", features = ["test-utils"] }
 paste.workspace = true
 
 [features]
-test-utils = ["daphne_service_utils/test-utils"]
+test-utils = ["daphne_service_utils/test-utils", "dep:futures"]
 
 [lints]
 workspace = true

--- a/daphne_worker/src/durable/aggregate_store.rs
+++ b/daphne_worker/src/durable/aggregate_store.rs
@@ -317,7 +317,7 @@ impl AggregateStore {
         let mut req = match self.schedule_for_garbage_collection(req).await? {
             ControlFlow::Continue(req) => req,
             // This req was a GC request and as such we must return from this function.
-            ControlFlow::Break(_) => return Response::from_json(&()),
+            ControlFlow::Break(()) => return Response::from_json(&()),
         };
 
         match bindings::AggregateStore::try_from_uri(&req.path()) {

--- a/daphne_worker/src/durable/leader_agg_job_queue.rs
+++ b/daphne_worker/src/durable/leader_agg_job_queue.rs
@@ -72,7 +72,7 @@ impl LeaderAggregationJobQueue {
         let mut req = match self.schedule_for_garbage_collection(req).await? {
             ControlFlow::Continue(req) => req,
             // This req was a GC request and as such we must return from this function.
-            ControlFlow::Break(_) => return Response::from_json(&()),
+            ControlFlow::Break(()) => return Response::from_json(&()),
         };
         match bindings::LeaderAggJobQueue::try_from_uri(&req.path()) {
             // Put a job (near) the back of the queue.

--- a/daphne_worker/src/durable/leader_batch_queue.rs
+++ b/daphne_worker/src/durable/leader_batch_queue.rs
@@ -104,7 +104,7 @@ impl LeaderBatchQueue {
         let mut req = match self.schedule_for_garbage_collection(req).await? {
             ControlFlow::Continue(req) => req,
             // This req was a GC request and as such we must return from this function.
-            ControlFlow::Break(_) => return Response::from_json(&()),
+            ControlFlow::Break(()) => return Response::from_json(&()),
         };
 
         match bindings::LeaderBatchQueue::try_from_uri(&req.path()) {

--- a/daphne_worker/src/durable/leader_col_job_queue.rs
+++ b/daphne_worker/src/durable/leader_col_job_queue.rs
@@ -83,7 +83,7 @@ impl LeaderCollectionJobQueue {
         let mut req = match self.schedule_for_garbage_collection(req).await? {
             ControlFlow::Continue(req) => req,
             // This req was a GC request and as such we must return from this function.
-            ControlFlow::Break(_) => return Response::from_json(&()),
+            ControlFlow::Break(()) => return Response::from_json(&()),
         };
         match bindings::LeaderColJobQueue::try_from_uri(&req.path()) {
             // Create a collect job for a collect request issued by the Collector.

--- a/daphne_worker/src/durable/reports_pending.rs
+++ b/daphne_worker/src/durable/reports_pending.rs
@@ -82,7 +82,7 @@ impl ReportsPending {
         let mut req = match self.schedule_for_garbage_collection(req).await? {
             ControlFlow::Continue(req) => req,
             // This req was a GC request and as such we must return from this function.
-            ControlFlow::Break(_) => return Response::from_json(&()),
+            ControlFlow::Break(()) => return Response::from_json(&()),
         };
 
         let durable = DurableConnector::new(&self.env);

--- a/daphne_worker/src/lib.rs
+++ b/daphne_worker/src/lib.rs
@@ -1,25 +1,6 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::ignored_unit_patterns)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::default_trait_access)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::inconsistent_struct_constructor)]
-#![allow(clippy::similar_names)]
-#![allow(clippy::inline_always)]
-#![allow(clippy::no_effect_underscore_binding)]
-
 //! Daphne-Worker implements a [Workers](https://developers.cloudflare.com/workers/) backend for
 //! Daphne.
 //!

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -28,12 +28,10 @@ cfg-if = "1.0.0"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 daphne_worker = { path = "../daphne_worker", features = ["test-utils"] }
-getrandom = { workspace = true, features = ["js", "std"] }
 tracing.workspace = true
 worker.workspace = true
 
 [dev-dependencies]
-async-trait.workspace = true
 assert_matches.workspace = true
 daphne = { path = "../daphne", features = ["test-utils"] }
 daphne_service_utils = { path = "../daphne_service_utils" }
@@ -41,10 +39,8 @@ hex.workspace = true
 hpke-rs.workspace = true
 paste.workspace = true
 prio.workspace = true
-prometheus.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
-ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -49,3 +49,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 url.workspace = true
+
+[lints]
+workspace = true

--- a/daphne_worker_test/src/lib.rs
+++ b/daphne_worker_test/src/lib.rs
@@ -1,23 +1,6 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![warn(clippy::pedantic)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::ignored_unit_patterns)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::default_trait_access)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::inconsistent_struct_constructor)]
-#![allow(clippy::similar_names)]
-#![allow(clippy::inline_always)]
-
 use daphne_worker::{initialize_tracing, DapWorkerMode};
 use tracing::info;
 use worker::{event, Env, Request, Response, Result};

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -53,12 +53,12 @@ async fn leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let prefix = if want_prefix {
         format!("/{}", version.as_ref())
     } else {
-        String::from("")
+        String::new()
     };
     let t = TestRunner::default_with_version(version).await;
     let res: InternalTestEndpointForTaskResult = t
         .leader_post_internal(
-            format!("{}/internal/test/endpoint_for_task", prefix).as_ref(),
+            format!("{prefix}/internal/test/endpoint_for_task").as_ref(),
             &json!({
                 "task_id": "blah blah ignored",
                 "role": "leader",
@@ -79,13 +79,13 @@ async fn leader_endpoint_for_task(version: DapVersion, want_prefix: bool) {
 }
 
 async fn leader_endpoint_for_task_unprefixed(version: DapVersion) {
-    leader_endpoint_for_task(version, false).await
+    leader_endpoint_for_task(version, false).await;
 }
 
 async_test_versions! { leader_endpoint_for_task_unprefixed }
 
 async fn leader_endpoint_for_task_prefixed(version: DapVersion) {
-    leader_endpoint_for_task(version, true).await
+    leader_endpoint_for_task(version, true).await;
 }
 
 async_test_versions! { leader_endpoint_for_task_prefixed }
@@ -94,12 +94,12 @@ async fn helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
     let prefix = if want_prefix {
         format!("/{}", version.as_ref())
     } else {
-        String::from("")
+        String::new()
     };
     let t = TestRunner::default_with_version(version).await;
     let res: InternalTestEndpointForTaskResult = t
         .helper_post_internal(
-            format!("{}/internal/test/endpoint_for_task", prefix).as_ref(),
+            format!("{prefix}/internal/test/endpoint_for_task").as_ref(),
             &json!({
                 "task_id": "blah blah ignored",
                 "role": "helper",
@@ -120,20 +120,20 @@ async fn helper_endpoint_for_task(version: DapVersion, want_prefix: bool) {
 }
 
 async fn helper_endpoint_for_task_unprefixed(version: DapVersion) {
-    helper_endpoint_for_task(version, false).await
+    helper_endpoint_for_task(version, false).await;
 }
 
 async_test_versions! { helper_endpoint_for_task_unprefixed }
 
 async fn helper_endpoint_for_task_prefixed(version: DapVersion) {
-    helper_endpoint_for_task(version, true).await
+    helper_endpoint_for_task(version, true).await;
 }
 
 async_test_versions! { helper_endpoint_for_task_prefixed }
 
 async fn leader_hpke_config(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     t.leader_get_raw_hpke_config(&client).await;
 }
 
@@ -141,7 +141,7 @@ async_test_versions! { leader_hpke_config }
 
 async fn helper_hpke_config(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     t.helper_get_raw_hpke_config(&client).await;
 }
 
@@ -149,7 +149,7 @@ async_test_versions! { helper_hpke_config }
 
 async fn hpke_configs_are_cached(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     // Get a set of HPKE configs from leader and helper.
     let hpke_config_list_0 = t.get_hpke_configs(version, &client).await;
     // Get another set of HPKE configs from leader and helper.
@@ -166,7 +166,7 @@ async_test_versions! { hpke_configs_are_cached }
 async fn leader_upload(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let mut rng = thread_rng();
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
 
@@ -352,7 +352,7 @@ async_test_versions! { leader_upload }
 async fn leader_upload_taskprov() {
     let version = DapVersion::Draft02;
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = "upload";
 
@@ -464,7 +464,7 @@ async fn internal_leader_process(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let path = t.upload_path();
 
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
 
     let report_sel = DaphneServiceReportSelector {
@@ -477,7 +477,7 @@ async fn internal_leader_process(version: DapVersion) {
     // Upload a number of reports (a few more than the aggregation rate).
     let mut rng = thread_rng();
     for _ in 0..report_sel.max_reports + 3 {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -524,7 +524,7 @@ async_test_versions! { internal_leader_process }
 // Test that all reports eventually get drained at minimum aggregation rate.
 async fn leader_process_min_agg_rate(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let batch_interval = t.batch_interval();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
@@ -532,7 +532,7 @@ async fn leader_process_min_agg_rate(version: DapVersion) {
     // The reports are uploaded in the background.
     let mut rng = thread_rng();
     for _ in 0..7 {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -563,7 +563,7 @@ async fn leader_process_min_agg_rate(version: DapVersion) {
     for i in 0..7 {
         // Each round should process exactly one report.
         let agg_telem = t.internal_process(&client, &report_sel).await;
-        assert_eq!(agg_telem.reports_processed, 1, "round {} is empty", i);
+        assert_eq!(agg_telem.reports_processed, 1, "round {i} is empty");
     }
 
     let agg_telem = t.internal_process(&client, &report_sel).await;
@@ -576,7 +576,7 @@ async fn leader_collect_ok(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
 
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
 
@@ -585,7 +585,7 @@ async fn leader_collect_ok(version: DapVersion) {
     let mut time_min = u64::MAX;
     let mut time_max = 0u64;
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         time_min = min(time_min, now);
         time_max = max(time_max, now);
         t.leader_put_expect_ok(
@@ -623,11 +623,11 @@ async fn leader_collect_ok(version: DapVersion) {
             collect_req.get_encoded_with_param(&t.version).unwrap(),
         )
         .await;
-    println!("collect_uri: {}", collect_uri);
+    println!("collect_uri: {collect_uri}");
 
     // Poll the collect URI before the CollectResp is ready.
     let resp = t.poll_collection_url(&client, &collect_uri).await;
-    assert_eq!(resp.status(), 202, "response: {:?}", resp);
+    assert_eq!(resp.status(), 202, "response: {resp:?}");
 
     // The reports are aggregated in the background.
     let agg_telem = t
@@ -676,7 +676,7 @@ async fn leader_collect_ok(version: DapVersion) {
         .unwrap();
     assert_eq!(
         agg_res,
-        DapAggregateResult::U128(t.task_config.min_batch_size as u128)
+        DapAggregateResult::U128(u128::from(t.task_config.min_batch_size))
     );
 
     if version != DapVersion::Draft02 {
@@ -703,7 +703,7 @@ async fn leader_collect_ok(version: DapVersion) {
     // to avoid sharding ReportsProcessed by batch bucket, which is not feasilbe for fixed-size
     // tasks.
     //
-    //  let now = rng.gen_range(t.report_interval(&batch_interval));
+    //  let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
     //  t.leader_post_expect_abort(
     //      &client,
     //      None, // dap_auth_token
@@ -725,7 +725,7 @@ async_test_versions! { leader_collect_ok }
 // have been processed.
 async fn leader_collect_ok_interleaved(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let batch_interval = t.batch_interval();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
@@ -733,7 +733,7 @@ async fn leader_collect_ok_interleaved(version: DapVersion) {
     // The reports are uploaded in the background.
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -795,14 +795,14 @@ async_test_versions! { leader_collect_ok_interleaved }
 async fn leader_collect_not_ready_min_batch_size(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
 
     // A number of reports are uploaded, but not enough to meet the minimum batch requirement.
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size - 1 {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -838,7 +838,7 @@ async fn leader_collect_not_ready_min_batch_size(version: DapVersion) {
             collect_req.get_encoded_with_param(&t.version).unwrap(),
         )
         .await;
-    println!("collect_uri: {}", collect_uri);
+    println!("collect_uri: {collect_uri}");
 
     // The reports are aggregated in the background.
     let agg_telem = t
@@ -869,7 +869,7 @@ async_test_versions! { leader_collect_not_ready_min_batch_size }
 
 async fn leader_collect_abort_unknown_request(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
 
     // Poll collect URI for an unknown collect request.
     let fake_task_id = TaskId([0; 32]);
@@ -893,7 +893,7 @@ async_test_versions! { leader_collect_abort_unknown_request }
 
 async fn leader_collect_accept_global_config_max_batch_duration(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let batch_interval = Interval {
         start: t.task_config.quantized_time_lower_bound(t.now)
             - t.global_config.max_batch_duration / 2,
@@ -918,7 +918,7 @@ async_test_versions! { leader_collect_accept_global_config_max_batch_duration }
 
 async fn leader_collect_abort_invalid_batch_interval(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let batch_interval = t.batch_interval();
     let path = &t.collect_path_for_task(&t.task_id);
 
@@ -998,14 +998,14 @@ async_test_versions! { leader_collect_abort_invalid_batch_interval }
 async fn leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
     let path = t.upload_path();
 
     // The reports are uploaded in the background.
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -1121,7 +1121,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
         max_reports: 100,
     };
 
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
 
     // Clients: Upload reports.
@@ -1181,11 +1181,11 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
             collect_req.get_encoded_with_param(&t.version).unwrap(),
         )
         .await;
-    println!("collect_uri: {}", collect_uri);
+    println!("collect_uri: {collect_uri}");
 
     // Collector: Poll the collect URI before the CollectResp is ready.
     let resp = t.poll_collection_url(&client, &collect_uri).await;
-    assert_eq!(resp.status(), 202, "response: {:?}", resp);
+    assert_eq!(resp.status(), 202, "response: {resp:?}");
 
     // ... Aggregators run processing loop.
     let agg_telem = t.internal_process(&client, &report_sel).await;
@@ -1218,7 +1218,7 @@ async fn fixed_size(version: DapVersion, use_current: bool) {
         .unwrap();
     assert_eq!(
         agg_res,
-        DapAggregateResult::U128(t.task_config.min_batch_size as u128)
+        DapAggregateResult::U128(u128::from(t.task_config.min_batch_size))
     );
 
     // Collector: Poll the collect URI once more. Expect the response to be the same as the first,
@@ -1323,7 +1323,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
 
-    let client = t.http_client();
+    let client = TestRunner::http_client();
     let hpke_config_list = t.get_hpke_configs(version, &client).await;
 
     let (task_config, task_id, taskprov_advertisement, taskprov_report_extension_payload) =
@@ -1354,7 +1354,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
                 DapVersion::Draft02 => taskprov_report_extension_payload.clone(),
             },
         }];
-        let now = rng.gen_range(t.report_interval(&batch_interval));
+        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
         t.leader_put_expect_ok(
             &client,
             &path,
@@ -1394,11 +1394,11 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
             collect_req.get_encoded_with_param(&t.version).unwrap(),
         )
         .await;
-    println!("collect_uri: {}", collect_uri);
+    println!("collect_uri: {collect_uri}");
 
     // Poll the collect URI before the CollectResp is ready.
     let resp = t.poll_collection_url(&client, &collect_uri).await;
-    assert_eq!(resp.status(), 202, "response: {:?}", resp);
+    assert_eq!(resp.status(), 202, "response: {resp:?}");
 
     // The reports are aggregated in the background.
     let agg_telem = t


### PR DESCRIPTION
As of [Rust 1.74](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#lint-configuration-through-cargo) lints can now be configured in the Cargo.toml instead of per crate. This is a lot more sane. It also makes sure lints are applied to all crates, even the less obvious ones (`daphne_server_test/tests/e2e`).

Also removed the `unused_crate_dependencies` lint as it's way too broken for
everyday use. Made sure to cleanup some dependencies in the meantime.
