### PR TITLE
Clean up heavy hitters

### DIFF
--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -755,18 +755,6 @@ pub enum DapAggregationParam {
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-impl DapAggregationParam {
-    /// Return the aggregation level for the aggregation parameter. Replay protection is enforced
-    /// with respect to this value.
-    pub(crate) fn level(&self) -> usize {
-        match self {
-            Self::Empty => 0,
-            Self::Mastic(agg_param) => agg_param.level(),
-        }
-    }
-}
-
-#[cfg(any(test, feature = "test-utils"))]
 impl deepsize::DeepSizeOf for DapAggregationParam {
     fn deep_size_of(&self) -> usize {
         0

--- a/crates/daphne/src/vdaf/mastic.rs
+++ b/crates/daphne/src/vdaf/mastic.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-//! Dummy Mastic [[draft-mouris-cfrg-mastic]], a 2-party, 1-round VDAF for (weighted) heavy hitters
-//! and attribute-based metrics. This module implements an insecure, "dummy" version of Mastic
-//! intended for testing and prototyping heavy hitters in daphne. Eventually it will be replaced by
-//! a production-quality implementation.
+//! Dummy Mastic [[draft-mouris-cfrg-mastic]], a 2-party, 1-round VDAF. This module implements an
+//! insecure, "dummy" version of Mastic intended for testing and prototyping. Eventually it will be
+//! replaced by a production-quality implementation.
 //!
 //! [draft-mouris-cfrg-mastic]: https://datatracker.ietf.org/doc/draft-mouris-cfrg-mastic/
 


### PR DESCRIPTION
We don't plan to add support for heavy hitters in the foreseeable future. Clean up some logic in `InMemoryAggregator` for supporting this and remove associated TODOs.