### PR TITLE
Fix bug in `try_put_agg_share_span()` retry loop

### DIFF
--- a/crates/daphne/src/messages/mod.rs
+++ b/crates/daphne/src/messages/mod.rs
@@ -550,7 +550,6 @@ impl Decode for Transition {
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub enum TransitionVar {
     Continued(Vec<u8>),
-    Finished,
     Failed(TransitionFailure),
 }
 
@@ -560,9 +559,6 @@ impl Encode for TransitionVar {
             TransitionVar::Continued(vdaf_message) => {
                 0_u8.encode(bytes)?;
                 encode_u32_bytes(bytes, vdaf_message)?;
-            }
-            TransitionVar::Finished => {
-                1_u8.encode(bytes)?;
             }
             TransitionVar::Failed(err) => {
                 2_u8.encode(bytes)?;
@@ -577,7 +573,6 @@ impl Decode for TransitionVar {
     fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self, CodecError> {
         match u8::decode(bytes)? {
             0 => Ok(Self::Continued(decode_u32_bytes(bytes)?)),
-            1 => Ok(Self::Finished),
             2 => Ok(Self::Failed(TransitionFailure::decode(bytes)?)),
             _ => Err(CodecError::UnexpectedValue),
         }

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -566,8 +566,9 @@ mod test {
             .await;
         let (_helper_agg_span, mut agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
-        // Helper sent a transition with an unrecognized report ID.
-        agg_job_resp.transitions[0].var = TransitionVar::Finished;
+        // Helper sent a transition with an unrecognized report ID. Simulate this by flipping the
+        // first bit of the report ID.
+        agg_job_resp.transitions[0].report_id.0[0] ^= 1;
 
         assert_matches!(
             t.consume_agg_job_resp_expect_err(leader_state, agg_job_resp),


### PR DESCRIPTION
First remove the `Finished` variant of `TransitionVar` as its not needed for 1-round VDAFs.

After making this change, we notice a bug in the
`try_put_agg_share_span()` retry loop: if a report was aggregated during the previous attempt (its `ReportProcessedStatus` is `Aggregated`), then we would have returned `TransitionVar::Finished`, which is incorrect. If a report was aggregated, we instead want to compute the `outbound` message and return `TransitionVar::Continued(outbound)`.

Note: This commit was cherry-picked from downstream.