### PR TITLE
Reduce the size of the interop test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ e2e: /tmp/private-key /tmp/certificate
 	export E2E_TEST_HPKE_SIGNING_CERTIFICATE="$$(cat /tmp/certificate)"; \
 	docker-compose -f daphne_server/docker-compose-e2e.yaml up --build --abort-on-container-exit --exit-code-from test
 
-make_interop:
+build_interop:
 	docker build . -f ./interop/Dockerfile.interop_helper --tag daphne_interop
 
-run_interop: make_interop
+run_interop:
 	docker run -it -p 8788:8788 -P daphne_interop --name daphne_interop
 
 /tmp/private-key:

--- a/daphne_worker_test/README.md
+++ b/daphne_worker_test/README.md
@@ -4,7 +4,7 @@ This directory defines a deployment of Daphne-Worker for testing changes
 locally. It also implements integration tests between Daphne and
 Daphne-Worker.
 
-[Wrangler](https://github.com/cloudflare/wrangler2) (>=2.6.2) is used to mock
+[Wrangler](https://github.com/cloudflare/wrangler2) (>=3.50.0) is used to mock
 the Cloudflare Workers platform for local testing. Wrangler is available from
 npm. To run the Leader, do
 

--- a/daphne_worker_test/docker/storage_proxy.Dockerfile
+++ b/daphne_worker_test/docker/storage_proxy.Dockerfile
@@ -21,6 +21,7 @@ COPY daphne ./daphne
 RUN cargo new --lib daphne_server
 WORKDIR /tmp/dap_test/daphne_worker_test
 COPY daphne_worker_test/wrangler.storage_proxy.toml ./wrangler.toml
+RUN worker-build --dev
 RUN wrangler publish --dry-run
 
 FROM alpine:3.16 AS test

--- a/daphne_worker_test/wrangler.storage_proxy.toml
+++ b/daphne_worker_test/wrangler.storage_proxy.toml
@@ -5,11 +5,12 @@ name = "daphne_storage_proxy"
 main = "build/worker/shim.mjs"
 compatibility_date = "2023-12-21"
 
-# This Worker requires `worker-build` in order to package Rust for WASM. In
-# most cases it is preferable to install it ahead of time so that `wrangler
-# dev` starts faster.
-[build]
-command = "cargo install --git https://github.com/cloudflare/workers-rs && worker-build --dev"
+# Don't ask to send metrics to Cloudflare. The worker may be run from a container.
+send_metrics = false
+
+# Before starting the worker, run `worker-build`.
+#[build]
+#command = "cargo install --git https://github.com/cloudflare/workers-rs && worker-build --dev"
 
 [[rules]]
 globs = ["**/*.wasm"]

--- a/interop/Dockerfile.interop_helper
+++ b/interop/Dockerfile.interop_helper
@@ -1,55 +1,53 @@
-# Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
+# Prepare dependencies common to both services.
+#
+# NOTE: We must use debian (bookworm). We cannot use alpine because building
+# the service proxy requires OpenSSL, which is not compatible with the musl
+# target required by alpine.
+FROM rust:1.76-bookworm AS build-deps-common
+RUN apt update && apt install -y capnproto clang
+RUN capnp --version
 
-# A container for running interop tests against the Helper:
-# https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/
-FROM rust:1.76-bookworm AS interop_helper
-WORKDIR /build
-
-# Dependencies:
-#
-# - capnproto: required by a workspace dependency (`capnp`)
-#
-# - colorized-logs: asni2txt is used to remove color from the output of
-#   `wrangler dev`
-#
-# - clang: required to a workspace dependency (`ring`)
-#
-# - make
-#
-# - npm: required to install `wrangler`
-RUN apt update && \
-    apt install -y \
-        capnproto \
-        colorized-logs \
-        clang \
-        make \
-        npm
-
-RUN npm install -g wrangler@3.33.0
-
-# Install worker-build, used to build the storage proxy.
+# Prepare dependencies for building the storage proxy.
+FROM build-deps-common AS build-deps-storage-proxy
+RUN rustup target add wasm32-unknown-unknown
 RUN cargo install --git https://github.com/cloudflare/workers-rs
 
-# Install the WASM target, as required for the storage proxy Worker.
-RUN rustup target add wasm32-unknown-unknown
-
-COPY Cargo.toml Cargo.lock ./
-COPY daphne ./daphne
-COPY daphne_server ./daphne_server
-COPY daphne_service_utils ./daphne_service_utils
-COPY daphne_worker ./daphne_worker
-COPY daphne_worker_test ./daphne_worker_test
-
-# Build the storage proxy.
-WORKDIR /build/daphne_worker_test
-RUN wrangler deploy --dry-run -c wrangler.storage_proxy.toml
-
 # Build the service.
-WORKDIR /build/daphne_server
+FROM build-deps-common AS builder-service
+WORKDIR /build
+COPY Cargo.toml Cargo.lock /build/
+COPY daphne /build/daphne
+COPY daphne_server /build/daphne_server
+COPY daphne_service_utils /build/daphne_service_utils
+RUN cargo new --lib daphne_worker  # mock workspace dependency
+RUN cargo new --lib daphne_worker_test  # mock workspace dependency
 RUN cargo build --example service --features test-utils --release
 
-COPY interop/run_interop_helper.sh /run_interop_helper.sh
+# Build the storage proxy.
+FROM build-deps-storage-proxy AS builder-storage-proxy
+WORKDIR /build
+COPY Cargo.toml Cargo.lock /build/
+COPY daphne /build/daphne
+RUN cargo new --lib daphne_server  # mock workspace dependency
+COPY daphne_service_utils /build/daphne_service_utils
+COPY daphne_worker /build/daphne_worker
+COPY daphne_worker_test /build/daphne_worker_test
+WORKDIR /build/daphne_worker_test
+RUN worker-build --dev
 
+# Prepare the environment in which the service and storage proxy will run.
+FROM node:bookworm AS final
+RUN apt update && apt install -y colorized-logs
+RUN npm install -g wrangler@3.50.0 && npm cache clean --force
+COPY --from=builder-service /build/target/release/examples/service /
+COPY --from=builder-storage-proxy /build/daphne_worker_test/build /build
+COPY daphne_worker_test/wrangler.storage_proxy.toml /
+COPY daphne_server/examples/configuration-helper.toml /
+COPY interop/run_interop_helper.sh /
+WORKDIR /
+RUN wrangler deploy --dry-run -c wrangler.storage_proxy.toml
+
+# Expose the port for the service. The test runner does not need direct access
+# to the storage proxy.
 EXPOSE 8788
 ENTRYPOINT ["/bin/bash", "/run_interop_helper.sh"]

--- a/interop/run_interop_helper.sh
+++ b/interop/run_interop_helper.sh
@@ -7,7 +7,6 @@ set -e
 mkdir /logs
 
 # Start storage proxy.
-cd /build/daphne_worker_test
 nohup wrangler dev --config wrangler.storage_proxy.toml --port 4001 | ansi2txt \
     > /logs/storage_proxy.log 2>&1 &
 
@@ -15,7 +14,7 @@ nohup wrangler dev --config wrangler.storage_proxy.toml --port 4001 | ansi2txt \
 curl --retry 10 --retry-delay 1 --retry-all-errors -s http://localhost:4001
 
 # Start service.
-nohup env RUST_LOG=info /build/target/release/examples/service -c /build/daphne_server/examples/configuration-helper.toml | ansi2txt \
+nohup env RUST_LOG=info ./service -c configuration-helper.toml | ansi2txt \
     > /logs/service.log 2>&1 &
 
 # Wait for the service to come up.


### PR DESCRIPTION
The main goal is to copy the service binary and storage proxy worker into the final layer. We also observe that we don't need wrangler until we're ready to invoke the worker; all we need to build the worker is `worker-build`.

