### PR TITLE
Don't use the "wasm-compat" feature for prio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "daphne",
  "daphne-service-utils",
  "futures",
+ "getrandom",
  "hex",
  "paste",
  "prio",
@@ -885,6 +886,7 @@ dependencies = [
  "console_error_panic_hook",
  "daphne",
  "daphne-worker",
+ "getrandom",
  "tracing",
  "worker",
 ]
@@ -1244,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1733,9 +1735,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linked-hash-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ config = "0.13.4"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 deepsize = { version = "0.2.0" }
 futures = "0.3.30"
+getrandom = "0.2.15"
 hex = { version = "0.4.3", features = ["serde"] }
 hpke-rs = "0.2.0"
 hpke-rs-crypto = "0.2.0"

--- a/crates/daphne-worker-test/Cargo.toml
+++ b/crates/daphne-worker-test/Cargo.toml
@@ -25,8 +25,9 @@ cfg-if.workspace = true
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
-daphne = { path = "../daphne", features = ["test-utils", "wasm-compat"] }
+daphne = { path = "../daphne", features = ["test-utils"] }
 daphne-worker = { path = "../daphne-worker", features = ["test-utils"] }
+getrandom = { workspace = true, features = ["js"] }
 tracing.workspace = true
 worker.workspace = true
 

--- a/crates/daphne-worker/Cargo.toml
+++ b/crates/daphne-worker/Cargo.toml
@@ -21,8 +21,9 @@ bincode.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock", "wasmbind"] }
 daphne = { path = "../daphne", features = ["prometheus"] }
 futures = { workspace = true, optional = true }
+getrandom = { workspace = true, features = ["js"] }
 hex.workspace = true
-prio = { workspace = true, features = ["wasm-compat"] }
+prio.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest-wasm.workspace = true

--- a/crates/daphne/Cargo.toml
+++ b/crates/daphne/Cargo.toml
@@ -55,7 +55,6 @@ test-utils = ["dep:deepsize", "dep:prometheus", "dep:pin-project"]
 report-generator = ["test-utils", "dep:tokio", "dep:rayon", "tokio/sync"]
 default = []
 prometheus = ["dep:prometheus"]
-wasm-compat = ["prio/wasm-compat"]
 
 [[bench]]
 name = "vdaf"


### PR DESCRIPTION
This feature is intended to ensure compatibility with WASM. Instead, add `getrandom` to the workspace dependencies with the "js" feature enabled. This has the same effect according to:
https://docs.rs/getrandom/0.2.15/getrandom/#webassembly-support