### PR TITLE
tasskprov: Opt-out if there are too many proofs

### DIFF
--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -2019,7 +2019,7 @@ mod test {
                 bits: 1,
                 length: 10,
                 chunk_length: 2,
-                num_proofs: 4,
+                num_proofs: 3,
             }),
             DapMeasurement::U64Vec(vec![1; 10]),
         )


### PR DESCRIPTION
For Prio3SumVecField64MultiproofHmacSha256Aes128, no more than 3 proofs are required to get good robustness. If the task author requests more than 3 proofs, then opt out to prevent ourselves from getting DoS'ed.

Also, opt out if 0 proofs are requested, as this is invalid.