### PR TITLE
Move unwraps to tests instead of test_runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
 name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "cap",
  "cfg-if",

--- a/daphne_worker_test/Cargo.toml
+++ b/daphne_worker_test/Cargo.toml
@@ -38,6 +38,7 @@ worker.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+anyhow.workspace = true
 daphne_service_utils = { path = "../daphne_service_utils" }
 futures.workspace = true
 hex.workspace = true


### PR DESCRIPTION
This way, when the panic happens it shows the line of the test that
paniced instead of the line of test runner that paniced. Hopefuly
improving the developer experience of finding out why e2e tests failed.
