### PR TITLE
Cleanup http header related code

### DIFF
--- a/daphne/src/auth.rs
+++ b/daphne/src/auth.rs
@@ -3,6 +3,8 @@
 
 //! DAP request authorization.
 
+use std::fmt::Display;
+
 use crate::{
     constants::DapMediaType,
     fatal_error,
@@ -23,11 +25,6 @@ pub struct BearerToken {
 impl BearerToken {
     pub fn as_str(&self) -> &str {
         self.raw.as_str()
-    }
-
-    /// Return "Bearer <`bearer_token`>"
-    pub fn to_standard_header_value(&self) -> String {
-        format!("Bearer {}", self.as_str())
     }
 }
 
@@ -58,6 +55,12 @@ impl From<&str> for BearerToken {
 impl AsRef<BearerToken> for BearerToken {
     fn as_ref(&self) -> &Self {
         self
+    }
+}
+
+impl Display for BearerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -1078,7 +1078,8 @@ pub struct DapRequest<S> {
     /// Sender authorization, e.g., a bearer token.
     pub sender_auth: Option<S>,
 
-    /// taskprov: The task advertisement, sent in the "dap-taskprov" header.
+    /// taskprov: The task advertisement, sent in the
+    /// [`DAP_TASKPROV`](daphne_service_utils::http_headers::DAP_TASKPROV) header.
     pub taskprov: Option<String>,
 }
 

--- a/daphne_server/src/roles/leader.rs
+++ b/daphne_server/src/roles/leader.rs
@@ -170,13 +170,13 @@ impl crate::App {
         if let Some(bearer_token) = req.sender_auth.and_then(|auth| auth.bearer_token) {
             headers.insert(
                 HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
-                HeaderValue::from_str(bearer_token.as_ref()).map_err(
-                    |e| fatal_error!(
+                HeaderValue::from_str(bearer_token.as_ref()).map_err(|e| {
+                    fatal_error!(
                         err = ?e,
                         "failed to construct {} header",
                         http_headers::DAP_AUTH_TOKEN
-                    ),
-                )?,
+                    )
+                })?,
             );
         }
 

--- a/daphne_server/src/roles/leader.rs
+++ b/daphne_server/src/roles/leader.rs
@@ -15,7 +15,7 @@ use daphne::{
     roles::{leader::WorkItem, DapAggregator, DapAuthorizedSender, DapLeader},
     DapAggregationParam, DapCollectionJob, DapError, DapRequest, DapResponse, DapTaskConfig,
 };
-use daphne_service_utils::auth::DaphneAuth;
+use daphne_service_utils::{auth::DaphneAuth, http_headers};
 use tracing::{error, info};
 use url::Url;
 
@@ -169,16 +169,20 @@ impl crate::App {
 
         if let Some(bearer_token) = req.sender_auth.and_then(|auth| auth.bearer_token) {
             headers.insert(
-                HeaderName::from_static("dap-auth-token"),
+                HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
                 HeaderValue::from_str(bearer_token.as_ref()).map_err(
-                    |e| fatal_error!(err = ?e, "failed to construct dap-auth-token header"),
+                    |e| fatal_error!(
+                        err = ?e,
+                        "failed to construct {} header",
+                        http_headers::DAP_AUTH_TOKEN
+                    ),
                 )?,
             );
         }
 
         if let Some(taskprov_advertisement) = req.taskprov.as_deref() {
             headers.insert(
-                HeaderName::from_static("dap-taskprov"),
+                HeaderName::from_static(http_headers::DAP_TASKPROV),
                 HeaderValue::from_str(taskprov_advertisement).map_err(
                     |e| fatal_error!(err = ?e, "failed to construct dap-taskprov header"),
                 )?,

--- a/daphne_server/src/roles/mod.rs
+++ b/daphne_server/src/roles/mod.rs
@@ -37,7 +37,7 @@ mod test_utils {
     };
     use prio::codec::Decode;
 
-    use crate::storage_proxy_connection::{kv, DAP_STORAGE_AUTH_TOKEN};
+    use crate::storage_proxy_connection::kv;
 
     impl crate::App {
         pub(crate) async fn internal_delete_all(&self) -> Result<(), DapError> {
@@ -48,12 +48,7 @@ mod test_utils {
 
             self.http
                 .delete(self.storage_proxy_config.url.join(PURGE_STORAGE).unwrap())
-                .header(
-                    DAP_STORAGE_AUTH_TOKEN,
-                    self.storage_proxy_config
-                        .auth_token
-                        .to_standard_header_value(),
-                )
+                .bearer_auth(&self.storage_proxy_config.auth_token)
                 .send()
                 .await
                 .map_err(|e| fatal_error!(err = ?e))?
@@ -67,12 +62,7 @@ mod test_utils {
             use daphne_service_utils::durable_requests::STORAGE_READY;
             self.http
                 .get(self.storage_proxy_config.url.join(STORAGE_READY).unwrap())
-                .header(
-                    DAP_STORAGE_AUTH_TOKEN,
-                    self.storage_proxy_config
-                        .auth_token
-                        .to_standard_header_value(),
-                )
+                .bearer_auth(&self.storage_proxy_config.auth_token)
                 .send()
                 .await
                 .map_err(|e| fatal_error!(err = ?e))?

--- a/daphne_server/src/router/mod.rs
+++ b/daphne_server/src/router/mod.rs
@@ -28,6 +28,7 @@ use daphne::{
 };
 use daphne_service_utils::{
     auth::{DaphneAuth, TlsClientAuth},
+    http_headers,
     metrics::{self, DaphneServiceMetrics},
     DapRole,
 };
@@ -263,7 +264,8 @@ where
         };
 
         let sender_auth = DaphneAuth {
-            bearer_token: extract_header_as_string("DAP-Auth-Token").map(BearerToken::from),
+            bearer_token: extract_header_as_string(http_headers::DAP_AUTH_TOKEN)
+                .map(BearerToken::from),
             cf_tls_client_auth: (|| {
                 // Whatever service ends up fronting this one and terminating mTLS must pass through
                 // these headers.
@@ -298,7 +300,7 @@ where
             None
         };
 
-        let taskprov = extract_header_as_string("dap-taskprov");
+        let taskprov = extract_header_as_string(http_headers::DAP_TASKPROV);
 
         // TODO(mendess): this is very eager, we could redesign DapResponse later to allow for
         // streaming of data.

--- a/daphne_server/src/storage_proxy_connection/kv/mod.rs
+++ b/daphne_server/src/storage_proxy_connection/kv/mod.rs
@@ -139,10 +139,7 @@ impl<'h> Kv<'h> {
         let resp = self
             .http
             .get(self.config.url.join(&key).unwrap())
-            .header(
-                super::DAP_STORAGE_AUTH_TOKEN,
-                self.config.auth_token.to_standard_header_value(),
-            )
+            .bearer_auth(&self.config.auth_token)
             .send()
             .await?;
         if resp.status() == status_http_1_0_to_reqwest_0_11(StatusCode::NOT_FOUND) {
@@ -164,10 +161,7 @@ impl<'h> Kv<'h> {
         tracing::debug!(key, "PUT");
         self.http
             .post(self.config.url.join(&key).unwrap())
-            .header(
-                super::DAP_STORAGE_AUTH_TOKEN,
-                self.config.auth_token.to_standard_header_value(),
-            )
+            .bearer_auth(&self.config.auth_token)
             .body(serde_json::to_vec(&value).unwrap())
             .send()
             .await?
@@ -193,10 +187,7 @@ impl<'h> Kv<'h> {
         let response = self
             .http
             .put(self.config.url.join(&key).unwrap())
-            .header(
-                super::DAP_STORAGE_AUTH_TOKEN,
-                self.config.auth_token.to_standard_header_value(),
-            )
+            .bearer_auth(&self.config.auth_token)
             .body(serde_json::to_vec(&value).unwrap())
             .send()
             .await?;

--- a/daphne_server/src/storage_proxy_connection/mod.rs
+++ b/daphne_server/src/storage_proxy_connection/mod.rs
@@ -19,8 +19,6 @@ pub(crate) use kv::Kv;
 
 use crate::StorageProxyConfig;
 
-pub(crate) const DAP_STORAGE_AUTH_TOKEN: &str = "Authorization";
-
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     #[error("serialization error: {0}")]
@@ -82,10 +80,7 @@ impl<'d, B: DurableMethod + Debug, P: AsRef<[u8]>> RequestBuilder<'d, B, P> {
             .http
             .post(url)
             .body(self.request.into_bytes())
-            .header(
-                DAP_STORAGE_AUTH_TOKEN,
-                self.durable.config.auth_token.to_standard_header_value(),
-            )
+            .bearer_auth(&self.durable.config.auth_token)
             .send()
             .await?;
 

--- a/daphne_service_utils/dapf/src/acceptance/mod.rs
+++ b/daphne_service_utils/dapf/src/acceptance/mod.rs
@@ -38,6 +38,7 @@ use daphne::{
     DapLeaderAggregationJobTransition, DapMeasurement, DapQueryConfig, DapTaskConfig,
     DapTaskParameters, DapVersion, EarlyReportStateConsumed, EarlyReportStateInitialized,
 };
+use daphne_service_utils::http_headers;
 use futures::{StreamExt, TryStreamExt};
 use prio::codec::{Decode, ParameterizedEncode};
 use prometheus::{Encoder, Registry, TextEncoder};
@@ -668,13 +669,13 @@ where
     }
     if let Some(taskprov) = taskprov.into() {
         headers.insert(
-            reqwest::header::HeaderName::from_static("dap-taskprov"),
+            reqwest::header::HeaderName::from_static(http_headers::DAP_TASKPROV),
             reqwest::header::HeaderValue::from_str(taskprov)?,
         );
     }
     if let Some(token) = bearer_token.into() {
         headers.insert(
-            reqwest::header::HeaderName::from_static("dap-auth-token"),
+            reqwest::header::HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
             reqwest::header::HeaderValue::from_str(token.as_ref())?,
         );
     }

--- a/daphne_service_utils/dapf/src/main.rs
+++ b/daphne_service_utils/dapf/src/main.rs
@@ -15,6 +15,7 @@ use daphne::{
     vdaf::VdafConfig,
     DapAggregationParam, DapMeasurement, DapVersion,
 };
+use daphne_service_utils::http_headers;
 use prio::codec::{ParameterizedDecode, ParameterizedEncode};
 use rand::{thread_rng, Rng};
 use reqwest::ClientBuilder;
@@ -431,7 +432,7 @@ async fn main() -> Result<()> {
             );
             if let Ok(token) = std::env::var("LEADER_BEARER_TOKEN") {
                 headers.insert(
-                    reqwest::header::HeaderName::from_static("dap-auth-token"),
+                    reqwest::header::HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
                     reqwest::header::HeaderValue::from_str(&token)?,
                 );
             }

--- a/daphne_service_utils/src/auth.rs
+++ b/daphne_service_utils/src/auth.rs
@@ -27,7 +27,8 @@ pub struct TlsClientAuth {
 // control to that service; Daphne-Worker would just need to verify that Access granted access.
 #[derive(PartialEq)]
 pub struct DaphneAuth {
-    /// Bearer token, expected to appear in the "dap-auth-token" header.
+    /// Bearer token, expected to appear in the
+    /// [`DAP_AUTH_TOKEN`](crate::http_headers::DAP_AUTH_TOKEN) header.
     pub bearer_token: Option<BearerToken>,
 
     /// TLS client authentication. The client uses a certificate when establishing the TLS

--- a/daphne_service_utils/src/http_headers.rs
+++ b/daphne_service_utils/src/http_headers.rs
@@ -1,1 +1,6 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
 pub const HPKE_SIGNATURE: &str = "x-hpke-config-signature";
+pub const DAP_AUTH_TOKEN: &str = "dap-auth-token";
+pub const DAP_TASKPROV: &str = "dap-taskprov";

--- a/daphne_worker_test/tests/e2e/test_runner.rs
+++ b/daphne_worker_test/tests/e2e/test_runner.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-// TODO Figure out why cargo thinks there is dead code here.
-
 use assert_matches::assert_matches;
 use daphne::{
     constants::DapMediaType,
@@ -14,6 +12,7 @@ use daphne::{
     vdaf::{Prio3Config, VdafConfig},
     DapGlobalConfig, DapLeaderProcessTelemetry, DapQueryConfig, DapTaskConfig, DapVersion,
 };
+use daphne_service_utils::http_headers;
 use futures::StreamExt;
 use hpke_rs::{HpkePrivateKey, HpkePublicKey};
 use prio::codec::{Decode, Encode};
@@ -365,7 +364,7 @@ impl TestRunner {
         );
         if let Some(taskprov_advertisement) = taskprov {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-taskprov"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_TASKPROV),
                 reqwest::header::HeaderValue::from_str(taskprov_advertisement).unwrap(),
             );
         }
@@ -410,13 +409,13 @@ impl TestRunner {
         );
         if let Some(token) = dap_auth_token {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-auth-token"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
                 reqwest::header::HeaderValue::from_str(token).unwrap(),
             );
         }
         if let Some(taskprov_advertisement) = taskprov {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-taskprov"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_TASKPROV),
                 reqwest::header::HeaderValue::from_str(taskprov_advertisement).unwrap(),
             );
         }
@@ -469,7 +468,7 @@ impl TestRunner {
         );
         if let Some(taskprov_advertisement) = taskprov {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-taskprov"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_TASKPROV),
                 reqwest::header::HeaderValue::from_str(taskprov_advertisement).unwrap(),
             );
         }
@@ -514,7 +513,7 @@ impl TestRunner {
         );
         if let Some(token) = dap_auth_token {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-auth-token"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
                 reqwest::header::HeaderValue::from_str(token).unwrap(),
             );
         }
@@ -568,12 +567,12 @@ impl TestRunner {
             .unwrap(),
         );
         headers.insert(
-            reqwest::header::HeaderName::from_static("dap-auth-token"),
+            reqwest::header::HeaderName::from_static(http_headers::DAP_AUTH_TOKEN),
             reqwest::header::HeaderValue::from_str(token).unwrap(),
         );
         if let Some(taskprov_advertisement) = taskprov {
             headers.insert(
-                reqwest::header::HeaderName::from_static("dap-taskprov"),
+                reqwest::header::HeaderName::from_static(http_headers::DAP_TASKPROV),
                 reqwest::header::HeaderValue::from_str(taskprov_advertisement).unwrap(),
             );
         }


### PR DESCRIPTION
- Move dap-auth-token and dap-taskprov headers to constants
- Use standard bearer token api in reqwest instead of manually implementing it
