### PR TITLE
Remove draft-ietf-ppm-dap-02

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -787,6 +787,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -1286,6 +1287,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2691,6 +2698,28 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ ring = "0.17.8"
 serde = { version = "1.0.197", features = ["derive"] }
 serde-wasm-bindgen = "0.5.0"
 serde_json = "1.0.114"
+strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.58"
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ under active development in the PPM working group of the IETF.
 
 Daphne currently implements:
 
-* draft-ietf-ppm-dap-02
-    * VDAF: draft-irtf-cfrg-vdaf-03
-    * Taskprov extension: draft-wang-ppm-dap-taskprov-02
 * draft-ietf-ppm-dap-09
     * VDAF: draft-irtf-cfrg-vdaf-08
     * Taskprov extension: draft-wang-ppm-dap-taskprov-06
+    * Interop test API: draft-dcook-ppm-dap-interop-test-design-07
+* draft-ietf-ppm-dap-10 (work-in-progress)
 
 This software is intended to support experimental DAP deployments and is not yet
 suitable for use in production. Daphne will evolve along with the DAP draft:

--- a/daphne/Cargo.toml
+++ b/daphne/Cargo.toml
@@ -47,6 +47,7 @@ paste.workspace = true
 prio = { workspace = true, features = ["test-util"] }
 prometheus.workspace = true
 regex.workspace = true
+strum.workspace = true
 tokio.workspace = true
 
 [features]

--- a/daphne/src/constants.rs
+++ b/daphne/src/constants.rs
@@ -6,14 +6,6 @@
 use crate::{DapSender, DapVersion};
 
 // Media types for HTTP requests.
-const DRAFT02_MEDIA_TYPE_AGG_CONT_REQ: &str = "application/dap-aggregate-continue-req";
-const DRAFT02_MEDIA_TYPE_AGG_CONT_RESP: &str = "application/dap-aggregate-continue-resp";
-const DRAFT02_MEDIA_TYPE_AGG_INIT_REQ: &str = "application/dap-aggregate-initialize-req";
-const DRAFT02_MEDIA_TYPE_AGG_INIT_RESP: &str = "application/dap-aggregate-initialize-resp";
-const DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP: &str = "application/dap-aggregate-share-resp";
-const DRAFT02_MEDIA_TYPE_COLLECT_RESP: &str = "application/dap-collect-resp";
-const DRAFT02_MEDIA_TYPE_HPKE_CONFIG: &str = "application/dap-hpke-config";
-const MEDIA_TYPE_AGG_JOB_CONT_REQ: &str = "application/dap-aggregation-job-continue-req";
 const MEDIA_TYPE_AGG_JOB_INIT_REQ: &str = "application/dap-aggregation-job-init-req";
 const MEDIA_TYPE_AGG_JOB_RESP: &str = "application/dap-aggregation-job-resp";
 const MEDIA_TYPE_AGG_SHARE_REQ: &str = "application/dap-aggregate-share-req";
@@ -25,13 +17,10 @@ const MEDIA_TYPE_REPORT: &str = "application/dap-report";
 
 /// Media type for each DAP request. This is included in the "content-type" HTTP header.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(test, derive(strum::EnumIter))]
 pub enum DapMediaType {
     AggregationJobInitReq,
     AggregationJobResp,
-    AggregationJobContinueReq,
-    /// draft02 compatibility: the latest draft doesn't define a separate media type for initialize
-    /// and continue responses, but draft02 does.
-    Draft02AggregateContinueResp,
     AggregateShareReq,
     AggregateShare,
     CollectReq,
@@ -46,119 +35,44 @@ impl DapMediaType {
     pub fn sender(&self) -> DapSender {
         match self {
             Self::AggregationJobInitReq
-            | Self::AggregationJobContinueReq
             | Self::AggregateShareReq
             | Self::Collection
             | Self::HpkeConfigList => DapSender::Leader,
-            Self::AggregationJobResp
-            | Self::Draft02AggregateContinueResp
-            | Self::AggregateShare => DapSender::Helper,
+            Self::AggregationJobResp | Self::AggregateShare => DapSender::Helper,
             Self::Report => DapSender::Client,
             Self::CollectReq => DapSender::Collector,
         }
     }
 
     /// Parse the media type from the content-type HTTP header.
-    pub fn from_str_for_version(version: DapVersion, content_type: &str) -> Option<Self> {
+    pub fn from_str_for_version(_version: DapVersion, content_type: &str) -> Option<Self> {
         let (content_type, _) = content_type.split_once(';').unwrap_or((content_type, ""));
-        let media_type = match (version, content_type) {
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_CONT_REQ) => {
-                Self::AggregationJobContinueReq
-            }
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_CONT_RESP) => {
-                Self::Draft02AggregateContinueResp
-            }
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_INIT_REQ) => {
-                Self::AggregationJobInitReq
-            }
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_JOB_RESP) => {
-                Self::AggregationJobResp
-            }
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_AGG_SHARE) => {
-                Self::AggregateShare
-            }
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_COLLECT_RESP)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_COLLECTION) => Self::Collection,
-            (DapVersion::Draft02, DRAFT02_MEDIA_TYPE_HPKE_CONFIG)
-            | (DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_HPKE_CONFIG_LIST) => {
-                Self::HpkeConfigList
-            }
-            (
-                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
-                MEDIA_TYPE_AGG_SHARE_REQ,
-            ) => Self::AggregateShareReq,
-            (
-                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
-                MEDIA_TYPE_COLLECT_REQ,
-            ) => Self::CollectReq,
-            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, MEDIA_TYPE_REPORT) => {
-                Self::Report
-            }
-            (_, _) => return None,
+        let media_type = match content_type {
+            MEDIA_TYPE_AGG_JOB_INIT_REQ => Self::AggregationJobInitReq,
+            MEDIA_TYPE_AGG_JOB_RESP => Self::AggregationJobResp,
+            MEDIA_TYPE_AGG_SHARE => Self::AggregateShare,
+            MEDIA_TYPE_COLLECTION => Self::Collection,
+            MEDIA_TYPE_HPKE_CONFIG_LIST => Self::HpkeConfigList,
+            MEDIA_TYPE_AGG_SHARE_REQ => Self::AggregateShareReq,
+            MEDIA_TYPE_COLLECT_REQ => Self::CollectReq,
+            MEDIA_TYPE_REPORT => Self::Report,
+            _ => return None,
         };
         Some(media_type)
     }
 
-    /// Get the content-type representation of the media type.
-    pub fn as_str_for_version(&self, version: DapVersion) -> Option<&'static str> {
-        match (version, self) {
-            (DapVersion::Draft02, Self::AggregationJobInitReq) => {
-                Some(DRAFT02_MEDIA_TYPE_AGG_INIT_REQ)
-            }
-            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobInitReq) => {
-                Some(MEDIA_TYPE_AGG_JOB_INIT_REQ)
-            }
-            (DapVersion::Draft02, Self::AggregationJobResp) => {
-                Some(DRAFT02_MEDIA_TYPE_AGG_INIT_RESP)
-            }
-            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobResp) => {
-                Some(MEDIA_TYPE_AGG_JOB_RESP)
-            }
-            (DapVersion::Draft02, Self::AggregationJobContinueReq) => {
-                Some(DRAFT02_MEDIA_TYPE_AGG_CONT_REQ)
-            }
-            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregationJobContinueReq) => {
-                Some(MEDIA_TYPE_AGG_JOB_CONT_REQ)
-            }
-            (DapVersion::Draft02, Self::Draft02AggregateContinueResp) => {
-                Some(DRAFT02_MEDIA_TYPE_AGG_CONT_RESP)
-            }
-            (
-                DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest,
-                Self::AggregateShareReq,
-            ) => Some(MEDIA_TYPE_AGG_SHARE_REQ),
-            (DapVersion::Draft02, Self::AggregateShare) => Some(DRAFT02_MEDIA_TYPE_AGG_SHARE_RESP),
-            (DapVersion::Draft09 | DapVersion::Latest, Self::AggregateShare) => {
-                Some(MEDIA_TYPE_AGG_SHARE)
-            }
-            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, Self::CollectReq) => {
-                Some(MEDIA_TYPE_COLLECT_REQ)
-            }
-            (DapVersion::Draft02, Self::Collection) => Some(DRAFT02_MEDIA_TYPE_COLLECT_RESP),
-            (DapVersion::Draft09 | DapVersion::Latest, Self::Collection) => {
-                Some(MEDIA_TYPE_COLLECTION)
-            }
-            (DapVersion::Draft02, Self::HpkeConfigList) => Some(DRAFT02_MEDIA_TYPE_HPKE_CONFIG),
-            (DapVersion::Draft09 | DapVersion::Latest, Self::HpkeConfigList) => {
-                Some(MEDIA_TYPE_HPKE_CONFIG_LIST)
-            }
-            (DapVersion::Draft02 | DapVersion::Draft09 | DapVersion::Latest, Self::Report) => {
-                Some(MEDIA_TYPE_REPORT)
-            }
-            (_, Self::Draft02AggregateContinueResp) => None,
-        }
-    }
-
-    /// draft02 compatibility: Construct the media type for the response to an
-    /// `AggregatecontinueResp`. This various depending upon the version used.
-    pub(crate) fn agg_job_cont_resp_for_version(version: DapVersion) -> Self {
-        match version {
-            DapVersion::Draft02 => Self::Draft02AggregateContinueResp,
-            DapVersion::Draft09 | DapVersion::Latest => Self::AggregationJobResp,
+    /// If the media type is used with the current DAP version, then return its representation as
+    /// an HTTP content type.
+    pub fn as_str_for_version(&self, _version: DapVersion) -> Option<&'static str> {
+        match self {
+            Self::AggregationJobInitReq => Some(MEDIA_TYPE_AGG_JOB_INIT_REQ),
+            Self::AggregationJobResp => Some(MEDIA_TYPE_AGG_JOB_RESP),
+            Self::AggregateShareReq => Some(MEDIA_TYPE_AGG_SHARE_REQ),
+            Self::AggregateShare => Some(MEDIA_TYPE_AGG_SHARE),
+            Self::CollectReq => Some(MEDIA_TYPE_COLLECT_REQ),
+            Self::Collection => Some(MEDIA_TYPE_COLLECTION),
+            Self::HpkeConfigList => Some(MEDIA_TYPE_HPKE_CONFIG_LIST),
+            Self::Report => Some(MEDIA_TYPE_REPORT),
         }
     }
 }
@@ -166,66 +80,11 @@ impl DapMediaType {
 #[cfg(test)]
 mod test {
     use super::DapMediaType;
-    use crate::DapVersion;
+    use crate::{test_versions, DapVersion};
+    use strum::IntoEnumIterator;
 
     #[test]
     fn from_str_for_version() {
-        // draft02, Section 8.1
-        assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::Draft02, "application/dap-hpke-config"),
-            Some(DapMediaType::HpkeConfigList)
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-initialize-req"
-            ),
-            Some(DapMediaType::AggregationJobInitReq),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-initialize-resp"
-            ),
-            Some(DapMediaType::AggregationJobResp),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-continue-req"
-            ),
-            Some(DapMediaType::AggregationJobContinueReq),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-continue-resp"
-            ),
-            Some(DapMediaType::Draft02AggregateContinueResp),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-share-req"
-            ),
-            Some(DapMediaType::AggregateShareReq),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft02,
-                "application/dap-aggregate-share-resp"
-            ),
-            Some(DapMediaType::AggregateShare),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::Draft02, "application/dap-collect-req"),
-            Some(DapMediaType::CollectReq),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(DapVersion::Draft02, "application/dap-collect-resp"),
-            Some(DapMediaType::Collection),
-        );
-
         assert_eq!(
             DapMediaType::from_str_for_version(
                 DapVersion::Draft09,
@@ -246,13 +105,6 @@ mod test {
                 "application/dap-aggregation-job-resp"
             ),
             Some(DapMediaType::AggregationJobResp),
-        );
-        assert_eq!(
-            DapMediaType::from_str_for_version(
-                DapVersion::Draft09,
-                "application/dap-aggregation-job-continue-req"
-            ),
-            Some(DapMediaType::AggregationJobContinueReq),
         );
         assert_eq!(
             DapMediaType::from_str_for_version(
@@ -284,65 +136,32 @@ mod test {
         );
     }
 
-    #[test]
-    fn round_trip() {
-        for (version, media_type) in [
-            (DapVersion::Draft02, DapMediaType::AggregationJobInitReq),
-            (DapVersion::Draft09, DapMediaType::AggregationJobInitReq),
-            (DapVersion::Draft02, DapMediaType::AggregationJobResp),
-            (DapVersion::Draft09, DapMediaType::AggregationJobResp),
-            (DapVersion::Draft02, DapMediaType::AggregationJobContinueReq),
-            (DapVersion::Draft09, DapMediaType::AggregationJobContinueReq),
-            (
-                DapVersion::Draft02,
-                DapMediaType::Draft02AggregateContinueResp,
-            ),
-            (DapVersion::Draft02, DapMediaType::AggregateShareReq),
-            (DapVersion::Draft09, DapMediaType::AggregateShareReq),
-            (DapVersion::Draft02, DapMediaType::AggregateShare),
-            (DapVersion::Draft09, DapMediaType::AggregateShare),
-            (DapVersion::Draft02, DapMediaType::CollectReq),
-            (DapVersion::Draft09, DapMediaType::CollectReq),
-            (DapVersion::Draft02, DapMediaType::Collection),
-            (DapVersion::Draft09, DapMediaType::Collection),
-            (DapVersion::Draft02, DapMediaType::HpkeConfigList),
-            (DapVersion::Draft09, DapMediaType::HpkeConfigList),
-            (DapVersion::Draft02, DapMediaType::Report),
-            (DapVersion::Draft09, DapMediaType::Report),
-        ] {
-            assert_eq!(
-                media_type
-                    .as_str_for_version(version)
-                    .and_then(|mime| DapMediaType::from_str_for_version(version, mime)),
-                Some(media_type),
-                "round trip test failed for {version:?} and {media_type:?}"
-            );
+    // Test conversion of DAP media types to and from the content-type HTTP header.
+    fn round_trip(version: DapVersion) {
+        for media_type in DapMediaType::iter() {
+            if let Some(content_type) = media_type.as_str_for_version(version) {
+                // If the DAP media type is used for this version of DAP, then expect decoding the
+                // content-type should result in the same DAP media type.
+                assert_eq!(
+                    DapMediaType::from_str_for_version(version, content_type).unwrap(),
+                    media_type,
+                    "round trip test failed for {version:?} and {media_type:?}"
+                );
+            }
         }
     }
 
-    // Issue #269: Ensure the media type included with the AggregateContinueResp in draft02 is not
-    // overwritten by the media type for AggregationJobResp.
-    #[test]
-    fn media_type_for_agg_cont_req() {
-        assert_eq!(
-            DapMediaType::Draft02AggregateContinueResp,
-            DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft02)
-        );
+    test_versions! { round_trip }
 
-        assert_eq!(
-            DapMediaType::AggregationJobResp,
-            DapMediaType::agg_job_cont_resp_for_version(DapVersion::Draft09)
-        );
-    }
-
-    #[test]
-    fn media_type_parsing_ignores_content_type_paramters() {
+    fn media_type_parsing_ignores_content_type_paramters(version: DapVersion) {
         assert_eq!(
             DapMediaType::from_str_for_version(
-                DapVersion::Draft09,
+                version,
                 "application/dap-aggregation-job-init-req;version=09",
             ),
             Some(DapMediaType::AggregationJobInitReq),
         );
     }
+
+    test_versions! { media_type_parsing_ignores_content_type_paramters }
 }

--- a/daphne/src/protocol/collector.rs
+++ b/daphne/src/protocol/collector.rs
@@ -12,10 +12,7 @@ use crate::{
 };
 use prio::codec::Encode;
 
-use super::{
-    CTX_AGG_SHARE_DRAFT02, CTX_AGG_SHARE_DRAFT09, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER,
-    CTX_ROLE_LEADER,
-};
+use super::{CTX_AGG_SHARE_DRAFT09, CTX_ROLE_COLLECTOR, CTX_ROLE_HELPER, CTX_ROLE_LEADER};
 
 impl VdafConfig {
     /// Decrypt and unshard a sequence of aggregate shares. This method is run by the Collector
@@ -50,10 +47,7 @@ impl VdafConfig {
             ));
         }
 
-        let agg_share_text = match version {
-            DapVersion::Draft02 => CTX_AGG_SHARE_DRAFT02,
-            DapVersion::Draft09 | DapVersion::Latest => CTX_AGG_SHARE_DRAFT09,
-        };
+        let agg_share_text = CTX_AGG_SHARE_DRAFT09;
         let n: usize = agg_share_text.len();
         let mut info = Vec::with_capacity(n + 2);
         info.extend_from_slice(agg_share_text);
@@ -62,10 +56,8 @@ impl VdafConfig {
 
         let mut aad = Vec::with_capacity(40);
         task_id.encode(&mut aad).map_err(DapError::encoding)?;
-        if version != DapVersion::Draft02 {
-            encode_u32_prefixed(version, &mut aad, |_version, bytes| agg_param.encode(bytes))
-                .map_err(DapError::encoding)?;
-        }
+        encode_u32_prefixed(version, &mut aad, |_version, bytes| agg_param.encode(bytes))
+            .map_err(DapError::encoding)?;
         batch_sel.encode(&mut aad).map_err(DapError::encoding)?;
 
         let mut agg_shares = Vec::with_capacity(encrypted_agg_shares.len());

--- a/daphne/src/roles/aggregator.rs
+++ b/daphne/src/roles/aggregator.rs
@@ -15,7 +15,7 @@ use crate::{
     metrics::{DaphneMetrics, DaphneRequestType},
     protocol::aggregator::{EarlyReportStateConsumed, EarlyReportStateInitialized},
     DapAggregateShare, DapAggregateSpan, DapAggregationParam, DapError, DapGlobalConfig,
-    DapRequest, DapResponse, DapTaskConfig, DapVersion,
+    DapRequest, DapResponse, DapTaskConfig,
 };
 
 /// Report initializer. Used by a DAP Aggregator [`DapAggregator`] when initializing an aggregation
@@ -187,17 +187,11 @@ where
         }
     }
 
-    let payload = match req.version {
-        DapVersion::Draft02 => hpke_config
-            .as_ref()
-            .get_encoded()
-            .map_err(DapError::encoding)?,
-        DapVersion::Draft09 | DapVersion::Latest => {
-            let hpke_config_list = HpkeConfigList {
-                hpke_configs: vec![hpke_config.as_ref().clone()],
-            };
-            hpke_config_list.get_encoded().map_err(DapError::encoding)?
-        }
+    let payload = {
+        let hpke_config_list = HpkeConfigList {
+            hpke_configs: vec![hpke_config.as_ref().clone()],
+        };
+        hpke_config_list.get_encoded().map_err(DapError::encoding)?
     };
 
     metrics.inbound_req_inc(DaphneRequestType::HpkeConfig);

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -14,41 +14,40 @@ use crate::{
     error::DapAbort,
     fatal_error,
     messages::{
-        constant_time_eq, AggregateShare, AggregateShareReq, AggregationJobContinueReq,
-        AggregationJobInitReq, AggregationJobResp, Draft02AggregationJobId, PartialBatchSelector,
-        ReportId, TaskId, TransitionFailure, TransitionVar,
+        constant_time_eq, AggregateShare, AggregateShareReq, AggregationJobId,
+        AggregationJobInitReq, AggregationJobResp, PartialBatchSelector, ReportId, TaskId,
+        TransitionFailure, TransitionVar,
     },
     metrics::{DaphneMetrics, DaphneRequestType},
     protocol::aggregator::ReportProcessedStatus,
     roles::aggregator::MergeAggShareError,
     DapAggregateShare, DapAggregateSpan, DapAggregationJobState, DapAggregationParam, DapError,
     DapHelperAggregationJobTransition, DapRequest, DapResource, DapResponse, DapTaskConfig,
-    DapVersion, MetaAggregationJobId,
 };
 
 /// DAP Helper functionality.
+//
+// TODO draft02 cleanup: Remove methods for mutating aggregation job state. This is not needed
+// until we add support for multi-round VDAFs. Note that we will likely still need this trait for
+// features coming in the next draft.
 #[async_trait]
 pub trait DapHelper<S: Sync>: DapAggregator<S> {
     /// Store the Helper's aggregation-flow state unless it already exists. Returns a boolean
     /// indicating if the operation succeeded.
-    async fn put_helper_state_if_not_exists<Id>(
+    async fn put_helper_state_if_not_exists(
         &self,
         task_id: &TaskId,
-        agg_job_id: Id,
+        agg_job_id: &AggregationJobId,
         helper_state: &DapAggregationJobState,
-    ) -> Result<bool, DapError>
-    where
-        Id: Into<MetaAggregationJobId> + Send;
+    ) -> Result<bool, DapError>;
 
     /// Fetch the Helper's aggregation-flow state. `None` is returned if the Helper has no state
     /// associated with the given task and aggregation job.
-    async fn get_helper_state<Id>(
+    async fn get_helper_state(
         &self,
         task_id: &TaskId,
-        agg_job_id: Id,
-    ) -> Result<Option<DapAggregationJobState>, DapError>
-    where
-        Id: Into<MetaAggregationJobId> + Send;
+        agg_job_id: &AggregationJobId,
+    ) -> Result<Option<DapAggregationJobState>, DapError>;
 }
 
 pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
@@ -65,45 +64,7 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
 
     // taskprov: Resolve the task config to use for the request.
     if aggregator.get_global_config().allow_taskprov {
-        // draft02 compatibility: We also need to ensure that all of the reports include the task
-        // config in the report extensions. (See draft-wang-ppm-dap-taskprov-02, Section 6.)
-        let first_metadata = if req.version == DapVersion::Draft02 {
-            let using_taskprov = agg_job_init_req
-                .prep_inits
-                .iter()
-                .filter(|prep_init| {
-                    prep_init
-                        .report_share
-                        .report_metadata
-                        .is_taskprov(req.version, task_id)
-                })
-                .count();
-
-            match using_taskprov {
-                0 => None,
-                c if c == agg_job_init_req.prep_inits.len() => {
-                    // All the extensions use taskprov and look ok, so compute first_metadata.
-                    // Note this will always be Some().
-                    agg_job_init_req
-                        .prep_inits
-                        .first()
-                        .map(|prep_init| &prep_init.report_share.report_metadata)
-                }
-                _ => {
-                    // It's not all taskprov or no taskprov, so it's an error.
-                    return Err(DapAbort::InvalidMessage {
-                        detail: "some reports include the taskprov extensions and some do not"
-                            .to_string(),
-                        task_id: Some(*task_id),
-                    }
-                    .into());
-                }
-            }
-        } else {
-            None
-        };
-
-        resolve_taskprov(aggregator, task_id, req, first_metadata).await?;
+        resolve_taskprov(aggregator, task_id, req).await?;
     }
 
     let wrapped_task_config = aggregator
@@ -121,7 +82,9 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
         .into());
     }
 
-    let agg_job_id = resolve_agg_job_id(req, agg_job_init_req.draft02_agg_job_id.as_ref())?;
+    let DapResource::AggregationJob(_agg_job_id) = req.resource else {
+        return Err(DapAbort::BadRequest("missing aggregation job ID".to_string()).into());
+    };
 
     // Check whether the DAP version in the request matches the task config.
     if task_config.version != req.version {
@@ -142,58 +105,30 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
         .helper_initialize_reports(aggregator, aggregator, task_id, agg_job_init_req)
         .await?;
 
-    let agg_job_resp = match task_config.version {
-        DapVersion::Draft02 => {
-            let DapHelperAggregationJobTransition::Continued(state, agg_job_resp) = task_config
-                .handle_agg_job_init_req(
-                    &HashMap::default(), // no reports have been processed yet
-                    &part_batch_sel,
-                    &initialized_reports,
-                    metrics,
-                )?
-            else {
-                return Err(fatal_error!(err = "unexpected transition"));
-            };
+    let agg_job_resp = {
+        let agg_job_resp = finish_agg_job_and_aggregate(
+            aggregator,
+            task_id,
+            task_config,
+            metrics,
+            |report_status| {
+                let DapHelperAggregationJobTransition::Finished(agg_span, agg_job_resp) =
+                    task_config.handle_agg_job_init_req(
+                        report_status,
+                        &part_batch_sel,
+                        &initialized_reports,
+                    )?
+                else {
+                    return Err(fatal_error!(err = "unexpected transition"));
+                };
+                Ok((agg_span, agg_job_resp))
+            },
+        )
+        .await?;
 
-            if !aggregator
-                .put_helper_state_if_not_exists(task_id, agg_job_id, &state)
-                .await?
-            {
-                return Err(DapAbort::BadRequest(
-                    "unexpected message for aggregation job (already exists)".into(),
-                )
-                .into());
-            }
-            metrics.agg_job_started_inc();
-            agg_job_resp
-        }
-
-        DapVersion::Draft09 | DapVersion::Latest => {
-            let agg_job_resp = finish_agg_job_and_aggregate(
-                aggregator,
-                task_id,
-                task_config,
-                metrics,
-                |report_status| {
-                    let DapHelperAggregationJobTransition::Finished(agg_span, agg_job_resp) =
-                        task_config.handle_agg_job_init_req(
-                            report_status,
-                            &part_batch_sel,
-                            &initialized_reports,
-                            metrics,
-                        )?
-                    else {
-                        return Err(fatal_error!(err = "unexpected transition"));
-                    };
-                    Ok((agg_span, agg_job_resp))
-                },
-            )
-            .await?;
-
-            metrics.agg_job_started_inc();
-            metrics.agg_job_completed_inc();
-            agg_job_resp
-        }
+        metrics.agg_job_started_inc();
+        metrics.agg_job_completed_inc();
+        agg_job_resp
     };
 
     aggregator.audit_log().on_aggregation_job(
@@ -212,86 +147,6 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
     })
 }
 
-pub async fn handle_agg_job_cont_req<'req, S: Sync, A: DapHelper<S>>(
-    aggregator: &A,
-    req: &'req DapRequest<S>,
-) -> Result<DapResponse, DapError> {
-    let task_id = req.task_id()?;
-    let metrics = aggregator.metrics();
-
-    if aggregator.get_global_config().allow_taskprov {
-        resolve_taskprov(aggregator, task_id, req, None).await?;
-    }
-    let wrapped_task_config = aggregator
-        .get_task_config_for(task_id)
-        .await?
-        .ok_or(DapAbort::UnrecognizedTask)?;
-    let task_config = wrapped_task_config.as_ref();
-
-    if let Some(reason) = aggregator.unauthorized_reason(task_config, req).await? {
-        error!("aborted unauthorized collect request: {reason}");
-        return Err(DapAbort::UnauthorizedRequest {
-            detail: reason,
-            task_id: *task_id,
-        }
-        .into());
-    }
-
-    // Check whether the DAP version in the request matches the task config.
-    if task_config.version != req.version {
-        return Err(DapAbort::version_mismatch(req.version, task_config.version).into());
-    }
-
-    let agg_job_cont_req =
-        AggregationJobContinueReq::get_decoded_with_param(&req.version, &req.payload)
-            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
-
-    let agg_job_id = resolve_agg_job_id(req, agg_job_cont_req.draft02_agg_job_id.as_ref())?;
-
-    let state = aggregator
-        .get_helper_state(task_id, agg_job_id)
-        .await?
-        .ok_or_else(|| DapAbort::UnrecognizedAggregationJob {
-            task_id: *task_id,
-            agg_job_id_base64url: agg_job_id.to_base64url(),
-        })?;
-
-    let agg_job_resp =
-        finish_agg_job_and_aggregate(aggregator, task_id, task_config, metrics, |report_status| {
-            task_config.handle_agg_job_cont_req(
-                task_id,
-                &state,
-                report_status,
-                &agg_job_id,
-                &agg_job_cont_req,
-            )
-        })
-        .await?;
-
-    let out_shares_count = agg_job_resp
-        .transitions
-        .iter()
-        .filter(|t| matches!(t.var, TransitionVar::Finished))
-        .count()
-        .try_into()
-        .expect("usize to fit in u64");
-    aggregator.audit_log().on_aggregation_job(
-        aggregator.host(),
-        task_id,
-        task_config,
-        out_shares_count,
-        AggregationJobAuditAction::Continue,
-    );
-
-    metrics.agg_job_completed_inc();
-    metrics.inbound_req_inc(DaphneRequestType::Aggregate);
-    Ok(DapResponse {
-        version: req.version,
-        media_type: DapMediaType::agg_job_cont_resp_for_version(task_config.version),
-        payload: agg_job_resp.get_encoded().map_err(DapError::encoding)?,
-    })
-}
-
 /// Handle a request pertaining to an aggregation job.
 pub async fn handle_agg_job_req<'req, S: Sync, A: DapHelper<S>>(
     aggregator: &A,
@@ -299,10 +154,6 @@ pub async fn handle_agg_job_req<'req, S: Sync, A: DapHelper<S>>(
 ) -> Result<DapResponse, DapError> {
     match req.media_type {
         Some(DapMediaType::AggregationJobInitReq) => handle_agg_job_init_req(aggregator, req).await,
-        Some(DapMediaType::AggregationJobContinueReq) => {
-            handle_agg_job_cont_req(aggregator, req).await
-        }
-        //TODO spec: Specify this behavior.
         _ => Err(DapAbort::BadRequest("unexpected media type".into()).into()),
     }
 }
@@ -320,7 +171,7 @@ pub async fn handle_agg_share_req<'req, S: Sync, A: DapHelper<S>>(
     check_request_content_type(req, DapMediaType::AggregateShareReq)?;
 
     if aggregator.get_global_config().allow_taskprov {
-        resolve_taskprov(aggregator, task_id, req, None).await?;
+        resolve_taskprov(aggregator, task_id, req).await?;
     }
 
     let wrapped_task_config = aggregator
@@ -448,29 +299,8 @@ fn check_part_batch(
     Ok(())
 }
 
-fn resolve_agg_job_id<'id, S>(
-    req: &'id DapRequest<S>,
-    draft02_agg_job_id: Option<&'id Draft02AggregationJobId>,
-) -> Result<MetaAggregationJobId, DapAbort> {
-    // draft02 compatibility: In draft02, the aggregation job ID is parsed from the
-    // HTTP request payload; in the latest, the aggregation job ID is parsed from the
-    // request path.
-    match (req.version, &req.resource, draft02_agg_job_id) {
-        (DapVersion::Draft02, DapResource::Undefined, Some(agg_job_id)) => {
-            Ok(MetaAggregationJobId::Draft02(*agg_job_id))
-        }
-        (
-            DapVersion::Draft09 | DapVersion::Latest,
-            DapResource::AggregationJob(agg_job_id),
-            None,
-        ) => Ok(MetaAggregationJobId::Draft09(*agg_job_id)),
-        (DapVersion::Draft09 | DapVersion::Latest, DapResource::Undefined, None) => {
-            Err(DapAbort::BadRequest("undefined resource".into()))
-        }
-        _ => unreachable!("unhandled resource {:?}", req.resource),
-    }
-}
-
+// TODO draft02 cleanup: Hard-code this now that we don't have to deal with two variants of
+// `finish_agg_job`.
 async fn finish_agg_job_and_aggregate<S: Sync>(
     helper: &impl DapHelper<S>,
     task_id: &TaskId,
@@ -569,119 +399,5 @@ async fn finish_agg_job_and_aggregate<S: Sync>(
 
     // We need to prevent an attacker from keeping this loop running for too long, potentially
     // enabling an DOS attack.
-    Err(DapAbort::BadRequest("AggregationJobContinueReq contained too many replays".into()).into())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-
-    use assert_matches::assert_matches;
-    use futures::StreamExt;
-    use prio::codec::ParameterizedDecode;
-
-    use crate::messages::{AggregationJobInitReq, AggregationJobResp, Transition, TransitionVar};
-    use crate::vdaf::{Prio3Config, VdafConfig};
-    use crate::{assert_metrics_include, MetaAggregationJobId};
-    use crate::{roles::test::TestData, DapVersion};
-
-    #[tokio::test]
-    async fn replay_reports_when_continuing_aggregation_draft02() {
-        let mut data = TestData::new(DapVersion::Draft02);
-        let task_id = data.insert_task(DapVersion::Draft02, VdafConfig::Prio3(Prio3Config::Count));
-        let helper = data.new_helper();
-        let test = data.with_leader(Arc::clone(&helper));
-
-        let reports = futures::stream::iter(0..3)
-            .then(|_| async { test.gen_test_report(&task_id).await })
-            .collect::<Vec<_>>()
-            .await;
-
-        let report_ids = reports
-            .iter()
-            .map(|r| r.report_metadata.id)
-            .collect::<Vec<_>>();
-
-        let (_, req) = test
-            .gen_test_agg_job_init_req(
-                &task_id,
-                DapVersion::Draft02,
-                DapAggregationParam::Empty,
-                reports,
-            )
-            .await;
-
-        let meta_agg_job_id = MetaAggregationJobId::Draft02(
-            AggregationJobInitReq::get_decoded_with_param(&DapVersion::Draft02, &req.payload)
-                .unwrap()
-                .draft02_agg_job_id
-                .unwrap(),
-        );
-
-        super::handle_agg_job_init_req(&*helper, &req)
-            .await
-            .unwrap();
-
-        {
-            let req = test
-                .gen_test_agg_job_cont_req(
-                    &task_id,
-                    &meta_agg_job_id,
-                    report_ids[0..2]
-                        .iter()
-                        .map(|id| Transition {
-                            report_id: *id,
-                            var: TransitionVar::Continued(vec![]),
-                        })
-                        .collect(),
-                    DapVersion::Draft02,
-                )
-                .await;
-
-            let resp = handle_agg_job_cont_req(&*helper, &req).await.unwrap();
-
-            let a_job_resp =
-                AggregationJobResp::get_decoded_with_param(&DapVersion::Draft02, &resp.payload)
-                    .unwrap();
-            assert_eq!(a_job_resp.transitions.len(), 2);
-            assert!(a_job_resp
-                .transitions
-                .iter()
-                .all(|t| matches!(t.var, TransitionVar::Finished)));
-        }
-        {
-            let req = test
-                .gen_test_agg_job_cont_req(
-                    &task_id,
-                    &meta_agg_job_id,
-                    report_ids[1..3]
-                        .iter()
-                        .map(|id| Transition {
-                            report_id: *id,
-                            var: TransitionVar::Continued(vec![]),
-                        })
-                        .collect(),
-                    DapVersion::Draft02,
-                )
-                .await;
-
-            let resp = handle_agg_job_cont_req(&*helper, &req).await.unwrap();
-
-            let a_job_resp =
-                AggregationJobResp::get_decoded_with_param(&DapVersion::Draft02, &resp.payload)
-                    .unwrap();
-            assert_eq!(a_job_resp.transitions.len(), 2);
-            assert_matches!(
-                a_job_resp.transitions[0].var,
-                TransitionVar::Failed(crate::messages::TransitionFailure::ReportReplayed)
-            );
-            assert_matches!(a_job_resp.transitions[1].var, TransitionVar::Finished);
-        };
-
-        assert_metrics_include!(test.helper_registry, {
-            r#"report_counter{env="test_helper",host="helper.org",status="aggregated"}"#: 3,
-            r#"report_counter{env="test_helper",host="helper.org",status="rejected_report_replayed"}"#: 1,
-        });
-    }
+    Err(DapAbort::BadRequest("aggregation job contained too many replays".into()).into())
 }

--- a/daphne_server/src/roles/aggregator.rs
+++ b/daphne_server/src/roles/aggregator.rs
@@ -416,9 +416,8 @@ impl HpkeDecrypter for crate::App {
             .get_mapped::<kv::prefix::HpkeReceiverConfigSet, _, _>(&version, |config_list| {
                 // Assume the first HPKE config in the receiver list has the highest preference.
                 //
-                // NOTE draft02 compatibility: The spec allows us to return multiple configs, but
-                // draft02 does not. In order to keep things imple we preserve the semantics of the old
-                // version for now.
+                // TODO draft02 cleanup: Return the entire list and not just a single HPKE config.
+                // Note that we previously returned one because this was required in draft02.
                 config_list
                     .iter()
                     .next()

--- a/daphne_server/src/roles/leader.rs
+++ b/daphne_server/src/roles/leader.rs
@@ -72,7 +72,7 @@ impl DapLeader<DaphneAuth> for crate::App {
     async fn init_collect_job(
         &self,
         task_id: &TaskId,
-        coll_job_id: &Option<CollectionJobId>,
+        coll_job_id: &CollectionJobId,
         batch_sel: BatchSelector,
         agg_param: DapAggregationParam,
     ) -> Result<url::Url, DapError> {

--- a/daphne_server/src/router/helper.rs
+++ b/daphne_server/src/router/helper.rs
@@ -54,15 +54,8 @@ where
             AxumDapResponse::from_result_with_success_code(
                 resp,
                 app.server_metrics(),
-                match req.version {
-                    daphne::DapVersion::Draft02 => StatusCode::OK,
-                    daphne::DapVersion::Draft09 | daphne::DapVersion::Latest => StatusCode::CREATED,
-                },
+                StatusCode::CREATED,
             )
-        }
-        Some(DapMediaType::AggregationJobContinueReq) => {
-            let resp = helper::handle_agg_job_cont_req(&*app, &req).await;
-            AxumDapResponse::from_result(resp, app.server_metrics())
         }
         m => AxumDapResponse::new_error(
             DapAbort::BadRequest(format!("unexpected media type: {m:?}")),

--- a/daphne_service_utils/dapf/src/lib.rs
+++ b/daphne_service_utils/dapf/src/lib.rs
@@ -9,7 +9,6 @@ use std::{io::Cursor, path::Path};
 
 use anyhow::{anyhow, Context};
 use daphne::{
-    hpke::HpkeConfig,
     messages::{decode_base64url_vec, HpkeConfigList},
     DapVersion,
 };
@@ -67,14 +66,7 @@ impl HttpClientExt for Client {
             .map_err(|e| anyhow!("signature not verified: {}", e.to_string()))?;
         }
 
-        match deduce_dap_version_from_url(base_url)? {
-            DapVersion::Draft02 => Ok(HpkeConfigList {
-                hpke_configs: vec![HpkeConfig::get_decoded(&hpke_config_bytes)?],
-            }),
-            DapVersion::Latest | DapVersion::Draft09 => {
-                Ok(HpkeConfigList::get_decoded(&hpke_config_bytes)?)
-            }
-        }
+        Ok(HpkeConfigList::get_decoded(&hpke_config_bytes)?)
     }
 }
 

--- a/daphne_service_utils/dapf/src/main.rs
+++ b/daphne_service_utils/dapf/src/main.rs
@@ -284,7 +284,7 @@ async fn main() -> Result<()> {
                 reqwest::header::HeaderValue::from_str(
                     DapMediaType::Report
                         .as_str_for_version(version)
-                        .expect("failed to construct content-type value"),
+                        .ok_or_else(|| anyhow!("invalid content-type for dap version"))?,
                 )
                 .expect("failecd to construct content-type header"),
             );
@@ -306,7 +306,7 @@ async fn main() -> Result<()> {
         }
         Action::Collect {
             leader_url,
-            task_id,
+            task_id: _,
         } => {
             // Read the batch selector from stdin.
             let mut buf = String::new();
@@ -320,11 +320,6 @@ async fn main() -> Result<()> {
             let version = deduce_dap_version_from_url(&leader_url)?;
             // Construct collect request.
             let collect_req = CollectionReq {
-                draft02_task_id: if version == DapVersion::Draft02 {
-                    Some(task_id)
-                } else {
-                    None
-                },
                 query,
                 agg_param: Vec::default(),
             };
@@ -335,7 +330,7 @@ async fn main() -> Result<()> {
                 reqwest::header::HeaderValue::from_str(
                     DapMediaType::CollectReq
                         .as_str_for_version(version)
-                        .expect("failed to construct content-type value"),
+                        .ok_or_else(|| anyhow!("invalid content-type for dap version"))?,
                 )
                 .expect("failed to construct content-type hader"),
             );

--- a/daphne_service_utils/src/durable_requests/bindings.rs
+++ b/daphne_service_utils/src/durable_requests/bindings.rs
@@ -9,8 +9,8 @@
 use std::collections::HashSet;
 
 use daphne::{
-    messages::{ReportId, TaskId},
-    DapAggregateShare, DapBatchBucket, DapVersion, MetaAggregationJobId,
+    messages::{AggregationJobId, ReportId, TaskId},
+    DapAggregateShare, DapBatchBucket, DapVersion,
 };
 use serde::{Deserialize, Serialize};
 
@@ -148,7 +148,7 @@ define_do_binding! {
         Get = "/internal/do/helper_state/get",
     }
 
-    fn name((version, task_id, agg_job_id): (DapVersion, &'n TaskId, &'n MetaAggregationJobId)) -> ObjectIdFrom {
+    fn name((version, task_id, agg_job_id): (DapVersion, &'n TaskId, &'n AggregationJobId)) -> ObjectIdFrom {
         ObjectIdFrom::Name(format!(
             "{}/task/{}/agg_job/{}",
             version.as_ref(),

--- a/daphne_service_utils/src/durable_requests/mod.rs
+++ b/daphne_service_utils/src/durable_requests/mod.rs
@@ -297,7 +297,7 @@ mod test {
         let (want, _) = DurableRequest::new(
             AggregateStore::Merge,
             (
-                DapVersion::Draft02,
+                DapVersion::Draft09,
                 "some-task-id-hex",
                 &DapBatchBucket::TimeInterval { batch_window: 0 },
             ),
@@ -314,7 +314,7 @@ mod test {
         let (want, _) = DurableRequest::new(
             bindings::AggregateStore::Merge,
             (
-                DapVersion::Draft02,
+                DapVersion::Draft09,
                 "some-task-id-hex",
                 &DapBatchBucket::TimeInterval { batch_window: 0 },
             ),


### PR DESCRIPTION
Partially addresses #537.

Drop support for DAP draft 02 and prune some code that is no longer
needed:

1. Remove `AggregationJobContinueReq`, as this is only needed to support
   multi-round VDAFs. For now we only support 1-round VDAFs.

2. Remove code for draft-wang-ppm-dap-taskprov-02, including processing
   of `TaskConfig` struct carried by report extensions.

2. Remove `MetaAggregationJobId`. This was used to unify shared
   semantics across draft 02 and 09, which have a different syntax for
   aggregation job IDs.

3. Remove the code in draft 02 for generating a collection job ID.

As a result of dropping draft 02, it is possible to further simplify
control flow and some protocol semantics (e.g., returning multiple HPKE
configs). To keep the commit as small as possible, we leave most of
these changes as TODOs.