### PR TITLE
Dynamically determine the number of chunks needed to store the aggregate share and report ids

### DIFF
--- a/crates/daphne-worker/src/durable/aggregate_store.rs
+++ b/crates/daphne-worker/src/durable/aggregate_store.rs
@@ -51,7 +51,7 @@ use super::{req_parse, GcDurableObject};
 const MAX_AGG_SHARE_CHUNK_KEY_COUNT: usize = 8;
 
 /// Minimum number of chunks needed to store `40_000` report ids.
-const MAX_REPORT_ID_CHUNK_KEY_COUNT: usize = 5;
+const DEFAULT_REPORT_ID_CHUNK_KEY_COUNT: u8 = 5;
 
 /// The maximum chunk size as documented in
 /// [the public docs](https://developers.cloudflare.com/durable-objects/platform/limits/)
@@ -114,11 +114,11 @@ impl DapAggregateShareMetadata {
 }
 
 fn js_map_to_chunks<'s, T: DeserializeOwned + 's>(
-    keys: &'s [&str],
+    keys: &'s [impl AsRef<str>],
     map: &'s js_sys::Map,
 ) -> impl Iterator<Item = Vec<T>> + 's {
     keys.iter()
-        .map(|k| JsValue::from_str(k))
+        .map(|k| JsValue::from_str(k.as_ref()))
         .filter(|k| map.has(k))
         .map(|k| map.get(&k))
         .map(|js_v| {
@@ -127,27 +127,16 @@ fn js_map_to_chunks<'s, T: DeserializeOwned + 's>(
 }
 
 fn shard_bytes_to_object(
-    keys: &[&str],
+    keys: &[impl AsRef<str>],
     bytes: Vec<u8>,
     object_to_fill: &js_sys::Object,
 ) -> Result<()> {
-    // stolen from
-    // https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil
-    // because it's nightly only
-    fn div_ceil(lhs: usize, rhs: usize) -> usize {
-        let d = lhs / rhs;
-        let r = lhs % rhs;
-        if r > 0 && rhs > 0 {
-            d + 1
-        } else {
-            d
-        }
-    }
-
-    let num_chunks = div_ceil(bytes.len(), MAX_CHUNK_SIZE);
-    if num_chunks > keys.len() {
-        return Err(format!("too many chunks {num_chunks}. max is {}", keys.len()).into());
-    }
+    let num_chunks: usize = number_of_chunks_needed_for(&bytes).into();
+    assert!(
+        num_chunks <= keys.len(),
+        "number of keys ({}) is lower than the required number of chunks ({num_chunks})",
+        keys.len()
+    );
 
     let mut base_idx = 0;
     for key in &keys[..num_chunks] {
@@ -159,7 +148,11 @@ fn shard_bytes_to_object(
         let value = js_sys::Uint8Array::new_with_length(u32::try_from(chunk.len()).unwrap());
         value.copy_from(chunk);
 
-        js_sys::Reflect::set(object_to_fill, &JsValue::from_str(key), &value.into())?;
+        js_sys::Reflect::set(
+            object_to_fill,
+            &JsValue::from_str(key.as_ref()),
+            &value.into(),
+        )?;
 
         base_idx = end;
     }
@@ -175,7 +168,27 @@ super::mk_durable_object! {
         report_ids: Option<HashSet<ReportId>>,
         agg_share: Option<DapAggregateShare>,
         collected: Option<bool>,
+        report_id_chunk_key_count: Option<u8>,
     }
+}
+
+fn number_of_chunks_needed_for(bytes: &[u8]) -> u8 {
+    // stolen from
+    // https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil
+    // because it's nightly only
+    fn div_ceil(lhs: usize, rhs: usize) -> usize {
+        let d = lhs / rhs;
+        let r = lhs % rhs;
+        if r > 0 && rhs > 0 {
+            d + 1
+        } else {
+            d
+        }
+    }
+
+    div_ceil(bytes.len(), MAX_CHUNK_SIZE)
+        .try_into()
+        .expect("number of chunks must be below u8::MAX")
 }
 
 impl AggregateStore {
@@ -192,17 +205,37 @@ impl AggregateStore {
         ]
     }
 
-    const fn aggregated_reports_keys() -> &'static [&'static str; MAX_REPORT_ID_CHUNK_KEY_COUNT] {
-        &[
-            "aggregated_report_ids_000",
-            "aggregated_report_ids_001",
-            "aggregated_report_ids_002",
-            "aggregated_report_ids_003",
-            "aggregated_report_ids_004",
-        ]
+    async fn aggregated_reports_keys(&mut self) -> Result<Vec<String>> {
+        let key_count = if let Some(key_count) = self.report_id_chunk_key_count {
+            key_count
+        } else {
+            let key_count = self
+                .get("report_id_chunk_key_count")
+                .await?
+                .unwrap_or(DEFAULT_REPORT_ID_CHUNK_KEY_COUNT);
+            self.report_id_chunk_key_count = Some(key_count);
+            key_count
+        };
+        Ok((0..key_count)
+            .map(|n| format!("aggregated_report_ids_{n:03}"))
+            .collect())
     }
 
-    async fn get_agg_share(&mut self, keys: &[&str]) -> Result<&mut DapAggregateShare> {
+    async fn set_report_id_chunk_key_count(&mut self, count: u8) -> Result<()> {
+        if Some(count) == self.report_id_chunk_key_count {
+            return Ok(());
+        }
+        self.state
+            .storage()
+            .put("report_id_chunk_key_count", count)
+            .await?;
+
+        self.report_id_chunk_key_count = Some(count);
+        Ok(())
+    }
+
+    async fn get_agg_share(&mut self) -> Result<&mut DapAggregateShare> {
+        let keys = Self::agg_share_shard_keys();
         let agg_share = if let Some(agg_share) = self.agg_share.take() {
             agg_share
         } else {
@@ -291,14 +324,14 @@ impl AggregateStore {
     }
 
     async fn cold_load_aggregated_report_ids(&mut self) -> Result<()> {
+        let report_keys = self.aggregated_reports_keys().await?;
         let chunks_map = self
             .state
             .storage()
-            .get_multiple(Self::aggregated_reports_keys().to_vec())
+            .get_multiple(report_keys.clone())
             .await?;
 
-        let report_keys = Self::aggregated_reports_keys();
-        let bytes = js_map_to_chunks::<u8>(report_keys, &chunks_map);
+        let bytes = js_map_to_chunks::<u8>(&report_keys, &chunks_map);
 
         let report_count_estimate = {
             let (lower, _) = bytes.size_hint();
@@ -315,6 +348,7 @@ impl AggregateStore {
 
         Ok(())
     }
+
     async fn is_collected(&mut self) -> Result<bool> {
         Ok(if let Some(collected) = self.collected {
             collected
@@ -336,6 +370,7 @@ impl GcDurableObject for AggregateStore {
             report_ids: None,
             agg_share: None,
             collected: None,
+            report_id_chunk_key_count: None,
         }
     }
 
@@ -402,29 +437,26 @@ impl GcDurableObject for AggregateStore {
                             Error::RustError(format!("failed to encode report ID: {e}"))
                         })
                     })?;
-                    shard_bytes_to_object(Self::aggregated_reports_keys(), as_bytes, &chunks_map)?;
+                    self.set_report_id_chunk_key_count(number_of_chunks_needed_for(&as_bytes))
+                        .await?;
+                    shard_bytes_to_object(
+                        &self.aggregated_reports_keys().await?,
+                        as_bytes,
+                        &chunks_map,
+                    )?;
                 };
 
-                let keys = Self::agg_share_shard_keys();
-                let agg_share = self.get_agg_share(keys).await?;
+                let agg_share = self.get_agg_share().await?;
                 agg_share.merge(agg_share_delta).map_err(int_err)?;
 
                 let meta = DapAggregateShareMetadata::from_agg_share(agg_share);
 
-                agg_share
-                    .data
-                    .as_ref()
-                    .map(|data| {
-                        shard_bytes_to_object(
-                            keys,
-                            data.get_encoded().map_err(|e| {
-                                Error::RustError(format!("failed to encode agg share: {e}"))
-                            })?,
-                            &chunks_map,
-                        )
-                    })
-                    .transpose()? // Option<Result> -> Result<Option> -> Option
-                    .unwrap_or_default();
+                if let Some(data) = &agg_share.data {
+                    let as_bytes = data.get_encoded().map_err(|e| {
+                        Error::RustError(format!("failed to encode agg share: {e}"))
+                    })?;
+                    shard_bytes_to_object(Self::agg_share_shard_keys(), as_bytes, &chunks_map)?;
+                }
 
                 js_sys::Reflect::set(
                     &chunks_map,
@@ -443,7 +475,7 @@ impl GcDurableObject for AggregateStore {
             // Idempotent
             // Output: `DapAggregateShare`
             Some(bindings::AggregateStore::Get) => {
-                let agg_share = self.get_agg_share(Self::agg_share_shard_keys()).await?;
+                let agg_share = self.get_agg_share().await?;
                 Response::from_json(&agg_share)
             }
 


### PR DESCRIPTION
- Reorganize aggregate_store.rs
- Dynamically determine the number of chunks needed to store the aggregate share and report ids
