### PR TITLE
protocol: Add skeleton for `AggregationJobInitReqFromStored` handling

### DIFF
--- a/daphne/src/lib.rs
+++ b/daphne/src/lib.rs
@@ -69,7 +69,7 @@ use constants::DapMediaType;
 pub use error::DapError;
 use error::FatalDapError;
 use hpke::{HpkeConfig, HpkeKemId};
-use messages::encode_base64url;
+use messages::{encode_base64url, Report, ReportMetadata};
 #[cfg(any(test, feature = "test-utils"))]
 use prio::vdaf::poplar1::Poplar1AggregationParam;
 use prio::{
@@ -1123,6 +1123,18 @@ pub enum DapCollectionJob {
     Done(Collection),
     Pending,
     Unknown,
+}
+
+/// Leader: A report waiting to be aggregated.
+pub enum DapPendingReport {
+    /// This is the first time the report has been aggregated. The Leader still needs to transmit
+    /// the Helper's share.
+    New(Report),
+    /// The report has already been aggregated and is stored by the Leader and Helper.
+    ///
+    /// draft09 compatibility: This variant is needed to support heavy hitters and is only
+    /// constructed in the latest version.
+    Stored(ReportMetadata),
 }
 
 /// Telemetry information for the leader's processing loop.

--- a/daphne/src/protocol/aggregator.rs
+++ b/daphne/src/protocol/aggregator.rs
@@ -10,7 +10,7 @@ use crate::{
     messages::{
         encode_u32_bytes, encode_u32_prefixed, AggregationJobInitReq, AggregationJobResp,
         Base64Encode, BatchSelector, Extension, HpkeCiphertext, PartialBatchSelector,
-        PlaintextInputShare, PrepareInit, Report, ReportId, ReportMetadata, ReportShare, TaskId,
+        PlaintextInputShare, PrepareInit, ReportId, ReportMetadata, ReportShare, TaskId,
         Transition, TransitionFailure, TransitionVar,
     },
     metrics::DaphneMetrics,
@@ -21,7 +21,7 @@ use crate::{
         VdafError, VdafPrepMessage, VdafPrepState, VdafVerifyKey,
     },
     AggregationJobReportState, DapAggregateShare, DapAggregateSpan, DapAggregationJobState,
-    DapAggregationParam, DapError, DapTaskConfig, DapVersion, VdafConfig,
+    DapAggregationParam, DapError, DapPendingReport, DapTaskConfig, DapVersion, VdafConfig,
 };
 use futures::{Stream, StreamExt};
 use prio::codec::{
@@ -83,10 +83,17 @@ pub trait EarlyReportState {
 #[derive(Clone)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub enum EarlyReportStateConsumed {
-    Ready {
+    New {
         metadata: ReportMetadata,
         public_share: Vec<u8>,
         input_share: Vec<u8>,
+        // Set by the Helper.
+        peer_prep_share: Option<Vec<u8>>,
+    },
+    /// draft09 compatibility: This variant is only used in the latest version. It is required to
+    /// support the heavy hitters mode of operation for DAP.
+    Stored {
+        metadata: ReportMetadata,
         // Set by the Helper.
         peer_prep_share: Option<Vec<u8>>,
     },
@@ -214,7 +221,7 @@ impl EarlyReportStateConsumed {
             }
         };
 
-        Ok(Self::Ready {
+        Ok(Self::New {
             metadata: report_share.report_metadata,
             public_share: report_share.public_share,
             peer_prep_share,
@@ -229,9 +236,7 @@ impl EarlyReportStateConsumed {
         self,
         failure: TransitionFailure,
     ) -> EarlyReportStateInitialized {
-        let metadata = match self {
-            Self::Ready { metadata, .. } | Self::Rejected { metadata, .. } => metadata,
-        };
+        let metadata = self.metadata().clone();
         EarlyReportStateInitialized::Rejected { metadata, failure }
     }
 }
@@ -239,12 +244,14 @@ impl EarlyReportStateConsumed {
 impl EarlyReportState for EarlyReportStateConsumed {
     fn metadata(&self) -> &ReportMetadata {
         match self {
-            Self::Ready { metadata, .. } | Self::Rejected { metadata, .. } => metadata,
+            Self::New { metadata, .. }
+            | Self::Stored { metadata, .. }
+            | Self::Rejected { metadata, .. } => metadata,
         }
     }
 
     fn is_ready(&self) -> bool {
-        matches!(self, Self::Ready { .. })
+        matches!(self, Self::New { .. } | Self::Stored { .. })
     }
 }
 
@@ -276,18 +283,25 @@ impl EarlyReportStateInitialized {
         agg_param: &DapAggregationParam,
         early_report_state_consumed: EarlyReportStateConsumed,
     ) -> Result<Self, DapError> {
-        // We need to use this variable for Mastic, which is currently only enabled in tests or
-        // when the feature "test-utils" is enabled.
+        // TODO heavy hitters: Remove this once we use the aggregation parameter when compiling
+        // with the default feature set.
+        #[cfg(not(any(test, feature = "test-utils")))]
         let _ = agg_param;
 
         let (metadata, public_share, input_share, peer_prep_share) =
             match early_report_state_consumed {
-                EarlyReportStateConsumed::Ready {
+                EarlyReportStateConsumed::New {
                     metadata,
                     public_share,
                     input_share,
                     peer_prep_share,
                 } => (metadata, public_share, input_share, peer_prep_share),
+                EarlyReportStateConsumed::Stored { .. } => {
+                    // TODO heavy hitters: Initialize stored reports.
+                    return Err(fatal_error!(
+                        err = "handling of stored reports is not yet implemented"
+                    ));
+                }
                 EarlyReportStateConsumed::Rejected { metadata, failure } => {
                     return Ok(Self::Rejected { metadata, failure })
                 }
@@ -389,7 +403,7 @@ impl DapTaskConfig {
         metrics: &dyn DaphneMetrics,
     ) -> Result<(DapAggregationJobState, AggregationJobInitReq), DapError>
     where
-        S: Stream<Item = Report>,
+        S: Stream<Item = DapPendingReport>,
     {
         let (report_count_hint, _upper_bound) = reports.size_hint();
         let mut consumed_reports = Vec::with_capacity(report_count_hint);
@@ -397,7 +411,13 @@ impl DapTaskConfig {
         {
             let mut processed = HashSet::with_capacity(report_count_hint);
             let mut reports = pin!(reports);
-            while let Some(report) = reports.next().await {
+            while let Some(pending_report) = reports.next().await {
+                let DapPendingReport::New(report) = pending_report else {
+                    // TODO heavy hitters: Initialize stored reports.
+                    return Err(fatal_error!(
+                        err = "handling of stored reports is not yet implemented"
+                    ));
+                };
                 if processed.contains(&report.report_metadata.id) {
                     return Err(fatal_error!(
                         err = "tried to process report sequence with non-unique report IDs",
@@ -426,6 +446,7 @@ impl DapTaskConfig {
                 helper_shares.push(helper_share);
             }
         }
+
         let initialized_reports = initializer
             .initialize_reports(true, self, agg_param, consumed_reports)
             .await?;
@@ -503,11 +524,16 @@ impl DapTaskConfig {
         task_id: &TaskId,
         agg_job_init_req: AggregationJobInitReq,
     ) -> Result<Vec<EarlyReportStateInitialized>, DapError> {
-        let num_reports = agg_job_init_req.prep_inits.len();
+        let AggregationJobInitReq {
+            agg_param,
+            part_batch_sel: _,
+            prep_inits,
+        } = agg_job_init_req;
+        let num_reports = prep_inits.len();
         let mut consumed_reports = Vec::with_capacity(num_reports);
         {
             let mut processed = HashSet::with_capacity(num_reports);
-            for prep_init in agg_job_init_req.prep_inits {
+            for prep_init in prep_inits {
                 let report_id = prep_init.report_id();
                 if processed.contains(report_id) {
                     return Err(DapAbort::InvalidMessage {
@@ -541,17 +567,17 @@ impl DapTaskConfig {
                         report_metadata: _,
                         payload: _,
                     } => {
+                        // TODO heavy hitters: Initialize stored reports.
                         return Err(fatal_error!(
                             err = "handling of stored reports is not yet implemented"
-                        ))
+                        ));
                     }
                 });
             }
         }
 
-        let agg_param =
-            DapAggregationParam::get_decoded_with_param(&self.vdaf, &agg_job_init_req.agg_param)
-                .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+        let agg_param = DapAggregationParam::get_decoded_with_param(&self.vdaf, &agg_param)
+            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
         let initialized_reports = initializer
             .initialize_reports(false, self, &agg_param, consumed_reports)

--- a/daphne/src/protocol/mod.rs
+++ b/daphne/src/protocol/mod.rs
@@ -30,7 +30,7 @@ mod test {
         testing::AggregationJobTest,
         vdaf::{Prio3Config, VdafConfig},
         DapAggregateResult, DapAggregateShare, DapAggregationParam, DapError, DapMeasurement,
-        DapVersion, VdafAggregateShare, VdafPrepMessage, VdafPrepState,
+        DapPendingReport, DapVersion, VdafAggregateShare, VdafPrepMessage, VdafPrepState,
     };
     use assert_matches::assert_matches;
     use hpke_rs::HpkePublicKey;
@@ -204,7 +204,10 @@ mod test {
         ]);
 
         let (agg_job_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.clone().into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 3);
         assert_eq!(agg_job_init_req.agg_param.len(), 0);
@@ -228,7 +231,10 @@ mod test {
         reports[0].encrypted_input_shares[0].payload[0] ^= 1;
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -247,7 +253,10 @@ mod test {
         reports[0].encrypted_input_shares[0].config_id ^= 1;
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -266,7 +275,10 @@ mod test {
         ];
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -285,7 +297,10 @@ mod test {
         reports[0].encrypted_input_shares[1].payload[0] ^= 1;
 
         let (_, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -306,7 +321,10 @@ mod test {
         reports[0].encrypted_input_shares[1].config_id ^= 1;
 
         let (_, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -368,7 +386,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -389,7 +410,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -410,7 +434,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -432,7 +459,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_helper_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -458,7 +488,10 @@ mod test {
         ]);
 
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
 
         let (leader_agg_span, helper_agg_span) = {
@@ -504,7 +537,10 @@ mod test {
         );
 
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let prep_init_ids = agg_job_init_req
             .prep_inits

--- a/daphne/src/roles/leader/mod.rs
+++ b/daphne/src/roles/leader/mod.rs
@@ -26,8 +26,8 @@ use crate::{
         PartialBatchSelector, Query, Report, TaskId,
     },
     metrics::DaphneRequestType,
-    DapAggregationParam, DapCollectionJob, DapError, DapLeaderProcessTelemetry, DapRequest,
-    DapResource, DapResponse, DapTaskConfig,
+    DapAggregationParam, DapCollectionJob, DapError, DapLeaderProcessTelemetry, DapPendingReport,
+    DapRequest, DapResource, DapResponse, DapTaskConfig,
 };
 
 struct LeaderHttpRequestOptions<'p> {
@@ -325,7 +325,7 @@ async fn run_agg_job<S: Sync, A: DapLeader<S>>(
     task_config: &DapTaskConfig,
     part_batch_sel: &PartialBatchSelector,
     agg_param: &DapAggregationParam,
-    reports: Vec<Report>,
+    reports: impl IntoIterator<Item = DapPendingReport>,
 ) -> Result<u64, DapError> {
     let metrics = aggregator.metrics();
 
@@ -572,7 +572,7 @@ pub async fn process<S: Sync, A: DapLeader<S>>(
                         task_config.as_ref(),
                         &part_batch_sel,
                         &agg_param,
-                        reports,
+                        reports.into_iter().map(DapPendingReport::New),
                     )
                     .await
                 });

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -166,8 +166,8 @@ mod test {
         testing::InMemoryAggregator,
         vdaf::{mastic::MasticWeight, MasticWeightConfig, Prio3Config, VdafConfig},
         DapAbort, DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapCollectionJob,
-        DapError, DapGlobalConfig, DapMeasurement, DapQueryConfig, DapRequest, DapResource,
-        DapTaskConfig, DapTaskParameters, DapVersion,
+        DapError, DapGlobalConfig, DapMeasurement, DapPendingReport, DapQueryConfig, DapRequest,
+        DapResource, DapTaskConfig, DapTaskParameters, DapVersion,
     };
     use assert_matches::assert_matches;
     use matchit::Router;
@@ -495,7 +495,7 @@ mod test {
             &self,
             task_id: &TaskId,
             agg_param: DapAggregationParam,
-            reports: Vec<Report>,
+            reports: Vec<DapPendingReport>,
         ) -> (DapAggregationJobState, DapRequest<BearerToken>) {
             let mut rng = thread_rng();
             let task_config = self.leader.unchecked_get_task_config(task_id).await;
@@ -733,7 +733,7 @@ mod test {
             .gen_test_agg_job_init_req(
                 &t.time_interval_task_id,
                 DapAggregationParam::Empty,
-                vec![report],
+                vec![DapPendingReport::New(report)],
             )
             .await;
         req.sender_auth = None;
@@ -931,7 +931,11 @@ mod test {
         let mut report = t.gen_test_report(task_id).await;
         report.encrypted_input_shares[1].payload[0] ^= 0xff; // Cause decryption to fail
         let (_, req) = t
-            .gen_test_agg_job_init_req(task_id, DapAggregationParam::Empty, vec![report])
+            .gen_test_agg_job_init_req(
+                task_id,
+                DapAggregationParam::Empty,
+                vec![DapPendingReport::New(report)],
+            )
             .await;
 
         // Get AggregationJobResp and then extract the transition data from inside.
@@ -959,7 +963,11 @@ mod test {
 
         let report = t.gen_test_report(task_id).await;
         let (_, req) = t
-            .gen_test_agg_job_init_req(task_id, DapAggregationParam::Empty, vec![report])
+            .gen_test_agg_job_init_req(
+                task_id,
+                DapAggregationParam::Empty,
+                vec![DapPendingReport::New(report)],
+            )
             .await;
 
         // Get AggregationJobResp and then extract the transition data from inside.

--- a/daphne_service_utils/dapf/src/acceptance/report_generator.rs
+++ b/daphne_service_utils/dapf/src/acceptance/report_generator.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use daphne::{messages, DapMeasurement, DapTaskConfig, DapVersion};
+use daphne::{messages, DapMeasurement, DapPendingReport, DapTaskConfig, DapVersion};
 use deepsize::DeepSizeOf;
 use futures::Stream;
 use pin_project::pin_project;
@@ -29,11 +29,11 @@ use super::{Now, TestTaskConfig};
 pub struct ReportGenerator {
     len: usize,
     #[pin]
-    ch: mpsc::Receiver<messages::Report>,
+    ch: mpsc::Receiver<DapPendingReport>,
 }
 
 impl Stream for ReportGenerator {
-    type Item = messages::Report;
+    type Item = DapPendingReport;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -115,7 +115,7 @@ impl ReportGenerator {
                         // --
 
                         sender
-                            .blocking_send(report)
+                            .blocking_send(DapPendingReport::New(report))
                             .context("sending generated report")?;
                         anyhow::Ok(())
                     },


### PR DESCRIPTION
Stacked on #552.

Extend `produce_agg_job_req()` and `consume_agg_job_req()` to operate on an `AggregationJobInitReqFromStored` message. The Aggregator is meant to read each report from storage, so a new variant of `EarlyReportStaateConsumed` is also required.