### PR TITLE
Small optimization o batch overlap check

### DIFF
--- a/daphne/src/messages/mod.rs
+++ b/daphne/src/messages/mod.rs
@@ -672,7 +672,7 @@ impl Decode for AggregationJobResp {
 }
 
 /// A batch interval.
-#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub struct Interval {
     pub start: Time,
@@ -704,7 +704,7 @@ impl Decode for Interval {
 }
 
 /// A query issued by the Collector in a collect request.
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub enum Query {

--- a/daphne/src/roles/mod.rs
+++ b/daphne/src/roles/mod.rs
@@ -84,7 +84,7 @@ async fn check_batch<S: Sync>(
     };
 
     // Check that the batch does not overlap with any previously collected batch.
-    if let Some(batch_sel) = query.clone().into_batch_sel() {
+    if let Some(batch_sel) = query.into_batch_sel() {
         if agg.is_batch_overlapping(task_id, &batch_sel).await? {
             return Err(DapAbort::batch_overlap(task_id, query).into());
         }


### PR DESCRIPTION
By iterating the stream instead of collecting to a vector we get the same amount
of concurrency but abort all in flight requests as soon as we get a 'collected'
response. And we avoid allocating a vector.
