### PR TITLE
Improvements to test code

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -269,6 +269,15 @@ pub struct DapAggregateSpan<T> {
     span: HashMap<DapBatchBucket, (T, Vec<(ReportId, Time)>)>,
 }
 
+impl std::fmt::Display for DapBatchBucket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimeInterval { batch_window } => write!(f, "window/{batch_window}"),
+            Self::FixedSize { batch_id } => write!(f, "batch/{}", batch_id.to_hex()),
+        }
+    }
+}
+
 // We can't derive default because it will require T to be Default, which we don't need.
 impl<T> Default for DapAggregateSpan<T> {
     fn default() -> Self {
@@ -799,6 +808,20 @@ pub enum DapAggregationParam {
     Empty,
     #[cfg(any(test, feature = "test-utils"))]
     Mastic(Poplar1AggregationParam),
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl DapAggregationParam {
+    /// Return the aggregation level for the aggregation parameter. Replay protection is enforced
+    /// with respect to this value.
+    //
+    // TODO heavy hitters: Decide if we're comfortable with this level of abstraction.
+    pub(crate) fn level(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::Mastic(agg_param) => agg_param.level(),
+        }
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -166,7 +166,7 @@ mod test {
         },
         roles::leader::WorkItem,
         test_versions,
-        testing::MockAggregator,
+        testing::InMemoryAggregator,
         vdaf::{mastic::MasticWeight, MasticWeightConfig, Prio3Config, VdafConfig},
         DapAbort, DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapCollectionJob,
         DapError, DapGlobalConfig, DapLeaderAggregationJobTransition, DapMeasurement,
@@ -419,8 +419,8 @@ mod test {
             task_id
         }
 
-        pub fn new_helper(&self) -> Arc<MockAggregator> {
-            Arc::new(MockAggregator::new_helper(
+        pub fn new_helper(&self) -> Arc<InMemoryAggregator> {
+            Arc::new(InMemoryAggregator::new_helper(
                 self.tasks.clone(),
                 self.global_config
                     .gen_hpke_receiver_config_list(thread_rng().gen())
@@ -434,8 +434,8 @@ mod test {
             ))
         }
 
-        pub fn with_leader(self, helper: Arc<MockAggregator>) -> Test {
-            let leader = Arc::new(MockAggregator::new_leader(
+        pub fn with_leader(self, helper: Arc<InMemoryAggregator>) -> Test {
+            let leader = Arc::new(InMemoryAggregator::new_leader(
                 self.tasks,
                 self.global_config
                     .gen_hpke_receiver_config_list(thread_rng().gen())
@@ -469,8 +469,8 @@ mod test {
 
     pub(super) struct Test {
         now: Time,
-        leader: Arc<MockAggregator>,
-        helper: Arc<MockAggregator>,
+        leader: Arc<InMemoryAggregator>,
+        helper: Arc<InMemoryAggregator>,
         collector_token: BearerToken,
         taskprov_collector_token: BearerToken,
         time_interval_task_id: TaskId,

--- a/daphne_service_utils/src/durable_requests/bindings.rs
+++ b/daphne_service_utils/src/durable_requests/bindings.rs
@@ -98,14 +98,7 @@ define_do_binding! {
 
     fn name((version, task_id_hex, bucket): (DapVersion, &'n str, &'n DapBatchBucket)) -> ObjectIdFrom {
         fn durable_name_bucket(bucket: &DapBatchBucket) -> String {
-            match bucket {
-                DapBatchBucket::TimeInterval { batch_window } => {
-                    format!("window/{batch_window}")
-                }
-                DapBatchBucket::FixedSize { batch_id } => {
-                    format!("batch/{}", batch_id.to_hex())
-                }
-            }
+            format!("{bucket}")
         }
         ObjectIdFrom::Name(format!(
             "{}/{}",
@@ -164,4 +157,28 @@ define_do_binding! {
         ))
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use daphne::{messages::BatchId, DapBatchBucket};
+
+    // We use `std::fmt::Display` for `DapBatchBucket` to format names for DO instances. Ensure
+    // that they are formatted the way we expect.
+    #[test]
+    fn bucket_display() {
+        assert_eq!(
+            "batch/1111111111111111111111111111111111111111111111111111111111111111",
+            format!(
+                "{}",
+                DapBatchBucket::FixedSize {
+                    batch_id: BatchId([17; 32])
+                }
+            )
+        );
+        assert_eq!(
+            "window/1337",
+            format!("{}", DapBatchBucket::TimeInterval { batch_window: 1337 })
+        );
+    }
 }


### PR DESCRIPTION
Stacked on #523 

In preparation for supporting heavy hitters, make some changes to `daphne::testing::MockAggregator`:
1. Make aggregate storage look more like `daphne_server::App`
2. Rename to `InMemoryAggregator`