### PR TITLE
Add acceptance test specific metrics

### DIFF
--- a/daphne_service_utils/dapf/src/acceptance/load_testing.rs
+++ b/daphne_service_utils/dapf/src/acceptance/load_testing.rs
@@ -152,9 +152,6 @@ impl TestResults {
     fn agg_init(&self) -> (Duration, Duration, Duration) {
         self.measurements_of(|d| d.aggregate_init_req)
     }
-    fn agg_cont(&self) -> (Duration, Duration, Duration) {
-        self.measurements_of(|d| d.aggregate_cont_req)
-    }
     fn agg_share(&self) -> (Duration, Duration, Duration) {
         self.measurements_of(|d| d.aggregate_share_req)
     }
@@ -253,11 +250,10 @@ fn print_perf_report(measurments: &HashMap<MeasurementParameters, TestResults>) 
     println!(";success;runs;min;avg;max;min;avg;max;min;avg;max;reports/sec");
     for (param, results) in measurments {
         println!(
-            "{param};{};{};{};{};{};{}",
+            "{param};{};{};{};{};{}",
             results.success_rate,
             results.tests.len(),
             tabularize_durations(results.agg_init()),
-            tabularize_durations(results.agg_cont()),
             tabularize_durations(results.agg_share()),
             {
                 let (sum, c) = results

--- a/daphne_service_utils/dapf/src/main.rs
+++ b/daphne_service_utils/dapf/src/main.rs
@@ -636,7 +636,7 @@ async fn main() -> Result<()> {
                 })
                 .await
                 .map(|_| ());
-            println!("\n\nMETRICS:\n{}\n\n", t.encode_metrics());
+            println!("{}", t.encode_metrics());
             res
         }
         Action::LoadTest {

--- a/daphne_service_utils/dapf/src/test_durations.rs
+++ b/daphne_service_utils/dapf/src/test_durations.rs
@@ -10,7 +10,6 @@ use std::{
 pub struct TestDurations {
     pub hpke_config_fetch: Duration,
     pub aggregate_init_req: Duration,
-    pub aggregate_cont_req: Duration,
     pub aggregate_share_req: Duration,
 }
 
@@ -20,7 +19,6 @@ impl Add<&Self> for TestDurations {
         Self {
             hpke_config_fetch: self.hpke_config_fetch + rhs.hpke_config_fetch,
             aggregate_init_req: self.aggregate_init_req + rhs.aggregate_init_req,
-            aggregate_cont_req: self.aggregate_cont_req + rhs.aggregate_cont_req,
             aggregate_share_req: self.aggregate_share_req + rhs.aggregate_share_req,
         }
     }
@@ -32,7 +30,6 @@ impl Add for TestDurations {
         Self {
             hpke_config_fetch: self.hpke_config_fetch + rhs.hpke_config_fetch,
             aggregate_init_req: self.aggregate_init_req + rhs.aggregate_init_req,
-            aggregate_cont_req: self.aggregate_cont_req + rhs.aggregate_cont_req,
             aggregate_share_req: self.aggregate_share_req + rhs.aggregate_share_req,
         }
     }
@@ -45,7 +42,6 @@ impl Div<u32> for TestDurations {
         Self {
             hpke_config_fetch: self.hpke_config_fetch / rhs,
             aggregate_init_req: self.aggregate_init_req / rhs,
-            aggregate_cont_req: self.aggregate_cont_req / rhs,
             aggregate_share_req: self.aggregate_share_req / rhs,
         }
     }
@@ -59,9 +55,6 @@ impl AsRef<Self> for TestDurations {
 
 impl TestDurations {
     pub fn total_service_time(&self) -> Duration {
-        self.hpke_config_fetch
-            + self.aggregate_init_req
-            + self.aggregate_cont_req
-            + self.aggregate_share_req
+        self.hpke_config_fetch + self.aggregate_init_req + self.aggregate_share_req
     }
 }


### PR DESCRIPTION
This PR first removes the unused test duration of aggregation continuations.

Then it tailors the metrics exported by the test to only contain test relevant
metrics.
