### PR TITLE
Make argument parsing in dapf more consistent.

### DIFF
--- a/daphne_service_utils/dapf/Cargo.toml
+++ b/daphne_service_utils/dapf/Cargo.toml
@@ -1,3 +1,4 @@
+# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 [package]
@@ -13,7 +14,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.79"
-clap = { version = "4.4.18", features = ["derive"] }
+clap = { version = "4.4.18", features = ["derive", "env"] }
 daphne = { path = "../../daphne", features = ["test-utils", "prometheus"] }
 daphne_service_utils = { path = ".." }
 prio.workspace = true

--- a/daphne_service_utils/dapf/src/acceptance/mod.rs
+++ b/daphne_service_utils/dapf/src/acceptance/mod.rs
@@ -149,13 +149,13 @@ impl Test {
 
     pub fn from_env(
         helper_url: Url,
+        vdaf_config: VdafConfig,
         hpke_signing_certificate_path: Option<PathBuf>,
     ) -> Result<Self> {
         const LEADER_BEARER_TOKEN_VAR: &str = "LEADER_BEARER_TOKEN";
         const LEADER_TLS_CLIENT_CERT_VAR: &str = "LEADER_TLS_CLIENT_CERT";
         const LEADER_TLS_CLIENT_KEY_VAR: &str = "LEADER_TLS_CLIENT_KEY";
         const VDAF_VERIFY_INIT_VAR: &str = "VDAF_VERIFY_INIT";
-        const VDAF_CONFIG: &str = "VDAF_CONFIG";
 
         let leader_bearer_token = env::var(LEADER_BEARER_TOKEN_VAR).ok();
         let leader_tls_client_cert = env::var(LEADER_TLS_CLIENT_CERT_VAR).ok();
@@ -196,18 +196,6 @@ impl Test {
         let http_client = http_client_builder
             .build()
             .with_context(|| "failed to build HTTP client")?;
-
-        let vdaf_config = env::var(VDAF_CONFIG)
-            .ok()
-            .map_or(Ok(VdafConfig::Prio2 { dimension: 44 }), |c| {
-                serde_json::from_str(&c)
-            })
-            .unwrap_or_else(|_| {
-                panic!(
-                    "VDAF_CONFIG {:?} is not a valid config type",
-                    env::var(VDAF_CONFIG)
-                )
-            });
 
         Test::new(
             http_client,


### PR DESCRIPTION
Also make use of the `env` atribute to make the CLI easier to script and
use. All options annotated with `env` can be set in the environment
instead of being passed as command line arguments.

And finally removed the option to pass a bearer token through the
commmand line to avoid accidentally leaking secrets to a user's bash
history.
