### PR TITLE
Feature gate daphne_service_utils dependency on capnproto

### DIFF
--- a/daphne_server/Cargo.toml
+++ b/daphne_server/Cargo.toml
@@ -20,7 +20,7 @@ readme = "../README.md"
 axum.workspace = true
 bincode.workspace = true
 daphne = { path = "../daphne" }
-daphne_service_utils = { path = "../daphne_service_utils" }
+daphne_service_utils = { path = "../daphne_service_utils", features = ["durable_requests"] }
 futures.workspace = true
 hex.workspace = true
 http.workspace = true

--- a/daphne_service_utils/Cargo.toml
+++ b/daphne_service_utils/Cargo.toml
@@ -17,7 +17,7 @@ readme = "../README.md"
 
 [dependencies]
 async-trait.workspace = true
-capnp.workspace = true
+capnp = { workspace = true, optional = true }
 daphne = { path = "../daphne", default-features = false }
 futures.workspace = true
 itertools.workspace = true
@@ -37,12 +37,12 @@ prometheus.workspace = true
 rand.workspace = true
 
 [build-dependencies]
-capnpc = "0.18.1"
+capnpc = { version = "0.18.1", optional = true }
 
 [features]
 test-utils = ["dep:prometheus", "daphne/prometheus", "daphne/test-utils"]
 prometheus = ["dep:prometheus", "daphne/prometheus"]
-test_acceptance = ["dep:prometheus"]
+durable_requests = ["dep:capnp", "dep:capnpc"]
 
 [lints]
 workspace = true

--- a/daphne_service_utils/build.rs
+++ b/daphne_service_utils/build.rs
@@ -1,4 +1,8 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
 fn main() {
+    #[cfg(feature = "durable_requests")]
     ::capnpc::CompilerCommand::new()
         .file("./src/durable_requests/durable_request.capnp")
         .run()

--- a/daphne_service_utils/src/lib.rs
+++ b/daphne_service_utils/src/lib.rs
@@ -7,12 +7,14 @@ use serde::{Deserialize, Serialize};
 
 pub mod auth;
 pub mod config;
+#[cfg(feature = "durable_requests")]
 pub mod durable_requests;
 pub mod http_headers;
 pub mod metrics;
 pub mod test_route_types;
 
 // the generated code expects this module to be defined at the root of the library.
+#[cfg(feature = "durable_requests")]
 mod durable_request_capnp {
     #![allow(dead_code)]
     #![allow(clippy::pedantic)]

--- a/daphne_worker/Cargo.toml
+++ b/daphne_worker/Cargo.toml
@@ -23,7 +23,6 @@ crate-type = ["cdylib", "rlib"]
 bincode.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne", features = ["prometheus"] }
-daphne_service_utils = { path = "../daphne_service_utils", features = ["prometheus"] }
 futures = { workspace = true, optional = true }
 hex.workspace = true
 prio.workspace = true
@@ -39,6 +38,10 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"]}
 tracing.workspace = true
 url.workspace = true
 worker.workspace = true
+
+[dependencies.daphne_service_utils]
+path = "../daphne_service_utils"
+features = ["prometheus", "durable_requests"]
 
 [dev-dependencies]
 daphne = { path = "../daphne", features = ["test-utils"] }


### PR DESCRIPTION
This lets dapf not depend on capnproto which helps keep CI builds simpler.