### PR TITLE
Simplify `DapReportInitializer`

### DIFF
--- a/daphne/src/protocol/aggregator.rs
+++ b/daphne/src/protocol/aggregator.rs
@@ -436,14 +436,7 @@ impl DapTaskConfig {
             }
         }
         let initialized_reports = initializer
-            .initialize_reports(
-                true,
-                task_id,
-                self,
-                part_batch_sel,
-                agg_param,
-                consumed_reports,
-            )
+            .initialize_reports(true, self, agg_param, consumed_reports)
             .await?;
 
         assert_eq!(initialized_reports.len(), helper_shares.len());
@@ -569,14 +562,7 @@ impl DapTaskConfig {
                 .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
         let initialized_reports = initializer
-            .initialize_reports(
-                false,
-                task_id,
-                self,
-                &agg_job_init_req.part_batch_sel,
-                &agg_param,
-                consumed_reports,
-            )
+            .initialize_reports(false, self, &agg_param, consumed_reports)
             .await?;
 
         Ok(initialized_reports)

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -11,9 +11,7 @@ use crate::{
     constants::DapMediaType,
     error::DapAbort,
     hpke::{HpkeConfig, HpkeDecrypter},
-    messages::{
-        BatchId, BatchSelector, HpkeConfigList, PartialBatchSelector, ReportId, TaskId, Time,
-    },
+    messages::{BatchId, BatchSelector, HpkeConfigList, ReportId, TaskId, Time},
     metrics::{DaphneMetrics, DaphneRequestType},
     protocol::aggregator::{EarlyReportStateConsumed, EarlyReportStateInitialized},
     DapAggregateShare, DapAggregateSpan, DapAggregationParam, DapError, DapGlobalConfig,
@@ -26,12 +24,10 @@ use crate::{
 pub trait DapReportInitializer {
     /// Initialize a sequence of reports that are in the "consumed" state by initializing VDAF
     /// preparation.
-    async fn initialize_reports<'req>(
+    async fn initialize_reports(
         &self,
         is_leader: bool,
-        task_id: &TaskId,
         task_config: &DapTaskConfig,
-        part_batch_sel: &PartialBatchSelector,
         agg_param: &DapAggregationParam,
         consumed_reports: Vec<EarlyReportStateConsumed>,
     ) -> Result<Vec<EarlyReportStateInitialized>, DapError>;

--- a/daphne_server/src/roles/aggregator.rs
+++ b/daphne_server/src/roles/aggregator.rs
@@ -10,10 +10,7 @@ use daphne::{
     error::DapAbort,
     fatal_error,
     hpke::{HpkeConfig, HpkeDecrypter},
-    messages::{
-        BatchId, BatchSelector, HpkeCiphertext, PartialBatchSelector, TaskId, Time,
-        TransitionFailure,
-    },
+    messages::{BatchId, BatchSelector, HpkeCiphertext, TaskId, Time, TransitionFailure},
     metrics::DaphneMetrics,
     roles::{aggregator::MergeAggShareError, DapAggregator, DapReportInitializer},
     DapAggregateShare, DapAggregateSpan, DapAggregationParam, DapBatchBucket, DapError,
@@ -357,12 +354,10 @@ impl DapAggregator<DaphneAuth> for crate::App {
 
 #[async_trait]
 impl DapReportInitializer for crate::App {
-    async fn initialize_reports<'req>(
+    async fn initialize_reports(
         &self,
         is_leader: bool,
-        _task_id: &TaskId,
         task_config: &DapTaskConfig,
-        _part_batch_sel: &PartialBatchSelector,
         agg_param: &DapAggregationParam,
         consumed_reports: Vec<EarlyReportStateConsumed>,
     ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {


### PR DESCRIPTION
Long ago, an implementation of this trait was responsible for some of the early report validation checks, including checking for replays and batch overlaps. These days it is used solely for initializing preparation for a set of reports.

However, `MockAggregator` currently does a bit more, in particular what `DapAggregator::try_put_agg_share_span()` already does. After removing this code, we can simplify the `DapReportInitializer` API so that it does only what it's supposed to do.