### PR TITLE
Improve ready check by propagating the check to the storage as well.

### DIFF
--- a/daphne_server/src/roles/mod.rs
+++ b/daphne_server/src/roles/mod.rs
@@ -63,6 +63,24 @@ mod test_utils {
             Ok(())
         }
 
+        pub(crate) async fn storage_ready_check(&self) -> Result<(), DapError> {
+            use daphne_service_utils::durable_requests::STORAGE_READY;
+            self.http
+                .get(self.storage_proxy_config.url.join(STORAGE_READY).unwrap())
+                .header(
+                    DAP_STORAGE_AUTH_TOKEN,
+                    self.storage_proxy_config
+                        .auth_token
+                        .to_standard_header_value(),
+                )
+                .send()
+                .await
+                .map_err(|e| fatal_error!(err = ?e))?
+                .error_for_status()
+                .map_err(|e| fatal_error!(err  = ?e))?;
+            Ok(())
+        }
+
         pub(crate) fn internal_endpoint_for_task(
             &self,
             version: DapVersion,

--- a/daphne_server/src/router/test_routes.rs
+++ b/daphne_server/src/router/test_routes.rs
@@ -46,7 +46,7 @@ where
 
     router
         .route("/internal/delete_all", post(delete_all))
-        .route("/internal/test/ready", post(StatusCode::OK))
+        .route("/internal/test/ready", post(check_storage_readyness))
         .route(
             "/internal/test/endpoint_for_task",
             post(endpoint_for_task_default),
@@ -62,6 +62,14 @@ where
             "/:version/internal/test/add_hpke_config",
             post(add_hpke_config),
         )
+}
+
+#[tracing::instrument(skip(app))]
+async fn check_storage_readyness(State(app): State<Arc<App>>) -> Response {
+    match app.storage_ready_check().await {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(e) => AxumDapResponse::new_error(e, &*app.metrics).into_response(),
+    }
 }
 
 #[tracing::instrument(skip(app))]

--- a/daphne_service_utils/src/durable_requests/mod.rs
+++ b/daphne_service_utils/src/durable_requests/mod.rs
@@ -71,6 +71,9 @@ pub const DO_PATH_PREFIX: &str = "/v1/do";
 #[cfg(feature = "test-utils")]
 /// The path of the purge request, which wipes all storage. This is meant for tests only.
 pub const PURGE_STORAGE: &str = "/v1/purge";
+#[cfg(feature = "test-utils")]
+/// The path used to check for readyness
+pub const STORAGE_READY: &str = "/v1/ready";
 
 /// The way the target object's id will be obtained.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/daphne_worker/src/storage_proxy.rs
+++ b/daphne_worker/src/storage_proxy.rs
@@ -136,7 +136,12 @@ pub async fn handle_request(
         #[cfg(feature = "test-utils")]
         if let Some("") = path.strip_prefix(daphne_service_utils::durable_requests::PURGE_STORAGE) {
             return storage_purge(env).await;
+        } else if let Some("") =
+            path.strip_prefix(daphne_service_utils::durable_requests::STORAGE_READY)
+        {
+            return Response::ok("");
         }
+
         tracing::error!("path {path:?} was invalid");
         Response::error("invalid base path", 400)
     }

--- a/daphne_worker_test/docker/storage_proxy.Dockerfile
+++ b/daphne_worker_test/docker/storage_proxy.Dockerfile
@@ -28,6 +28,5 @@ RUN apk add --update npm bash
 RUN npm install -g miniflare@2.14.0
 COPY --from=builder /tmp/dap_test/daphne_worker_test/wrangler.toml /wrangler.toml
 COPY --from=builder /tmp/dap_test/daphne_worker_test/build/worker/* /build/worker/
-EXPOSE 8080
 # `-B ""` to skip build command.
 ENTRYPOINT ["miniflare", "--modules", "--modules-rule=CompiledWasm=**/*.wasm", "/build/worker/shim.mjs", "-B", ""]


### PR DESCRIPTION
This should help minimize flakyness by making sure tests only run when
both the service and storage layers are up and ready.
