### PR TITLE
Prepare to support the next DAP version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "paste",
  "prio",
  "prometheus",
  "rand",

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -63,29 +63,41 @@ impl DapMediaType {
         let (content_type, _) = content_type.split_once(';').unwrap_or((content_type, ""));
         let media_type = match (version, content_type) {
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_AGG_JOB_CONT_REQ) => {
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_CONT_REQ) => {
                 Self::AggregationJobContinueReq
             }
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_CONT_RESP) => {
                 Self::Draft02AggregateContinueResp
             }
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_AGG_JOB_INIT_REQ) => Self::AggregationJobInitReq,
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_INIT_REQ) => {
+                Self::AggregationJobInitReq
+            }
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_AGG_JOB_RESP) => Self::AggregationJobResp,
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_RESP) => {
+                Self::AggregationJobResp
+            }
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_AGG_SHARE) => Self::AggregateShare,
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_SHARE) => {
+                Self::AggregateShare
+            }
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_COLLECT_RESP)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_COLLECTION) => Self::Collection,
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_COLLECTION) => Self::Collection,
             (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_HPKE_CONFIG)
-            | (DapVersion::DraftLatest, MEDIA_TYPE_HPKE_CONFIG_LIST) => Self::HpkeConfigList,
-            (DapVersion::Draft02 | DapVersion::DraftLatest, MEDIA_TYPE_AGG_SHARE_REQ) => {
-                Self::AggregateShareReq
+            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_HPKE_CONFIG_LIST) => {
+                Self::HpkeConfigList
             }
-            (DapVersion::Draft02 | DapVersion::DraftLatest, MEDIA_TYPE_COLLECT_REQ) => {
-                Self::CollectReq
+            (
+                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
+                MEDIA_TYPE_AGG_SHARE_REQ,
+            ) => Self::AggregateShareReq,
+            (
+                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
+                MEDIA_TYPE_COLLECT_REQ,
+            ) => Self::CollectReq,
+            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_REPORT) => {
+                Self::Report
             }
-            (DapVersion::Draft02 | DapVersion::DraftLatest, MEDIA_TYPE_REPORT) => Self::Report,
             (_, _) => return None,
         };
         Some(media_type)
@@ -97,35 +109,44 @@ impl DapMediaType {
             (DapVersion::Draft02, Self::AggregationJobInitReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
             }
-            (DapVersion::DraftLatest, Self::AggregationJobInitReq) => {
+            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobInitReq) => {
                 Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)
             }
             (DapVersion::Draft02, Self::AggregationJobResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
             }
-            (DapVersion::DraftLatest, Self::AggregationJobResp) => Some(MEDIA_TYPE_AGG_JOB_RESP),
+            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobResp) => {
+                Some(MEDIA_TYPE_AGG_JOB_RESP)
+            }
             (DapVersion::Draft02, Self::AggregationJobContinueReq) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
             }
-            (DapVersion::DraftLatest, Self::AggregationJobContinueReq) => {
+            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobContinueReq) => {
                 Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)
             }
             (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
                 Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
             }
-            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::AggregateShareReq) => {
-                Some(MEDIA_TYPE_AGG_SHARE_REQ)
-            }
+            (
+                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
+                Self::AggregateShareReq,
+            ) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
             (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-            (DapVersion::DraftLatest, Self::AggregateShare) => Some(MEDIA_TYPE_AGG_SHARE),
-            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::CollectReq) => {
+            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregateShare) => {
+                Some(MEDIA_TYPE_AGG_SHARE)
+            }
+            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, Self::CollectReq) => {
                 Some(MEDIA_TYPE_COLLECT_REQ)
             }
             (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-            (DapVersion::DraftLatest, Self::Collection) => Some(MEDIA_TYPE_COLLECTION),
+            (DapVersion::Draft09 | DapVersion::Latest, Self::Collection) => {
+                Some(MEDIA_TYPE_COLLECTION)
+            }
             (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
-            (DapVersion::DraftLatest, Self::HpkeConfigList) => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
-            (DapVersion::Draft02 | DapVersion::DraftLatest, Self::Report) => {
+            (DapVersion::Draft09 | DapVersion::Latest, Self::HpkeConfigList) => {
+                Some(MEDIA_TYPE_HPKE_CONFIG_LIST)
+            }
+            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, Self::Report) => {
                 Some(MEDIA_TYPE_REPORT)
             }
             (_, Self::Draft02AggregateContinueResp) => None,
@@ -137,7 +158,7 @@ impl DapMediaType {
     pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
         match version {
             DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
-            DapVersion::DraftLatest => Self::AggregationJobResp,
+            DapVersion::Draft09 | DapVersion::Latest => Self::AggregationJobResp,
         }
     }
 }
@@ -207,64 +228,58 @@ mod test {
 
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
-                "application/dap-hpke-config-list"
+                DapVersion::Draft09,
+                "application/dap-hpke-config-list",
             ),
             Some(DapMediaType::HpkeConfigList)
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregation-job-init-req"
             ),
             Some(DapMediaType::AggregationJobInitReq),
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregation-job-resp"
             ),
             Some(DapMediaType::AggregationJobResp),
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregation-job-continue-req"
             ),
             Some(DapMediaType::AggregationJobContinueReq),
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregate-share-req"
             ),
             Some(DapMediaType::AggregateShareReq),
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregate-share"
             ),
             Some(DapMediaType::AggregateShare),
         );
         assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
-                "application/dap-collect-req"
-            ),
+            DapMediaType::from_str_for_version(DapVersion::Draft09, "application/dap-collect-req"),
             Some(DapMediaType::CollectReq),
         );
         assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
-                "application/dap-collection"
-            ),
+            DapMediaType::from_str_for_version(DapVersion::Draft09, "application/dap-collection"),
             Some(DapMediaType::Collection),
         );
 
         // Invalid media type
         assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::DraftLatest, "blah-blah-blah"),
+            DapMediaType::from_str_for_version(DapVersion::Draft09, "blah-blah-blah"),
             None,
         );
     }
@@ -273,30 +288,27 @@ mod test {
     fn round_trip() {
         for (version, media_type) in [
             (DapVersion::Draft02, DapMediaType::AggregationJobInitReq),
-            (DapVersion::DraftLatest, DapMediaType::AggregationJobInitReq),
+            (DapVersion::Draft09, DapMediaType::AggregationJobInitReq),
             (DapVersion::Draft02, DapMediaType::AggregationJobResp),
-            (DapVersion::DraftLatest, DapMediaType::AggregationJobResp),
+            (DapVersion::Draft09, DapMediaType::AggregationJobResp),
             (DapVersion::Draft02, DapMediaType::AggregationJobContinueReq),
-            (
-                DapVersion::DraftLatest,
-                DapMediaType::AggregationJobContinueReq,
-            ),
+            (DapVersion::Draft09, DapMediaType::AggregationJobContinueReq),
             (
                 DapVersion::Draft02,
                 DapMediaType::Draft02AggregateContinueResp,
             ),
             (DapVersion::Draft02, DapMediaType::AggregateShareReq),
-            (DapVersion::DraftLatest, DapMediaType::AggregateShareReq),
+            (DapVersion::Draft09, DapMediaType::AggregateShareReq),
             (DapVersion::Draft02, DapMediaType::AggregateShare),
-            (DapVersion::DraftLatest, DapMediaType::AggregateShare),
+            (DapVersion::Draft09, DapMediaType::AggregateShare),
             (DapVersion::Draft02, DapMediaType::CollectReq),
-            (DapVersion::DraftLatest, DapMediaType::CollectReq),
+            (DapVersion::Draft09, DapMediaType::CollectReq),
             (DapVersion::Draft02, DapMediaType::Collection),
-            (DapVersion::DraftLatest, DapMediaType::Collection),
+            (DapVersion::Draft09, DapMediaType::Collection),
             (DapVersion::Draft02, DapMediaType::HpkeConfigList),
-            (DapVersion::DraftLatest, DapMediaType::HpkeConfigList),
+            (DapVersion::Draft09, DapMediaType::HpkeConfigList),
             (DapVersion::Draft02, DapMediaType::Report),
-            (DapVersion::DraftLatest, DapMediaType::Report),
+            (DapVersion::Draft09, DapMediaType::Report),
         ] {
             assert_eq!(
                 media_type
@@ -319,7 +331,7 @@ mod test {
 
         assert_eq!(
             DapMediaType::AggregationJobResp,
-            DapMediaType::agg_job_cont_resp_for_version(DapVersion::DraftLatest)
+            DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft09)
         );
     }
 
@@ -327,7 +339,7 @@ mod test {
     fn media_type_parsing_ignores_content_type_paramters() {
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::DraftLatest,
+                DapVersion::Draft09,
                 "application/dap-aggregation-job-init-req;version=09",
             ),
             Some(DapMediaType::AggregationJobInitReq),

--- a/daphne/src/protocol/aggregator.rs
+++ b/daphne/src/protocol/aggregator.rs
@@ -35,9 +35,8 @@ use std::{
 };
 
 use super::{
-    CTX_AGG_SHARE_DRAFT02, CTX_AGG_SHARE_DRAFT_LATEST, CTX_INPUT_SHARE_DRAFT02,
-    CTX_INPUT_SHARE_DRAFT_LATEST, CTX_ROLE_CLIENT, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER,
-    CTX_ROLE_LEADER,
+    CTX_AGG_SHARE_DRAFT02, CTX_AGG_SHARE_DRAFT09, CTX_INPUT_SHARE_DRAFT02, CTX_INPUT_SHARE_DRAFT09,
+    CTX_ROLE_CLIENT, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER, CTX_ROLE_LEADER,
 };
 
 // Ping-pong message framing as defined in draft-irtf-cfrg-vdaf-08, Section 5.8. We do not
@@ -124,7 +123,7 @@ impl EarlyReportStateConsumed {
 
         let input_share_text = match task_config.version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
-            DapVersion::DraftLatest => CTX_INPUT_SHARE_DRAFT_LATEST,
+            DapVersion::Draft09 | DapVersion::Latest => CTX_INPUT_SHARE_DRAFT09,
         };
         let n: usize = input_share_text.len();
         let mut info = Vec::with_capacity(n + 2);
@@ -160,9 +159,9 @@ impl EarlyReportStateConsumed {
 
         // draft02 compatibility: The plaintext is passed to the VDAF directly. In the latest
         // draft, the plaintext also encodes the report extensions.
-        let (input_share, draft_latest_extensions) = match task_config.version {
+        let (input_share, draft09_extensions) = match task_config.version {
             DapVersion::Draft02 => (encoded_input_share, None),
-            DapVersion::DraftLatest => {
+            DapVersion::Draft09 | DapVersion::Latest => {
                 match PlaintextInputShare::get_decoded_with_param(
                     &task_config.version,
                     &encoded_input_share,
@@ -181,7 +180,7 @@ impl EarlyReportStateConsumed {
         // Handle report extensions.
         {
             let extensions = match task_config.version {
-                DapVersion::DraftLatest => draft_latest_extensions.as_ref().unwrap(),
+                DapVersion::Draft09 | DapVersion::Latest => draft09_extensions.as_ref().unwrap(),
                 DapVersion::Draft02 => state.metadata.draft02_extensions.as_ref().unwrap(),
             };
 
@@ -202,7 +201,7 @@ impl EarlyReportStateConsumed {
                     }
 
                     // Reject reports with unrecognized extensions.
-                    (DapVersion::DraftLatest, ..) => {
+                    (DapVersion::Draft09 | DapVersion::Latest, ..) => {
                         return Ok(Self::Rejected {
                             metadata: state.metadata,
                             failure: TransitionFailure::InvalidMessage,
@@ -457,9 +456,9 @@ impl DapTaskConfig {
                 } => {
                     // draft02 compatibility: In the latest version, the Leader sends the Helper
                     // its initial prep share in the first request.
-                    let (draft02_prep_share, draft_latest_payload) = match self.version {
+                    let (draft02_prep_share, draft09_payload) = match self.version {
                         DapVersion::Draft02 => (Some(prep_share), None),
-                        DapVersion::DraftLatest => {
+                        DapVersion::Draft09 | DapVersion::Latest => {
                             let mut outbound = Vec::with_capacity(
                                 prep_share
                                     .encoded_len_with_param(&self.version)
@@ -487,7 +486,7 @@ impl DapTaskConfig {
                             public_share: state.public_share,
                             encrypted_input_share: helper_share,
                         },
-                        draft_latest_payload,
+                        draft09_payload,
                     });
                 }
 
@@ -552,7 +551,7 @@ impl DapTaskConfig {
                     ReportState {
                         metadata: prep_init.report_share.report_metadata,
                         public_share: prep_init.report_share.public_share,
-                        draft_latest_prep_init_payload: prep_init.draft_latest_payload,
+                        draft_latest_prep_init_payload: prep_init.draft09_payload,
                     },
                     prep_init.report_share.encrypted_input_share,
                 )
@@ -596,7 +595,7 @@ impl DapTaskConfig {
                 initialized_reports,
                 metrics,
             )),
-            DapVersion::DraftLatest => self.draft_latest_handle_agg_job_init_req(
+            DapVersion::Draft09 | DapVersion::Latest => self.draft09_handle_agg_job_init_req(
                 task_id,
                 report_status,
                 part_batch_sel,
@@ -662,7 +661,7 @@ impl DapTaskConfig {
         )
     }
 
-    fn draft_latest_handle_agg_job_init_req(
+    fn draft09_handle_agg_job_init_req(
         &self,
         task_id: &TaskId,
         report_status: &HashMap<ReportId, ReportProcessedStatus>,
@@ -786,8 +785,8 @@ impl DapTaskConfig {
             DapVersion::Draft02 => self
                 .draft02_handle_agg_job_resp(task_id, agg_job_id, state, agg_job_resp, metrics)
                 .map_err(Into::into),
-            DapVersion::DraftLatest => {
-                self.draft_latest_handle_agg_job_resp(task_id, state, agg_job_resp, metrics)
+            DapVersion::Draft09 | DapVersion::Latest => {
+                self.draft09_handle_agg_job_resp(task_id, state, agg_job_resp, metrics)
             }
         }
     }
@@ -913,7 +912,7 @@ impl DapTaskConfig {
         ))
     }
 
-    fn draft_latest_handle_agg_job_resp(
+    fn draft09_handle_agg_job_resp(
         &self,
         task_id: &TaskId,
         state: DapAggregationJobState,
@@ -1296,7 +1295,7 @@ fn produce_encrypted_agg_share(
 
     let agg_share_text = match version {
         DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
-        DapVersion::DraftLatest => CTX_AGG_SHARE_DRAFT_LATEST,
+        DapVersion::Draft09 | DapVersion::Latest => CTX_AGG_SHARE_DRAFT09,
     };
     let n: usize = agg_share_text.len();
     let mut info = Vec::with_capacity(n + 2);

--- a/daphne/src/protocol/client.rs
+++ b/daphne/src/protocol/client.rs
@@ -17,7 +17,7 @@ use prio::codec::{Encode, ParameterizedEncode};
 use rand::prelude::*;
 
 use super::{
-    CTX_INPUT_SHARE_DRAFT02, CTX_INPUT_SHARE_DRAFT_LATEST, CTX_ROLE_CLIENT, CTX_ROLE_HELPER,
+    CTX_INPUT_SHARE_DRAFT02, CTX_INPUT_SHARE_DRAFT09, CTX_ROLE_CLIENT, CTX_ROLE_HELPER,
     CTX_ROLE_LEADER,
 };
 
@@ -84,8 +84,8 @@ impl VdafConfig {
             return Err(fatal_error!(err = "unexpected number of HPKE configs"));
         }
 
-        let (draft02_extensions, mut draft_latest_plaintext_input_share) = match version {
-            DapVersion::DraftLatest => (
+        let (draft02_extensions, mut draft09_plaintext_input_share) = match version {
+            DapVersion::Draft09 | DapVersion::Latest => (
                 None,
                 Some(PlaintextInputShare {
                     extensions,
@@ -102,7 +102,7 @@ impl VdafConfig {
         };
 
         let encoded_input_shares = input_shares.into_iter().map(|input_share| {
-            if let Some(ref mut plaintext_input_share) = draft_latest_plaintext_input_share {
+            if let Some(ref mut plaintext_input_share) = draft09_plaintext_input_share {
                 plaintext_input_share.payload = input_share;
                 plaintext_input_share.get_encoded_with_param(&version)
             } else {
@@ -112,7 +112,7 @@ impl VdafConfig {
 
         let input_share_text = match version {
             DapVersion::Draft02 => CTX_INPUT_SHARE_DRAFT02,
-            DapVersion::DraftLatest => CTX_INPUT_SHARE_DRAFT_LATEST,
+            DapVersion::Draft09 | DapVersion::Latest => CTX_INPUT_SHARE_DRAFT09,
         };
         let n: usize = input_share_text.len();
         let mut info = Vec::with_capacity(n + 2);

--- a/daphne/src/protocol/collector.rs
+++ b/daphne/src/protocol/collector.rs
@@ -13,7 +13,7 @@ use crate::{
 use prio::codec::Encode;
 
 use super::{
-    CTX_AGG_SHARE_DRAFT02, CTX_AGG_SHARE_DRAFT_LATEST, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER,
+    CTX_AGG_SHARE_DRAFT02, CTX_AGG_SHARE_DRAFT09, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER,
     CTX_ROLE_LEADER,
 };
 
@@ -52,7 +52,7 @@ impl VdafConfig {
 
         let agg_share_text = match version {
             DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
-            DapVersion::DraftLatest => CTX_AGG_SHARE_DRAFT_LATEST,
+            DapVersion::Draft09 | DapVersion::Latest => CTX_AGG_SHARE_DRAFT09,
         };
         let n: usize = agg_share_text.len();
         let mut info = Vec::with_capacity(n + 2);

--- a/daphne/src/protocol/mod.rs
+++ b/daphne/src/protocol/mod.rs
@@ -6,9 +6,9 @@ mod client;
 mod collector;
 
 const CTX_INPUT_SHARE_DRAFT02: &[u8] = b"dap-02 input share";
-const CTX_INPUT_SHARE_DRAFT_LATEST: &[u8] = b"dap-09 input share";
+const CTX_INPUT_SHARE_DRAFT09: &[u8] = b"dap-09 input share";
 const CTX_AGG_SHARE_DRAFT02: &[u8] = b"dap-02 aggregate share";
-const CTX_AGG_SHARE_DRAFT_LATEST: &[u8] = b"dap-09 aggregate share";
+const CTX_AGG_SHARE_DRAFT09: &[u8] = b"dap-09 aggregate share";
 const CTX_ROLE_COLLECTOR: u8 = 0;
 const CTX_ROLE_CLIENT: u8 = 1;
 const CTX_ROLE_LEADER: u8 = 2;
@@ -418,7 +418,7 @@ mod test {
                         public_share: report0.public_share,
                         encrypted_input_share: report0.encrypted_input_shares[1].clone(),
                     },
-                    draft_latest_payload: Some(b"malformed payload".to_vec()),
+                    draft09_payload: Some(b"malformed payload".to_vec()),
                 },
                 PrepareInit {
                     report_share: ReportShare {
@@ -426,7 +426,7 @@ mod test {
                         public_share: report1.public_share,
                         encrypted_input_share: report1.encrypted_input_shares[1].clone(),
                     },
-                    draft_latest_payload: Some(b"malformed payload".to_vec()),
+                    draft09_payload: Some(b"malformed payload".to_vec()),
                 },
             ],
         };
@@ -658,18 +658,12 @@ mod test {
 
     #[tokio::test]
     async fn agg_job_init_req_skip_vdaf_prep_error_draft09() {
-        let t = AggregationJobTest::new(
-            TEST_VDAF,
-            HpkeKemId::X25519HkdfSha256,
-            DapVersion::DraftLatest,
-        );
+        let t =
+            AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, DapVersion::Draft09);
         let mut reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         reports.insert(
             1,
-            t.produce_invalid_report_vdaf_prep_failure(
-                DapMeasurement::U64(1),
-                DapVersion::DraftLatest,
-            ),
+            t.produce_invalid_report_vdaf_prep_failure(DapMeasurement::U64(1), DapVersion::Draft09),
         );
 
         let (leader_state, agg_job_init_req) = t
@@ -908,7 +902,7 @@ mod test {
             DapVersion::Draft02 => true,
             // In the latest version we're meant to reject reports containing unrecognized
             // extensions.
-            DapVersion::DraftLatest => false,
+            DapVersion::Draft09 | DapVersion::Latest => false,
         };
         assert_eq!(consumed_report.is_ready(), expect_ready);
     }

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -196,7 +196,7 @@ where
             .as_ref()
             .get_encoded()
             .map_err(DapError::encoding)?,
-        DapVersion::DraftLatest => {
+        DapVersion::Draft09 | DapVersion::Latest => {
             let hpke_config_list = HpkeConfigList {
                 hpke_configs: vec![hpke_config.as_ref().clone()],
             };

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -170,7 +170,7 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
             agg_job_resp
         }
 
-        DapVersion::DraftLatest => {
+        DapVersion::Draft09 | DapVersion::Latest => {
             let agg_job_resp = finish_agg_job_and_aggregate(
                 aggregator,
                 task_id,
@@ -462,10 +462,12 @@ fn resolve_agg_job_id<'id, S>(
         (DapVersion::Draft02, DapResource::Undefined, Some(agg_job_id)) => {
             Ok(MetaAggregationJobId::Draft02(*agg_job_id))
         }
-        (DapVersion::DraftLatest, DapResource::AggregationJob(agg_job_id), None) => {
-            Ok(MetaAggregationJobId::DraftLatest(*agg_job_id))
-        }
-        (DapVersion::DraftLatest, DapResource::Undefined, None) => {
+        (
+            DapVersion::Draft09 | DapVersion::Latest,
+            DapResource::AggregationJob(agg_job_id),
+            None,
+        ) => Ok(MetaAggregationJobId::Draft09(*agg_job_id)),
+        (DapVersion::Draft09 | DapVersion::Latest, DapResource::Undefined, None) => {
             Err(DapAbort::BadRequest("undefined resource".into()))
         }
         _ => unreachable!("unhandled resource {:?}", req.resource),

--- a/daphne/src/taskprov.rs
+++ b/daphne/src/taskprov.rs
@@ -147,7 +147,7 @@ fn get_taskprov_task_config<S>(
             )
         })?)
     } else if let Some(metadata) = report_metadata_advertisement {
-        if req.version == DapVersion::DraftLatest {
+        if matches!(req.version, DapVersion::Draft09 | DapVersion::Latest) {
             return Ok(None);
         }
         let taskprovs: Vec<&Extension> = metadata
@@ -234,7 +234,7 @@ impl VdafConfig {
                 })?,
             }),
             (
-                DapVersion::DraftLatest,
+                DapVersion::Draft09 | DapVersion::Latest,
                 VdafTypeVar::Prio3SumVecField64MultiproofHmacSha256Aes128 {
                     bits,
                     length,
@@ -684,7 +684,7 @@ mod test {
             (DapVersion::Draft02, Err(DapAbort::InvalidMessage { detail, .. })) => {
                 assert_eq!(detail, "codec error: unexpected value");
             }
-            (DapVersion::DraftLatest, Err(DapAbort::InvalidTask { detail, .. })) => {
+            (DapVersion::Draft09, Err(DapAbort::InvalidTask { detail, .. })) => {
                 assert_eq!(detail, "unimplemented VDAF type (1337)");
             }
             (_, r) => panic!("unexpected result: {r:?} ({version})"),

--- a/daphne/src/testing.rs
+++ b/daphne/src/testing.rs
@@ -499,7 +499,7 @@ impl AggregationJobTest {
 //
 // and
 //
-//     something_draftlatest
+//     something_draft09
 //
 // that called something(version) with the appropriate version.
 //
@@ -522,7 +522,7 @@ macro_rules! test_versions {
     ($($fname:ident),*) => {
         $(
             $crate::test_version! { $fname, Draft02 }
-            $crate::test_version! { $fname, DraftLatest }
+            $crate::test_version! { $fname, Draft09 }
         )*
     };
 }
@@ -544,7 +544,8 @@ macro_rules! async_test_versions {
     ($($fname:ident),*) => {
         $(
             $crate::async_test_version! { $fname, Draft02 }
-            $crate::async_test_version! { $fname, DraftLatest }
+            $crate::async_test_version! { $fname, Draft09 }
+            $crate::async_test_version! { $fname, Latest }
         )*
     };
 }

--- a/daphne/src/vdaf/mastic.rs
+++ b/daphne/src/vdaf/mastic.rs
@@ -242,19 +242,18 @@ mod test {
 
     use super::*;
     use crate::{
-        hpke::HpkeKemId, testing::AggregationJobTest, vdaf::VdafConfig, DapAggregateResult,
-        DapMeasurement, DapVersion,
+        async_test_version, hpke::HpkeKemId, testing::AggregationJobTest, vdaf::VdafConfig,
+        DapAggregateResult, DapMeasurement, DapVersion,
     };
 
-    #[tokio::test]
-    async fn roundtrip_count() {
+    async fn roundtrip_count(version: DapVersion) {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Mastic {
                 input_size: 4,
                 weight_config: MasticWeightConfig::Count,
             },
             HpkeKemId::X25519HkdfSha256,
-            DapVersion::DraftLatest,
+            version,
         );
         let got = t
             .roundtrip(
@@ -292,4 +291,7 @@ mod test {
 
         assert_eq!(got, DapAggregateResult::U64Vec(vec![1, 2]));
     }
+
+    async_test_version! { roundtrip_count, Draft09 }
+    async_test_version! { roundtrip_count, Latest }
 }

--- a/daphne_server/Cargo.toml
+++ b/daphne_server/Cargo.toml
@@ -41,6 +41,7 @@ clap = { version = "4.4.18", features = ["derive"] }
 config = "0.13.4"
 daphne = { path = "../daphne", features = ["test-utils"] }
 daphne_service_utils = { path = "../daphne_service_utils", features = ["prometheus"] }
+paste.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 tower = "0.4.13"

--- a/daphne_server/src/lib.rs
+++ b/daphne_server/src/lib.rs
@@ -55,7 +55,7 @@ mod storage_proxy_connection;
 ///     report_shard_count: 4,
 ///     base_url: None,
 ///     taskprov: None,
-///     default_version: DapVersion::DraftLatest,
+///     default_version: DapVersion::Draft09,
 ///     report_storage_epoch_duration: 300,
 ///     report_storage_max_future_time_skew: 300,
 /// };

--- a/daphne_server/src/router/helper.rs
+++ b/daphne_server/src/router/helper.rs
@@ -56,7 +56,7 @@ where
                 app.server_metrics(),
                 match req.version {
                     daphne::DapVersion::Draft02 => StatusCode::OK,
-                    daphne::DapVersion::DraftLatest => StatusCode::CREATED,
+                    daphne::DapVersion::Draft09 | daphne::DapVersion::Latest => StatusCode::CREATED,
                 },
             )
         }

--- a/daphne_server/src/router/leader.rs
+++ b/daphne_server/src/router/leader.rs
@@ -110,7 +110,7 @@ where
             AppendHeaders([(header::LOCATION, uri.as_str())]),
         )
             .into_response(),
-        (Ok(_), DapVersion::DraftLatest) => StatusCode::CREATED.into_response(),
+        (Ok(_), DapVersion::Draft09 | DapVersion::Latest) => StatusCode::CREATED.into_response(),
         (Err(e), _) => AxumDapResponse::new_error(e, app.server_metrics()).into_response(),
     }
 }

--- a/daphne_worker/src/storage_proxy.rs
+++ b/daphne_worker/src/storage_proxy.rs
@@ -49,7 +49,7 @@
 //!     bindings::AggregateStore::Merge,
 //!     // some mock data here
 //!     (
-//!         daphne::DapVersion::DraftLatest,
+//!         daphne::DapVersion::Draft09,
 //!         "some-task-id-in-hex",
 //!         &daphne::DapBatchBucket::TimeInterval { batch_window: 50 }
 //!     ),

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -289,7 +289,7 @@ async fn leader_upload(version: DapVersion) {
     );
     let builder = match t.version {
         DapVersion::Draft02 => client.post(url.as_str()),
-        DapVersion::DraftLatest => client.put(url.as_str()),
+        DapVersion::Draft09 | DapVersion::Latest => client.put(url.as_str()),
     };
     let resp = builder
         .body(
@@ -300,7 +300,7 @@ async fn leader_upload(version: DapVersion) {
                     time: t.now,
                     draft02_extensions: match version {
                         DapVersion::Draft02 => Some(Vec::default()),
-                        DapVersion::DraftLatest => None,
+                        DapVersion::Draft09 | DapVersion::Latest => None,
                     },
                 },
                 public_share: b"public share".to_vec(),
@@ -621,7 +621,7 @@ async fn leader_collect_ok(version: DapVersion) {
 
     if version != DapVersion::Draft02 {
         // Check that the time interval for the reports is correct.
-        let interval = collection.draft_latest_interval.as_ref().unwrap();
+        let interval = collection.draft09_interval.as_ref().unwrap();
         let low = t.task_config.quantized_time_lower_bound(time_min);
         let high = t.task_config.quantized_time_upper_bound(time_max);
         assert!(low < high);
@@ -1026,7 +1026,7 @@ async_test_versions! { leader_collect_abort_overlapping_batch_interval }
 
 #[tokio::test]
 async fn fixed_size() {
-    let version = DapVersion::DraftLatest;
+    let version = DapVersion::Draft09;
     let t = TestRunner::fixed_size(version).await;
     let path = t.upload_path();
     let client = TestRunner::http_client();
@@ -1064,7 +1064,7 @@ async fn fixed_size() {
         draft02_task_id: t.collect_task_id_field(),
         query: match version {
             DapVersion::Draft02 => Query::FixedSizeByBatchId { batch_id },
-            DapVersion::DraftLatest => Query::FixedSizeCurrentBatch,
+            DapVersion::Draft09 | DapVersion::Latest => Query::FixedSizeCurrentBatch,
         },
         agg_param: agg_param.get_encoded().unwrap(),
     };
@@ -1164,7 +1164,7 @@ async fn fixed_size() {
         draft02_task_id: t.collect_task_id_field(),
         query: match version {
             DapVersion::Draft02 => Query::FixedSizeByBatchId { batch_id },
-            DapVersion::DraftLatest => Query::FixedSizeCurrentBatch,
+            DapVersion::Draft09 | DapVersion::Latest => Query::FixedSizeCurrentBatch,
         },
         agg_param: agg_param.get_encoded().unwrap(),
     };
@@ -1255,7 +1255,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     for _ in 0..t.task_config.min_batch_size {
         let extensions = vec![Extension::Taskprov {
             draft02_payload: match version {
-                DapVersion::DraftLatest => None,
+                DapVersion::Draft09 | DapVersion::Latest => None,
                 DapVersion::Draft02 => taskprov_report_extension_payload.clone(),
             },
         }];

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -79,12 +79,8 @@ impl TestRunner {
 
         // When running in a local development environment, override the hostname of each
         // aggregator URL with 127.0.0.1.
-        let version_path = match version {
-            DapVersion::Draft02 => "v02",
-            DapVersion::DraftLatest => "v09",
-        };
-        let mut leader_url = Url::parse(&format!("http://leader:8787/{version_path}/")).unwrap();
-        let mut helper_url = Url::parse(&format!("http://helper:8788/{version_path}/")).unwrap();
+        let mut leader_url = Url::parse(&format!("http://leader:8787/{version}/")).unwrap();
+        let mut helper_url = Url::parse(&format!("http://helper:8788/{version}/")).unwrap();
         println!("leader_url = {leader_url}");
         if let Ok(env) = std::env::var("DAP_DEPLOYMENT") {
             if env == "dev" {
@@ -295,7 +291,7 @@ impl TestRunner {
                 HpkeConfig::get_decoded(&raw_leader_hpke_config).unwrap(),
                 HpkeConfig::get_decoded(&raw_helper_hpke_config).unwrap(),
             ],
-            DapVersion::DraftLatest => {
+            DapVersion::Draft09 | DapVersion::Latest => {
                 let mut leader_hpke_config_list =
                     HpkeConfigList::get_decoded(&raw_leader_hpke_config).unwrap();
                 let mut helper_hpke_config_list =
@@ -710,14 +706,16 @@ impl TestRunner {
     pub fn upload_path_for_task(&self, id: &TaskId) -> String {
         match self.version {
             DapVersion::Draft02 => "upload".to_string(),
-            DapVersion::DraftLatest => format!("tasks/{}/reports", id.to_base64url()),
+            DapVersion::Draft09 | DapVersion::Latest => {
+                format!("tasks/{}/reports", id.to_base64url())
+            }
         }
     }
 
     pub fn collect_path_for_task(&self, task_id: &TaskId) -> String {
         match self.version {
             DapVersion::Draft02 => "collect".to_string(),
-            DapVersion::DraftLatest => {
+            DapVersion::Draft09 | DapVersion::Latest => {
                 let collection_job_id = CollectionJobId(thread_rng().gen());
                 format!(
                     "tasks/{}/collection_jobs/{}",


### PR DESCRIPTION
Change `DapVersion::DraftLatest` to `DapVersion::Draft09` and use `DapVersion::Latest` to track the next draft we'll target (currently draft 10, which is not yet published). So far there are no substantive changes in the next draft, but changes will be required to enable Mastic in its "heavy hitters" mode of operation.