### PR TITLE
Add Dockerfile.interop_helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ e2e: /tmp/private-key /tmp/certificate
 	export E2E_TEST_HPKE_SIGNING_CERTIFICATE="$$(cat /tmp/certificate)"; \
 	docker-compose -f daphne_server/docker-compose-e2e.yaml up --build --abort-on-container-exit --exit-code-from test
 
+make_interop:
+	docker build . -f ./interop/Dockerfile.interop_helper --tag daphne_interop
+
+run_interop: make_interop
+	docker run -it -p 8788:8788 -P daphne_interop --name daphne_interop
+
 /tmp/private-key:
 	openssl ecparam -name prime256v1 -genkey -noout -out $@
 

--- a/daphne_worker_test/wrangler.storage_proxy.toml
+++ b/daphne_worker_test/wrangler.storage_proxy.toml
@@ -5,6 +5,9 @@ name = "daphne_storage_proxy"
 main = "build/worker/shim.mjs"
 compatibility_date = "2023-12-21"
 
+# This Worker requires `worker-build` in order to package Rust for WASM. In
+# most cases it is preferable to install it ahead of time so that `wrangler
+# dev` starts faster.
 [build]
 command = "cargo install --git https://github.com/cloudflare/workers-rs && worker-build --dev"
 

--- a/interop/Dockerfile.interop_helper
+++ b/interop/Dockerfile.interop_helper
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# A container for running interop tests against the Helper:
+# https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/
+FROM rust:1.76-bookworm AS interop_helper
+WORKDIR /build
+
+# Dependencies:
+#
+# - capnproto: required by a workspace dependency (`capnp`)
+#
+# - colorized-logs: asni2txt is used to remove color from the output of
+#   `wrangler dev`
+#
+# - clang: required to a workspace dependency (`ring`)
+#
+# - make
+#
+# - npm: required to install `wrangler`
+RUN apt update && \
+    apt install -y \
+        capnproto \
+        colorized-logs \
+        clang \
+        make \
+        npm
+
+RUN npm install -g wrangler@3.33.0
+
+# Install worker-build, used to build the storage proxy.
+RUN cargo install --git https://github.com/cloudflare/workers-rs
+
+# Install the WASM target, as required for the storage proxy Worker.
+RUN rustup target add wasm32-unknown-unknown
+
+COPY Cargo.toml Cargo.lock ./
+COPY daphne ./daphne
+COPY daphne_server ./daphne_server
+COPY daphne_service_utils ./daphne_service_utils
+COPY daphne_worker ./daphne_worker
+COPY daphne_worker_test ./daphne_worker_test
+
+# Build the storage proxy.
+WORKDIR /build/daphne_worker_test
+RUN wrangler deploy --dry-run -c wrangler.storage_proxy.toml
+
+# Build the service.
+WORKDIR /build/daphne_server
+RUN cargo build --example service --features test-utils --release
+
+COPY interop/run_interop_helper.sh /run_interop_helper.sh
+
+EXPOSE 8788
+ENTRYPOINT ["/bin/bash", "/run_interop_helper.sh"]

--- a/interop/run_interop_helper.sh
+++ b/interop/run_interop_helper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+
+mkdir /logs
+
+# Start storage proxy.
+cd /build/daphne_worker_test
+nohup wrangler dev --config wrangler.storage_proxy.toml --port 4001 | ansi2txt \
+    > /logs/storage_proxy.log 2>&1 &
+
+# Wait for the storage proxy to come up.
+curl --retry 10 --retry-delay 1 --retry-all-errors -s http://localhost:4001
+
+# Start service.
+nohup env RUST_LOG=info /build/target/release/examples/service -c /build/daphne_server/examples/configuration-helper.toml | ansi2txt \
+    > /logs/service.log 2>&1 &
+
+# Wait for the service to come up.
+curl --retry 10 --retry-delay 1 --retry-all-errors -s -X POST http://localhost:8788/internal/test/ready
+
+wait -n
+exit $?


### PR DESCRIPTION
Add a Dockerfile for driving interop tests against our Helper according to draft-dcook-ppm-dap-interop-test-design-07. To run it:

```
docker build . -f Dockerfile.interop_helper --tag daphne_interop
docker run -it -p 8788:8788 -P daphne_interop
```

To verify it is running:

```
curl http://localhost:8788/internal/test/ready -X POST
```