### PR TITLE
messages: Define `AggregationJobInitReqFromStored`

### DIFF
--- a/daphne/src/protocol/aggregator.rs
+++ b/daphne/src/protocol/aggregator.rs
@@ -463,7 +463,7 @@ impl DapTaskConfig {
                         time: metadata.time,
                         report_id: metadata.id,
                     });
-                    prep_inits.push(PrepareInit {
+                    prep_inits.push(PrepareInit::New {
                         report_share: ReportShare {
                             report_metadata: metadata,
                             public_share,
@@ -508,29 +508,44 @@ impl DapTaskConfig {
         {
             let mut processed = HashSet::with_capacity(num_reports);
             for prep_init in agg_job_init_req.prep_inits {
-                if processed.contains(&prep_init.report_share.report_metadata.id) {
+                let report_id = prep_init.report_id();
+                if processed.contains(report_id) {
                     return Err(DapAbort::InvalidMessage {
                         detail: format!(
                             "report ID {} appears twice in the same aggregation job",
-                            prep_init.report_share.report_metadata.id.to_base64url()
+                            report_id.to_base64url()
                         ),
                         task_id: Some(*task_id),
                     }
                     .into());
                 }
-                processed.insert(prep_init.report_share.report_metadata.id);
+                processed.insert(*report_id);
 
-                consumed_reports.push(
-                    EarlyReportStateConsumed::consume(
-                        decrypter,
-                        false,
-                        task_id,
-                        self,
-                        prep_init.report_share,
-                        Some(prep_init.payload),
-                    )
-                    .await?,
-                );
+                consumed_reports.push(match prep_init {
+                    PrepareInit::New {
+                        report_share,
+                        payload,
+                    } => {
+                        EarlyReportStateConsumed::consume(
+                            decrypter,
+                            false,
+                            task_id,
+                            self,
+                            report_share,
+                            Some(payload),
+                        )
+                        .await?
+                    }
+                    #[cfg(any(test, feature = "test-utils"))]
+                    PrepareInit::Stored {
+                        report_metadata: _,
+                        payload: _,
+                    } => {
+                        return Err(fatal_error!(
+                            err = "handling of stored reports is not yet implemented"
+                        ))
+                    }
+                });
             }
         }
 

--- a/daphne/src/protocol/mod.rs
+++ b/daphne/src/protocol/mod.rs
@@ -210,10 +210,7 @@ mod test {
         assert_eq!(agg_job_init_req.agg_param.len(), 0);
         assert_eq!(agg_job_init_req.prep_inits.len(), 3);
         for (prep_init, report) in agg_job_init_req.prep_inits.iter().zip(reports.iter()) {
-            assert_eq!(
-                prep_init.report_share.report_metadata.id,
-                report.report_metadata.id
-            );
+            assert_eq!(prep_init.report_id(), &report.report_metadata.id);
         }
 
         let (agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
@@ -333,7 +330,7 @@ mod test {
             agg_param: Vec::new(),
             part_batch_sel: PartialBatchSelector::TimeInterval,
             prep_inits: vec![
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: report0.report_metadata,
                         public_share: report0.public_share,
@@ -341,7 +338,7 @@ mod test {
                     },
                     payload: b"malformed payload".to_vec(),
                 },
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: report1.report_metadata,
                         public_share: report1.public_share,
@@ -512,7 +509,7 @@ mod test {
         let prep_init_ids = agg_job_init_req
             .prep_inits
             .iter()
-            .map(|r| r.report_share.report_metadata.id)
+            .map(|prep_init| *prep_init.report_id())
             .collect::<Vec<_>>();
         let (helper_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 

--- a/daphne/src/roles/helper.rs
+++ b/daphne/src/roles/helper.rs
@@ -56,7 +56,7 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
     let task_id = req.task_id()?;
     let metrics = aggregator.metrics();
     let agg_job_init_req =
-        AggregationJobInitReq::get_decoded_with_param(&req.version, &req.payload)
+        AggregationJobInitReq::get_decoded_with_param(&(req.version, false), &req.payload)
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     metrics.agg_job_observe_batch_size(agg_job_init_req.prep_inits.len());

--- a/daphne/src/roles/leader/mod.rs
+++ b/daphne/src/roles/leader/mod.rs
@@ -366,7 +366,7 @@ async fn run_agg_job<S: Sync, A: DapLeader<S>>(
             resp_media_type: DapMediaType::AggregationJobResp,
             resource: DapResource::AggregationJob(agg_job_id),
             req_data: agg_job_init_req
-                .get_encoded_with_param(&task_config.version)
+                .get_encoded_with_param(&(task_config.version, false))
                 .map_err(DapError::encoding)?,
             method: LeaderHttpRequestMethod::Put,
             taskprov: taskprov.clone(),

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -528,7 +528,9 @@ mod test {
                     &task_config,
                     Some(&agg_job_id),
                     DapMediaType::AggregationJobInitReq,
-                    agg_job_init_req,
+                    agg_job_init_req
+                        .get_encoded_with_param(&(task_config.version, false))
+                        .unwrap(),
                 )
                 .await,
             )
@@ -552,7 +554,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count,
                     checksum,
-                },
+                }
+                .get_encoded_with_param(&task_config.version)
+                .unwrap(),
             )
             .await
         }
@@ -600,15 +604,14 @@ mod test {
                 .unwrap()
         }
 
-        pub async fn leader_authorized_req<M: ParameterizedEncode<DapVersion>>(
+        pub async fn leader_authorized_req(
             &self,
             task_id: &TaskId,
             task_config: &DapTaskConfig,
             agg_job_id: Option<&AggregationJobId>,
             media_type: DapMediaType,
-            msg: M,
+            payload: Vec<u8>,
         ) -> DapRequest<BearerToken> {
-            let payload = msg.get_encoded_with_param(&task_config.version).unwrap();
             let sender_auth = Some(
                 self.leader
                     .authorize(task_id, task_config, &media_type, &payload)
@@ -676,7 +679,9 @@ mod test {
                         batch_id: BatchId(rng.gen()),
                     },
                     prep_inits: Vec::default(),
-                },
+                }
+                .get_encoded_with_param(&(version, false))
+                .unwrap(),
             )
             .await;
         assert_matches!(
@@ -838,7 +843,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count: 0,
                     checksum: [0; 32],
-                },
+                }
+                .get_encoded_with_param(&version)
+                .unwrap(),
             )
             .await;
         assert_matches!(
@@ -866,7 +873,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count: 0,
                     checksum: [0; 32],
-                },
+                }
+                .get_encoded_with_param(&version)
+                .unwrap(),
             )
             .await;
         assert_matches!(

--- a/daphne_service_utils/dapf/src/acceptance/mod.rs
+++ b/daphne_service_utils/dapf/src/acceptance/mod.rs
@@ -428,7 +428,7 @@ impl Test {
                 .post(url)
                 .body(
                     agg_job_init_req
-                        .get_encoded_with_param(&task_config.version)
+                        .get_encoded_with_param(&(task_config.version, false))
                         .unwrap(),
                 )
                 .headers(headers),


### PR DESCRIPTION
Stacked on #548.

This message is used to aggregate a set of reports that were transmitted in a previous aggregation job. This is required to support heavy hitters in DAP.