### PR TITLE
Fix bugs in draft-dcook-ppm-dap-interop-test-design

### DIFF
--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -179,7 +179,7 @@ impl TestRunner {
                 .then(|url| async {
                     (
                         t.http_client
-                            .get(url.join("/internal/test/ready").unwrap())
+                            .post(url.join("/internal/test/ready").unwrap())
                             .send()
                             .await
                             .map(|r| r.status()),


### PR DESCRIPTION
Running our Helper against Janus' Leader revealed a few minor bugs in our implementation of the interop API:

- POST /internal/test/ready instead of GET
- POST /internal/test/add_task was returning 500s

Also, add a method for Janus's test runner to conveniently configure an HPKE config: POST /internal/test/add_hpke_config