### PR TITLE
Make test bearer tokens more bash friendly

### DIFF
--- a/daphne_server/examples/configuration-helper.toml
+++ b/daphne_server/examples/configuration-helper.toml
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 port = 8788
 
 [storage_proxy]
@@ -20,10 +23,10 @@ allow_taskprov = true
 [service.taskprov]
 vdaf_verify_key_init = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
 leader_auth = """{
-  "bearer_token": "I am the leader!"
+  "bearer_token": "I-am-the-leader"
 }""" # SECRET
 collector_auth = """{
-  "bearer_token": "I am the collector!"
+  "bearer_token": "I-am-the-collector"
 }""" # SECRET
 hpke_collector_config = """{
     "id": 23,

--- a/daphne_server/examples/configuration-leader.toml
+++ b/daphne_server/examples/configuration-leader.toml
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 port = 8787
 
 [storage_proxy]
@@ -20,10 +23,10 @@ allow_taskprov = true
 [service.taskprov]
 vdaf_verify_key_init = "b029a72fa327931a5cb643dcadcaafa098fcbfac07d990cb9e7c9a8675fafb18" # SECRET
 leader_auth = """{
-  "bearer_token": "I am the leader!"
+  "bearer_token": "I-am-the-leader"
 }""" # SECRET
 collector_auth = """{
-  "bearer_token": "I am the collector!"
+  "bearer_token": "I-am-the-collector"
 }""" # SECRET
 hpke_collector_config = """{
     "id": 23,

--- a/daphne_worker_test/tests/e2e/e2e.rs
+++ b/daphne_worker_test/tests/e2e/e2e.rs
@@ -1286,7 +1286,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let collect_uri = t
         .leader_post_collect_using_token(
             client,
-            "I am the collector!", // DAP_TASKPROV_COLLECTOR_AUTH
+            "I-am-the-collector", // DAP_TASKPROV_COLLECTOR_AUTH
             taskprov_advertisement.as_deref(),
             Some(&task_id),
             collect_req.get_encoded_with_param(&t.version).unwrap(),


### PR DESCRIPTION
Having spaces and a `!` makes it harder/more error prone to write
scripts using these values.
