### PR TITLE
Don't generate reports in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ pin-project = "1.1.5"
 prio = "0.16.5"
 prometheus = "0.13.3"
 rand = "0.8.5"
-rayon = "1.9.0"
+rayon = "1.10.0"
 rcgen = "0.12.1"
 regex = "1.10.3"
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls-native-roots"] }

--- a/crates/daphne/src/testing/report_generator.rs
+++ b/crates/daphne/src/testing/report_generator.rs
@@ -25,7 +25,6 @@ use rand::{
     distributions::{Distribution, Uniform},
     thread_rng,
 };
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tokio::sync::mpsc;
 
 #[pin_project]
@@ -81,43 +80,41 @@ impl ReportGenerator {
                 // --
 
                 let report_time_dist = Uniform::from(now - (60 * 60 * 36)..now - (60 * 60 * 24));
-                let error = (0..reports_per_batch).into_par_iter().try_for_each_with(
-                    tx,
-                    move |sender, _| {
-                        // perf measurements
-                        let last_instant = *LAST_INSTANT.lock().unwrap().get_or_insert_with(Instant::now);
-                        let now = Instant::now();
-                        // ----
+                let error = (0..reports_per_batch).try_for_each(move |_| {
+                    // perf measurements
+                    let last_instant = *LAST_INSTANT
+                        .lock()
+                        .unwrap()
+                        .get_or_insert_with(Instant::now);
+                    let now = Instant::now();
+                    // ----
 
-                        let report = vdaf
-                            .produce_report_with_extensions(
-                                &hpke_config_list,
-                                report_time_dist.sample(&mut thread_rng()),
-                                &task_id,
-                                measurement.clone(),
-                                extensions.clone(),
-                                version,
-                            )?;
+                    let report = vdaf.produce_report_with_extensions(
+                        &hpke_config_list,
+                        report_time_dist.sample(&mut thread_rng()),
+                        &task_id,
+                        measurement.clone(),
+                        extensions.clone(),
+                        version,
+                    )?;
 
-                        // perf measurements
-                        let count = GENERATED_REPORT_COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
-                        if count % 1000 == 0 {
-                            tracing::debug!(
-                                "generated {count} reports in {:?}. Each of size {}. Last one in {:?}",
-                                last_instant.elapsed(),
-                                report.deep_size_of() as f64 / 1000.,
-                                now.elapsed(),
-                            );
-                            *LAST_INSTANT.lock().unwrap() = Some(Instant::now());
-                        }
-                        // --
+                    // perf measurements
+                    let count = GENERATED_REPORT_COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
+                    if count % 1000 == 0 {
+                        tracing::debug!(
+                            "generated {count} reports in {:?}. Each of size {}. Last one in {:?}",
+                            last_instant.elapsed(),
+                            report.deep_size_of() as f64 / 1000.,
+                            now.elapsed(),
+                        );
+                        *LAST_INSTANT.lock().unwrap() = Some(Instant::now());
+                    }
+                    // --
 
-                        sender
-                            .blocking_send(report)
-                            .map_err(|_| fatal_error!(err = "failed to send report, channel closed"))?;
-                        Ok::<_, DapError>(())
-                    },
-                );
+                    tx.blocking_send(report)
+                        .map_err(|_| fatal_error!(err = "failed to send report, channel closed"))?;
+                    Ok::<_, DapError>(())
+                });
                 if let Err(error) = error {
                     tracing::error!(?error, "failed to generate a report");
                 }


### PR DESCRIPTION
This fixes a potential stack overflow related with nesting rayon calls
