### PR TITLE
testing: Add aggregation parameter validation logic

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -783,7 +783,7 @@ pub enum DapMeasurement {
 }
 
 /// An aggregation parameter.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DapAggregationParam {
     Empty,
     #[cfg(any(test, feature = "test-utils"))]
@@ -794,8 +794,6 @@ pub enum DapAggregationParam {
 impl DapAggregationParam {
     /// Return the aggregation level for the aggregation parameter. Replay protection is enforced
     /// with respect to this value.
-    //
-    // TODO heavy hitters: Decide if we're comfortable with this level of abstraction.
     pub(crate) fn level(&self) -> usize {
         match self {
             Self::Empty => 0,

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -468,11 +468,11 @@ mod test {
             query: Query,
             task_id: &TaskId,
         ) -> DapRequest<BearerToken> {
-            self.gen_test_coll_job_req_for_agg_param(query, DapAggregationParam::Empty, task_id)
+            self.gen_test_coll_job_req_for_collection(query, DapAggregationParam::Empty, task_id)
                 .await
         }
 
-        pub async fn gen_test_coll_job_req_for_agg_param(
+        pub async fn gen_test_coll_job_req_for_collection(
             &self,
             query: Query,
             agg_param: DapAggregationParam,
@@ -990,7 +990,8 @@ mod test {
             };
             let mut agg_store = t.helper.agg_store.lock().unwrap();
             agg_store
-                .for_collection(task_id, &bucket, &DapAggregationParam::Empty)
+                .for_bucket(task_id, &bucket, &DapAggregationParam::Empty)
+                .unwrap()
                 .reports
                 .insert(report.report_metadata.id);
         }
@@ -1029,7 +1030,8 @@ mod test {
             };
             let mut agg_store = t.helper.agg_store.lock().unwrap();
             agg_store
-                .for_collection(task_id, &bucket, &DapAggregationParam::Empty)
+                .for_bucket(task_id, &bucket, &DapAggregationParam::Empty)
+                .unwrap()
                 .collected = true;
         }
 
@@ -1892,7 +1894,7 @@ mod test {
         );
         leader::handle_coll_job_req(
             &*t.leader,
-            &t.gen_test_coll_job_req_for_agg_param(query, agg_param, task_id)
+            &t.gen_test_coll_job_req_for_collection(query, agg_param, task_id)
                 .await,
         )
         .await


### PR DESCRIPTION
Each VDAF specifies constraints on the aggregation parameter used to aggregate reports:

1. For IDPF-based VDAFs like Mastic, the sequence of aggregation parameters must determine a valid tree traversal.

2. For simple VDAFs like Prio3, only the empty aggregation parameter is valid.

This commit adds code to `InMemoryAggregator` for enforcing aggregation parameter validity.

Note that this logic will eventually need to be implemented by `daphne_server::App`.