### PR TITLE
draft02 cleanup: Simplify state machine

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -880,11 +880,10 @@ impl Encode for DapAggregationJobState {
     }
 }
 
-// TODO(cjpatton) Consider replacing this with an implementation of
-// `ParameterizedDecode<VdafConfig>`. This requires changing the wire format to make the sequence
-// of report states length-prefixed.
 impl DapAggregationJobState {
     /// Decode the Helper state from a byte string.
+    //
+    // TODO draft02 cleanup: Remove this.
     pub fn get_decoded(vdaf_config: &VdafConfig, data: &[u8]) -> Result<Self, DapError> {
         let mut r = std::io::Cursor::new(data);
         let part_batch_sel = PartialBatchSelector::decode(&mut r)
@@ -907,6 +906,11 @@ impl DapAggregationJobState {
             part_batch_sel,
             seq,
         })
+    }
+
+    /// Count the number of reports that can still be aggregated.
+    pub fn report_count(&self) -> usize {
+        self.seq.len()
     }
 }
 
@@ -1000,28 +1004,6 @@ impl DapAggregateShare {
         })?;
         Ok(())
     }
-}
-
-/// Leader state transition during the aggregation flow.
-//
-// TODO draft02 clean up: Hard-code `M`.
-#[cfg_attr(any(test, feature = "test-utils"), derive(Debug))]
-pub enum DapLeaderAggregationJobTransition<M: Debug> {
-    /// Waiting for a response from the Helper.
-    Continued(DapAggregationJobState, M),
-
-    /// Committed to the output shares.
-    Finished(DapAggregateSpan<DapAggregateShare>),
-}
-
-/// Helper state transitions during the aggregation flow.
-#[cfg_attr(any(test, feature = "test-utils"), derive(Debug))]
-pub enum DapHelperAggregationJobTransition<M: Debug> {
-    /// Waiting for a response from the Leader.
-    Continued(DapAggregationJobState, M),
-
-    /// Committed to the output shares.
-    Finished(DapAggregateSpan<DapAggregateShare>, M),
 }
 
 /// DAP sender role.

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -166,8 +166,8 @@ mod test {
         testing::InMemoryAggregator,
         vdaf::{mastic::MasticWeight, MasticWeightConfig, Prio3Config, VdafConfig},
         DapAbort, DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapCollectionJob,
-        DapError, DapGlobalConfig, DapLeaderAggregationJobTransition, DapMeasurement,
-        DapQueryConfig, DapRequest, DapResource, DapTaskConfig, DapTaskParameters, DapVersion,
+        DapError, DapGlobalConfig, DapMeasurement, DapQueryConfig, DapRequest, DapResource,
+        DapTaskConfig, DapTaskParameters, DapVersion,
     };
     use assert_matches::assert_matches;
     use matchit::Router;
@@ -508,22 +508,18 @@ mod test {
 
             let agg_job_id = AggregationJobId(rng.gen());
 
-            let DapLeaderAggregationJobTransition::Continued(leader_state, agg_job_init_req) =
-                task_config
-                    .produce_agg_job_init_req(
-                        &*self.leader,
-                        &*self.leader,
-                        task_id,
-                        &part_batch_sel,
-                        &agg_param,
-                        futures::stream::iter(reports),
-                        &self.leader.metrics,
-                    )
-                    .await
-                    .unwrap()
-            else {
-                panic!("unexpected transition");
-            };
+            let (leader_state, agg_job_init_req) = task_config
+                .produce_agg_job_req(
+                    &*self.leader,
+                    &*self.leader,
+                    task_id,
+                    &part_batch_sel,
+                    &agg_param,
+                    futures::stream::iter(reports),
+                    &self.leader.metrics,
+                )
+                .await
+                .unwrap();
 
             (
                 leader_state,
@@ -696,7 +692,7 @@ mod test {
     async_test_versions! { handle_agg_job_req_invalid_batch_sel }
 
     // TODO(cjpatton) Re-enable this test. We need to refactor so that we can produce the
-    // AggregationJobInitReq without invoking `produce_agg_job_init_req()`, which filters reports
+    // AggregationJobInitReq without invoking `produce_agg_job_req()`, which filters reports
     // passed the expiration date.
     //
     //    async fn handle_agg_job_req_init_expired_task(version: DapVersion) {


### PR DESCRIPTION
In response to `AggregationJobInitReq`: in draft02 the Helper would wait for one more message before computing its agg share span; in draft09 it computes its agg share span immediately. The following types were introduced to deal with this complexity:

DapLeaderAggregationJobTransition
DapHelperAggregationJobTransition

Now that we've removed draft02, we can replace with explicit types and remove the code for handling unexpected transitions.

The new state machine is simply:

- Leader calls `produce_agg_job_req()` to get its `DapAggregationJobState` and the outbound request

- Helper calls `consume_agg_job_req()` to get the initialize reports `Vec<EarlyReportStateInitialized>`

- Helper calls `produce_agg_job_resp()` to get the outbound response and its agg share span

- Leader calls `consume_agg_job_resp()` to get its agg share span