### PR TITLE
Initial heavy hitters support via Mastic

### DIFF
--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -471,7 +471,7 @@ impl Test {
                 .put(url)
                 .body(
                     agg_job_init_req
-                        .get_encoded_with_param(&task_config.version)
+                        .get_encoded_with_param(&(task_config.version, false))
                         .unwrap(),
                 )
                 .headers(headers),

--- a/crates/dapf/src/acceptance/report_generator.rs
+++ b/crates/dapf/src/acceptance/report_generator.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use daphne::{messages, DapMeasurement, DapTaskConfig, DapVersion};
+use daphne::{messages, DapMeasurement, DapPendingReport, DapTaskConfig, DapVersion};
 use deepsize::DeepSizeOf;
 use futures::Stream;
 use pin_project::pin_project;
@@ -29,11 +29,11 @@ use super::{Now, TestTaskConfig};
 pub struct ReportGenerator {
     len: usize,
     #[pin]
-    ch: mpsc::Receiver<messages::Report>,
+    ch: mpsc::Receiver<DapPendingReport>,
 }
 
 impl Stream for ReportGenerator {
-    type Item = messages::Report;
+    type Item = DapPendingReport;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -115,7 +115,7 @@ impl ReportGenerator {
                         // --
 
                         sender
-                            .blocking_send(report)
+                            .blocking_send(DapPendingReport::New(report))
                             .context("sending generated report")?;
                         anyhow::Ok(())
                     },

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -69,7 +69,7 @@ use constants::DapMediaType;
 pub use error::DapError;
 use error::FatalDapError;
 use hpke::{HpkeConfig, HpkeKemId};
-use messages::encode_base64url;
+use messages::{encode_base64url, Report};
 #[cfg(any(test, feature = "test-utils"))]
 use prio::vdaf::poplar1::Poplar1AggregationParam;
 use prio::{
@@ -1087,6 +1087,18 @@ pub enum DapCollectionJob {
     Done(Collection),
     Pending,
     Unknown,
+}
+
+/// Leader: A report waiting to be aggregated.
+pub enum DapPendingReport {
+    /// This is the first time the report has been aggregated. The Leader still needs to transmit
+    /// the Helper's share.
+    New(Report),
+    /// The report has already been aggregated and is stored by the Leader and Helper.
+    ///
+    /// draft09 compatibility: This variant is needed to support heavy hitters and is only
+    /// constructed in the latest version.
+    Stored(ReportId),
 }
 
 /// Telemetry information for the leader's processing loop.

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -88,7 +88,8 @@ use url::Url;
 use vdaf::mastic::MasticWeight;
 
 pub use protocol::aggregator::{
-    EarlyReportState, EarlyReportStateConsumed, EarlyReportStateInitialized,
+    EarlyReportState, EarlyReportStateConsumed, EarlyReportStateFetched,
+    EarlyReportStateInitialized,
 };
 
 /// DAP version used for a task.
@@ -1090,6 +1091,7 @@ pub enum DapCollectionJob {
 }
 
 /// Leader: A report waiting to be aggregated.
+#[derive(Clone)]
 pub enum DapPendingReport {
     /// This is the first time the report has been aggregated. The Leader still needs to transmit
     /// the Helper's share.
@@ -1099,6 +1101,15 @@ pub enum DapPendingReport {
     /// draft09 compatibility: This variant is needed to support heavy hitters and is only
     /// constructed in the latest version.
     Stored(ReportId),
+}
+
+impl DapPendingReport {
+    pub(crate) fn report_id(&self) -> ReportId {
+        match self {
+            Self::New(report) => report.report_metadata.id,
+            Self::Stored(report_id) => *report_id,
+        }
+    }
 }
 
 /// Telemetry information for the leader's processing loop.

--- a/crates/daphne/src/messages/mod.rs
+++ b/crates/daphne/src/messages/mod.rs
@@ -238,23 +238,16 @@ pub struct ReportMetadata {
     pub time: Time,
 }
 
-impl ParameterizedEncode<DapVersion> for ReportMetadata {
-    fn encode_with_param(
-        &self,
-        _version: &DapVersion,
-        bytes: &mut Vec<u8>,
-    ) -> Result<(), CodecError> {
+impl Encode for ReportMetadata {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
         self.id.encode(bytes)?;
         self.time.encode(bytes)?;
         Ok(())
     }
 }
 
-impl ParameterizedDecode<DapVersion> for ReportMetadata {
-    fn decode_with_param(
-        _version: &DapVersion,
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
+impl Decode for ReportMetadata {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         let metadata = Self {
             id: ReportId::decode(bytes)?,
             time: Time::decode(bytes)?,
@@ -313,26 +306,19 @@ pub struct ReportShare {
     pub encrypted_input_share: HpkeCiphertext,
 }
 
-impl ParameterizedEncode<DapVersion> for ReportShare {
-    fn encode_with_param(
-        &self,
-        version: &DapVersion,
-        bytes: &mut Vec<u8>,
-    ) -> Result<(), CodecError> {
-        self.report_metadata.encode_with_param(version, bytes)?;
+impl Encode for ReportShare {
+    fn encode(&self, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.report_metadata.encode(bytes)?;
         encode_u32_bytes(bytes, &self.public_share)?;
         self.encrypted_input_share.encode(bytes)?;
         Ok(())
     }
 }
 
-impl ParameterizedDecode<DapVersion> for ReportShare {
-    fn decode_with_param(
-        version: &DapVersion,
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
+impl Decode for ReportShare {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         Ok(Self {
-            report_metadata: ReportMetadata::decode_with_param(version, bytes)?,
+            report_metadata: ReportMetadata::decode(bytes)?,
             public_share: decode_u32_bytes(bytes)?,
             encrypted_input_share: HpkeCiphertext::decode(bytes)?,
         })
@@ -450,38 +436,81 @@ impl Default for BatchSelector {
     }
 }
 
-/// The `PrepareInit` message consisting of the report share and the Leader's initial prep share.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
-pub struct PrepareInit {
-    pub report_share: ReportShare,
-    pub payload: Vec<u8>,
+pub enum PrepareInit {
+    New {
+        report_share: ReportShare,
+        payload: Vec<u8>,
+    },
+    /// draft09 compatibility: This variant is only constructed in the latest version, in heavy
+    /// hitters mode.
+    #[cfg(any(test, feature = "test-utils"))]
+    Stored {
+        report_id: ReportId,
+        payload: Vec<u8>,
+    },
 }
 
-impl ParameterizedEncode<DapVersion> for PrepareInit {
-    fn encode_with_param(
-        &self,
-        version: &DapVersion,
-        bytes: &mut Vec<u8>,
-    ) -> Result<(), CodecError> {
-        self.report_share.encode_with_param(version, bytes)?;
-        encode_u32_bytes(bytes, &self.payload)?;
+impl PrepareInit {
+    pub(crate) fn report_id(&self) -> ReportId {
+        match self {
+            Self::New { report_share, .. } => report_share.report_metadata.id,
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Stored { report_id, .. } => *report_id,
+        }
+    }
+}
+
+impl ParameterizedEncode<bool> for PrepareInit {
+    fn encode_with_param(&self, stored: &bool, bytes: &mut Vec<u8>) -> Result<(), CodecError> {
+        match self {
+            Self::New {
+                report_share,
+                payload,
+            } if !*stored => {
+                report_share.encode(bytes)?;
+                encode_u32_bytes(bytes, payload)?;
+            }
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Stored { report_id, payload } if *stored => {
+                report_id.encode(bytes)?;
+                encode_u32_bytes(bytes, payload)?;
+            }
+            _ => {
+                return Err(CodecError::Other(
+                    "unexpected encoding parameter for PrepareInit variant".into(),
+                ))
+            }
+        };
         Ok(())
     }
 }
 
-impl ParameterizedDecode<DapVersion> for PrepareInit {
-    fn decode_with_param(
-        version: &DapVersion,
-        bytes: &mut Cursor<&[u8]>,
-    ) -> Result<Self, CodecError> {
-        let report_share = ReportShare::decode_with_param(version, bytes)?;
-        let payload = decode_u32_bytes(bytes)?;
+impl ParameterizedDecode<bool> for PrepareInit {
+    fn decode_with_param(stored: &bool, bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
+        if !*stored {
+            Ok(Self::New {
+                report_share: ReportShare::decode(bytes)?,
+                payload: decode_u32_bytes(bytes)?,
+            })
+        } else {
+            #[cfg(any(test, feature = "test-utils"))]
+            {
+                Ok(Self::Stored {
+                    report_id: ReportId::decode(bytes)?,
+                    payload: decode_u32_bytes(bytes)?,
+                })
+            }
 
-        Ok(Self {
-            report_share,
-            payload,
-        })
+            // TODO heavy hitters: Remove this exception.
+            #[cfg(not(any(test, feature = "test-utils")))]
+            {
+                Err(CodecError::Other(
+                    "Decoding of AggregationJobInitReqFromStored is not implemented".into(),
+                ))
+            }
+        }
     }
 }
 
@@ -493,29 +522,41 @@ pub struct AggregationJobInitReq {
     pub prep_inits: Vec<PrepareInit>,
 }
 
-impl ParameterizedEncode<DapVersion> for AggregationJobInitReq {
+impl ParameterizedEncode<(DapVersion, bool)> for AggregationJobInitReq {
     fn encode_with_param(
         &self,
-        version: &DapVersion,
+        (version, stored): &(DapVersion, bool),
         bytes: &mut Vec<u8>,
     ) -> Result<(), CodecError> {
-        encode_u32_bytes(bytes, &self.agg_param)?;
-        self.part_batch_sel.encode(bytes)?;
-        encode_u32_items(bytes, version, &self.prep_inits)?;
-        Ok(())
+        if let (DapVersion::Draft09, true) = (version, stored) {
+            Err(CodecError::Other(
+                format!("AggregationJobInitReqFromStored is not specified in {version:?}").into(),
+            ))
+        } else {
+            encode_u32_bytes(bytes, &self.agg_param)?;
+            self.part_batch_sel.encode(bytes)?;
+            encode_u32_items(bytes, stored, &self.prep_inits)?;
+            Ok(())
+        }
     }
 }
 
-impl ParameterizedDecode<DapVersion> for AggregationJobInitReq {
+impl ParameterizedDecode<(DapVersion, bool)> for AggregationJobInitReq {
     fn decode_with_param(
-        version: &DapVersion,
+        (version, stored): &(DapVersion, bool),
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
-        Ok(Self {
-            agg_param: decode_u32_bytes(bytes)?,
-            part_batch_sel: PartialBatchSelector::decode(bytes)?,
-            prep_inits: decode_u32_items(version, bytes)?,
-        })
+        if let (DapVersion::Draft09, true) = (version, stored) {
+            Err(CodecError::Other(
+                format!("AggregationJobInitReqFromStored is not specified in {version:?}").into(),
+            ))
+        } else {
+            Ok(Self {
+                agg_param: decode_u32_bytes(bytes)?,
+                part_batch_sel: PartialBatchSelector::decode(bytes)?,
+                prep_inits: decode_u32_items(stored, bytes)?,
+            })
+        }
     }
 }
 
@@ -1277,7 +1318,7 @@ mod test {
                 batch_id: BatchId([0; 32]),
             },
             prep_inits: vec![
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([99; 16]),
@@ -1292,7 +1333,7 @@ mod test {
                     },
                     payload: b"prep share".to_vec(),
                 },
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([17; 16]),
@@ -1309,9 +1350,13 @@ mod test {
                 },
             ],
         };
-        println!("want {:?}", want.get_encoded_with_param(&version).unwrap());
+        println!(
+            "want {:?}",
+            want.get_encoded_with_param(&(version, false)).unwrap()
+        );
 
-        let got = AggregationJobInitReq::get_decoded_with_param(&version, TEST_DATA).unwrap();
+        let got =
+            AggregationJobInitReq::get_decoded_with_param(&(version, false), TEST_DATA).unwrap();
         assert_eq!(got, want);
     }
 
@@ -1324,7 +1369,7 @@ mod test {
                 batch_id: BatchId([0; 32]),
             },
             prep_inits: vec![
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([99; 16]),
@@ -1339,7 +1384,7 @@ mod test {
                     },
                     payload: b"prep share".to_vec(),
                 },
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: ReportMetadata {
                             id: ReportId([17; 16]),
@@ -1358,14 +1403,44 @@ mod test {
         };
 
         let got = AggregationJobInitReq::get_decoded_with_param(
-            &version,
-            &want.get_encoded_with_param(&version).unwrap(),
+            &(version, false),
+            &want.get_encoded_with_param(&(version, false)).unwrap(),
         )
         .unwrap();
         assert_eq!(got, want);
     }
 
     test_versions! { roundtrip_agg_job_init_req }
+
+    #[test]
+    fn roundtrip_agg_job_init_req_from_stored() {
+        let want = AggregationJobInitReq {
+            agg_param: b"this is an aggregation parameter".to_vec(),
+            part_batch_sel: PartialBatchSelector::FixedSizeByBatchId {
+                batch_id: BatchId([0; 32]),
+            },
+            prep_inits: vec![
+                PrepareInit::Stored {
+                    report_id: ReportId([99; 16]),
+                    payload: b"prep share".to_vec(),
+                },
+                PrepareInit::Stored {
+                    report_id: ReportId([17; 16]),
+                    payload: b"prep share".to_vec(),
+                },
+            ],
+        };
+
+        let got = AggregationJobInitReq::get_decoded_with_param(
+            &(DapVersion::Latest, true),
+            &want
+                .get_encoded_with_param(&(DapVersion::Latest, true))
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(got, want);
+    }
 
     #[test]
     fn read_agg_job_resp() {

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -150,6 +150,7 @@ impl VdafConfig {
             VdafConfig::Mastic {
                 input_size,
                 weight_config,
+                threshold: _,
             } => Ok(mastic_shard(*input_size, *weight_config, measurement)?),
         }
     }

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -88,6 +88,7 @@ impl VdafConfig {
             Self::Mastic {
                 input_size: _,
                 weight_config,
+                threshold: _,
             } => mastic_unshard(*weight_config, agg_param, agg_shares),
         }
         .map_err(DapError::from_vdaf)

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -31,7 +31,7 @@ mod test {
         testing::AggregationJobTest,
         vdaf::{Prio3Config, VdafConfig},
         DapAggregateResult, DapAggregateShare, DapAggregationParam, DapError, DapMeasurement,
-        DapVersion, VdafAggregateShare, VdafPrepMessage, VdafPrepState,
+        DapPendingReport, DapVersion, VdafAggregateShare, VdafPrepMessage, VdafPrepState,
     };
     use assert_matches::assert_matches;
     use hpke_rs::HpkePublicKey;
@@ -207,7 +207,10 @@ mod test {
         ]);
 
         let (agg_job_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.clone().into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 3);
         assert_eq!(agg_job_init_req.agg_param.len(), 0);
@@ -231,7 +234,10 @@ mod test {
         reports[0].encrypted_input_shares[0].payload[0] ^= 1;
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -257,7 +263,10 @@ mod test {
             .unwrap()];
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -283,7 +292,10 @@ mod test {
             .unwrap()];
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -302,7 +314,10 @@ mod test {
         reports[0].encrypted_input_shares[0].config_id ^= 1;
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -321,7 +336,10 @@ mod test {
         ];
 
         let (agg_job_state, _agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         assert_eq!(agg_job_state.report_count(), 0);
 
@@ -340,7 +358,10 @@ mod test {
         reports[0].encrypted_input_shares[1].payload[0] ^= 1;
 
         let (_, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -373,7 +394,10 @@ mod test {
             let tmp = t.valid_report_range.clone();
             t.valid_report_range = 0..u64::max_value();
             let (_, agg_job_init_req) = t
-                .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+                .produce_agg_job_req(
+                    &DapAggregationParam::Empty,
+                    reports.into_iter().map(DapPendingReport::New),
+                )
                 .await;
             t.valid_report_range = tmp;
             agg_job_init_req
@@ -409,7 +433,10 @@ mod test {
             let tmp = t.valid_report_range.clone();
             t.valid_report_range = 0..u64::max_value();
             let (_, agg_job_init_req) = t
-                .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+                .produce_agg_job_req(
+                    &DapAggregationParam::Empty,
+                    reports.into_iter().map(DapPendingReport::New),
+                )
                 .await;
             t.valid_report_range = tmp;
             agg_job_init_req
@@ -433,7 +460,10 @@ mod test {
         reports[0].encrypted_input_shares[1].config_id ^= 1;
 
         let (_, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports.clone())
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -495,7 +525,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -516,7 +549,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -537,7 +573,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1), DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -559,7 +598,10 @@ mod test {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let reports = t.produce_reports(vec![DapMeasurement::U64(1)]);
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let (_helper_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
@@ -585,7 +627,10 @@ mod test {
         ]);
 
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
 
         let (leader_agg_span, helper_agg_span) = {
@@ -631,7 +676,10 @@ mod test {
         );
 
         let (leader_state, agg_job_init_req) = t
-            .produce_agg_job_req(&DapAggregationParam::Empty, reports)
+            .produce_agg_job_req(
+                &DapAggregationParam::Empty,
+                reports.into_iter().map(DapPendingReport::New),
+            )
             .await;
         let prep_init_ids = agg_job_init_req
             .prep_inits

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -213,10 +213,7 @@ mod test {
         assert_eq!(agg_job_init_req.agg_param.len(), 0);
         assert_eq!(agg_job_init_req.prep_inits.len(), 3);
         for (prep_init, report) in agg_job_init_req.prep_inits.iter().zip(reports.iter()) {
-            assert_eq!(
-                prep_init.report_share.report_metadata.id,
-                report.report_metadata.id
-            );
+            assert_eq!(prep_init.report_id(), report.report_metadata.id);
         }
 
         let (agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
@@ -460,7 +457,7 @@ mod test {
             agg_param: Vec::new(),
             part_batch_sel: PartialBatchSelector::TimeInterval,
             prep_inits: vec![
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: report0.report_metadata,
                         public_share: report0.public_share,
@@ -468,7 +465,7 @@ mod test {
                     },
                     payload: b"malformed payload".to_vec(),
                 },
-                PrepareInit {
+                PrepareInit::New {
                     report_share: ReportShare {
                         report_metadata: report1.report_metadata,
                         public_share: report1.public_share,
@@ -639,7 +636,7 @@ mod test {
         let prep_init_ids = agg_job_init_req
             .prep_inits
             .iter()
-            .map(|r| r.report_share.report_metadata.id)
+            .map(|prep_init| prep_init.report_id())
             .collect::<Vec<_>>();
         let (helper_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -309,11 +309,15 @@ async fn finish_agg_job_and_aggregate<S: Sync>(
     const RETRY_COUNT: u32 = 3;
     let mut report_status = HashMap::new();
     for _ in 0..RETRY_COUNT {
-        let (agg_span, agg_job_resp) = task_config.produce_agg_job_resp(
-            &report_status,
-            part_batch_sel,
-            initialized_reports,
-        )?;
+        let (agg_span, agg_job_resp) = task_config
+            .produce_agg_job_resp(
+                helper,
+                task_id,
+                &report_status,
+                part_batch_sel,
+                initialized_reports,
+            )
+            .await?;
 
         let put_shares_result = helper
             .try_put_agg_share_span(task_id, task_config, agg_span)

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -56,7 +56,7 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
     let task_id = req.task_id()?;
     let metrics = aggregator.metrics();
     let agg_job_init_req =
-        AggregationJobInitReq::get_decoded_with_param(&req.version, &req.payload)
+        AggregationJobInitReq::get_decoded_with_param(&(req.version, false), &req.payload)
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     metrics.agg_job_observe_batch_size(agg_job_init_req.prep_inits.len());

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -377,8 +377,9 @@ async fn run_agg_job<S: Sync, A: DapLeader<S>>(
         .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     // Handle AggregationJobResp.
-    let agg_span =
-        task_config.consume_agg_job_resp(task_id, agg_job_state, agg_job_resp, metrics)?;
+    let agg_span = task_config
+        .consume_agg_job_resp(aggregator, task_id, agg_job_state, agg_job_resp, metrics)
+        .await?;
 
     let out_shares_count = agg_span.report_count() as u64;
     if out_shares_count == 0 {

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -366,7 +366,7 @@ async fn run_agg_job<S: Sync, A: DapLeader<S>>(
             resp_media_type: DapMediaType::AggregationJobResp,
             resource: DapResource::AggregationJob(agg_job_id),
             req_data: agg_job_init_req
-                .get_encoded_with_param(&task_config.version)
+                .get_encoded_with_param(&(task_config.version, false))
                 .map_err(DapError::encoding)?,
             method: LeaderHttpRequestMethod::Put,
             taskprov: taskprov.clone(),

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -26,8 +26,8 @@ use crate::{
         PartialBatchSelector, Query, Report, TaskId,
     },
     metrics::{DaphneRequestType, ReportStatus},
-    DapAggregationParam, DapCollectionJob, DapError, DapLeaderProcessTelemetry, DapRequest,
-    DapResource, DapResponse, DapTaskConfig,
+    DapAggregationParam, DapCollectionJob, DapError, DapLeaderProcessTelemetry, DapPendingReport,
+    DapRequest, DapResource, DapResponse, DapTaskConfig,
 };
 
 struct LeaderHttpRequestOptions<'p> {
@@ -325,7 +325,7 @@ async fn run_agg_job<S: Sync, A: DapLeader<S>>(
     task_config: &DapTaskConfig,
     part_batch_sel: &PartialBatchSelector,
     agg_param: &DapAggregationParam,
-    reports: Vec<Report>,
+    reports: impl IntoIterator<Item = DapPendingReport>,
 ) -> Result<u64, DapError> {
     let metrics = aggregator.metrics();
 
@@ -572,7 +572,7 @@ pub async fn process<S: Sync, A: DapLeader<S>>(
                         task_config.as_ref(),
                         &part_batch_sel,
                         &agg_param,
-                        reports,
+                        reports.into_iter().map(DapPendingReport::New),
                     )
                     .await
                 });

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use tracing::warn;
 
-pub use aggregator::{DapAggregator, DapReportInitializer};
+pub use aggregator::{DapAggregator, DapReportProcessor};
 pub use helper::DapHelper;
 pub use leader::{DapAuthorizedSender, DapLeader};
 
@@ -284,6 +284,7 @@ mod test {
             let mastic = VdafConfig::Mastic {
                 input_size: 1,
                 weight_config: MasticWeightConfig::Count,
+                threshold: None,
             };
             tasks.insert(
                 heavy_hitters_task_id,

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -499,7 +499,9 @@ mod test {
                     &task_config,
                     Some(&agg_job_id),
                     DapMediaType::AggregationJobInitReq,
-                    agg_job_init_req,
+                    agg_job_init_req
+                        .get_encoded_with_param(&(task_config.version, false))
+                        .unwrap(),
                 )
                 .await,
             )
@@ -523,7 +525,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count,
                     checksum,
-                },
+                }
+                .get_encoded_with_param(&task_config.version)
+                .unwrap(),
             )
             .await
         }
@@ -571,15 +575,14 @@ mod test {
                 .unwrap()
         }
 
-        pub async fn leader_authorized_req<M: ParameterizedEncode<DapVersion>>(
+        pub async fn leader_authorized_req(
             &self,
             task_id: &TaskId,
             task_config: &DapTaskConfig,
             agg_job_id: Option<&AggregationJobId>,
             media_type: DapMediaType,
-            msg: M,
+            payload: Vec<u8>,
         ) -> DapRequest<BearerToken> {
-            let payload = msg.get_encoded_with_param(&task_config.version).unwrap();
             let sender_auth = Some(
                 self.leader
                     .authorize(task_id, task_config, &media_type, &payload)
@@ -647,7 +650,9 @@ mod test {
                         batch_id: BatchId(rng.gen()),
                     },
                     prep_inits: Vec::default(),
-                },
+                }
+                .get_encoded_with_param(&(version, false))
+                .unwrap(),
             )
             .await;
         assert_matches!(
@@ -809,7 +814,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count: 0,
                     checksum: [0; 32],
-                },
+                }
+                .get_encoded_with_param(&version)
+                .unwrap(),
             )
             .await;
         assert_matches!(
@@ -837,7 +844,9 @@ mod test {
                     agg_param: Vec::default(),
                     report_count: 0,
                     checksum: [0; 32],
-                },
+                }
+                .get_encoded_with_param(&version)
+                .unwrap(),
             )
             .await;
         assert_matches!(

--- a/crates/daphne/src/testing.rs
+++ b/crates/daphne/src/testing.rs
@@ -24,7 +24,8 @@ use crate::{
     },
     DapAbort, DapAggregateResult, DapAggregateShare, DapAggregateSpan, DapAggregationJobState,
     DapAggregationParam, DapBatchBucket, DapCollectionJob, DapError, DapGlobalConfig,
-    DapMeasurement, DapQueryConfig, DapRequest, DapResponse, DapTaskConfig, DapVersion, VdafConfig,
+    DapMeasurement, DapPendingReport, DapQueryConfig, DapRequest, DapResponse, DapTaskConfig,
+    DapVersion, VdafConfig,
 };
 use async_trait::async_trait;
 use deepsize::DeepSizeOf;
@@ -182,7 +183,7 @@ impl AggregationJobTest {
     pub async fn produce_agg_job_req(
         &self,
         agg_param: &DapAggregationParam,
-        reports: Vec<Report>,
+        reports: impl IntoIterator<Item = DapPendingReport>,
     ) -> (DapAggregationJobState, AggregationJobInitReq) {
         self.task_config
             .produce_agg_job_req(
@@ -191,7 +192,7 @@ impl AggregationJobTest {
                 &self.task_id,
                 &PartialBatchSelector::TimeInterval,
                 agg_param,
-                futures::stream::iter(reports),
+                futures::stream::iter(reports.into_iter()),
                 &self.leader_metrics,
             )
             .await
@@ -328,7 +329,10 @@ impl AggregationJobTest {
         };
 
         // Clients: Shard
-        let reports = self.produce_reports(measurements);
+        let reports = self
+            .produce_reports(measurements)
+            .into_iter()
+            .map(DapPendingReport::New);
 
         // Aggregators: Preparation
         let (leader_state, agg_job_init_req) = self.produce_agg_job_req(&agg_param, reports).await;

--- a/crates/daphne/src/vdaf/mod.rs
+++ b/crates/daphne/src/vdaf/mod.rs
@@ -59,6 +59,12 @@ pub enum VdafConfig {
 
         /// The type of each weight.
         weight_config: MasticWeightConfig,
+
+        /// The heavy hitters threshold. If not set, then heavy hitters mode is disabled.
+        ///
+        /// draft09 compatibility: This variant is only used in the latest version of DAP. It is
+        /// used to support heavy hitters mode.
+        threshold: Option<u64>,
     },
 }
 
@@ -79,6 +85,16 @@ impl std::fmt::Display for VdafConfig {
             VdafConfig::Mastic {
                 input_size,
                 weight_config,
+                threshold: Some(threshold),
+            } => write!(
+                f,
+                "Mastic-Heavy-Hitters({input_size}, {weight_config}, {threshold})"
+            ),
+            #[cfg(any(test, feature = "test-utils"))]
+            VdafConfig::Mastic {
+                input_size,
+                weight_config,
+                threshold: None,
             } => write!(f, "Mastic({input_size}, {weight_config})"),
         }
     }

--- a/crates/daphne/src/vdaf/prio2.rs
+++ b/crates/daphne/src/vdaf/prio2.rs
@@ -164,7 +164,7 @@ mod test {
     };
 
     async fn roundtrip(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio2 { dimension: 5 },
             HpkeKemId::X25519HkdfSha256,
             version,

--- a/crates/daphne/src/vdaf/prio3.rs
+++ b/crates/daphne/src/vdaf/prio3.rs
@@ -668,7 +668,7 @@ mod test {
     };
 
     async fn roundtrip_count(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::Count),
             HpkeKemId::X25519HkdfSha256,
             version,
@@ -691,7 +691,7 @@ mod test {
     async_test_versions! { roundtrip_count }
 
     async fn roundtrip_sum(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::Sum { bits: 23 }),
             HpkeKemId::X25519HkdfSha256,
             version,
@@ -714,7 +714,7 @@ mod test {
     async_test_versions! { roundtrip_sum }
 
     async fn roundtrip_sum_vec(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::SumVec {
                 bits: 23,
                 length: 2,
@@ -739,7 +739,7 @@ mod test {
     async_test_versions! { roundtrip_sum_vec }
 
     async fn roundtrip_histogram(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::Histogram {
                 length: 3,
                 chunk_length: 1,
@@ -765,7 +765,7 @@ mod test {
     async_test_versions! { roundtrip_histogram }
 
     async fn roundtrip_sum_vec_field64_multiproof_hmac_sha256_aes128(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
+        let t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                 bits: 23,
                 length: 2,


### PR DESCRIPTION
~Based on #574 (merge that first).~

This is a prototype of proposal 1 from:
https://docs.google.com/document/d/1ZjXz-1kGsTDf2Vn2u-fwYqR8BSc3tOYlELVHAYvAfjk

Daphne will use the Mastic VDAF rather than Poplar1 because we only support 1-round VDAFs. (Poplar1 requires two rounds for preparation.) For now we're working with a dummy version of Mastic, as its implementation is still in progress:
https://github.com/divviup/libprio-rs/issues/947

This is not ready to merge. We need to:
- [ ] Align with the changes we settle on in the DAP specification (some changes will be required if we take proposal 2)
- [ ] Consider fencing changes to `protocol` and `messages` behind the "test-utils" feature
- [ ] Plumb the new code path through `roles` module
- [ ] Additional tests
     - Leader tries to override an existing report
     - Stored report does not exist
     - ...
- [ ] Replace dummy Mastic with the real one
- [ ] Implement VIDPF caching