### PR TITLE
pine: Specify number of proofs and algorithm ID dynamically

### DIFF
--- a/crates/daphne/benches/pine.rs
+++ b/crates/daphne/benches/pine.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use daphne::pine::Pine64;
+use daphne::pine::Pine;
 use prio::{
     field::random_vector,
     flp::Type,
@@ -17,7 +17,7 @@ fn pine(c: &mut Criterion) {
         (100_000, 320 * 6),
         (1_000_000, 1_000 * 8),
     ] {
-        let pine = Pine64::new(1.0, dimension, 15, chunk_len).unwrap();
+        let pine = Pine::new_64(1.0, dimension, 15, chunk_len).unwrap();
         let measurement = vec![0.0; dimension];
         let wr_joint_rand_seed = Seed::generate().unwrap();
         let nonce = [0; 16];

--- a/crates/daphne/src/pine/msg.rs
+++ b/crates/daphne/src/pine/msg.rs
@@ -45,9 +45,9 @@ impl Encode for PublicShare {
     }
 }
 
-impl<F, const PROOFS: u8> ParameterizedDecode<Pine<F, PROOFS>> for PublicShare {
+impl<F> ParameterizedDecode<Pine<F>> for PublicShare {
     fn decode_with_param(
-        _pine: &Pine<F, PROOFS>,
+        _pine: &Pine<F>,
         bytes: &mut std::io::Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         Ok(Self {
@@ -138,11 +138,9 @@ impl<F: FftFriendlyFieldElement> Encode for InputShare<F> {
     }
 }
 
-impl<F: FftFriendlyFieldElement, const PROOFS: u8> ParameterizedDecode<(&Pine<F, PROOFS>, usize)>
-    for InputShare<F>
-{
+impl<F: FftFriendlyFieldElement> ParameterizedDecode<(&Pine<F>, usize)> for InputShare<F> {
     fn decode_with_param(
-        (pine, agg_id): &(&Pine<F, PROOFS>, usize),
+        (pine, agg_id): &(&Pine<F>, usize),
         bytes: &mut std::io::Cursor<&[u8]>,
     ) -> Result<Self, CodecError> {
         match agg_id {
@@ -152,7 +150,7 @@ impl<F: FftFriendlyFieldElement, const PROOFS: u8> ParameterizedDecode<(&Pine<F,
                     .take(pine.flp.cfg.encoded_input_len)
                     .collect::<Result<Vec<_>, _>>()?,
                 proofs_share: iter::repeat_with(|| F::decode(bytes))
-                    .take(pine.flp.proof_len() * usize::from(PROOFS))
+                    .take(pine.flp.proof_len() * usize::from(pine.flp.cfg.num_proofs))
                     .collect::<Result<Vec<_>, _>>()?,
                 wr_blind: Seed::decode(bytes)?,
                 vf_blind: Seed::decode(bytes)?,

--- a/crates/daphne/src/pine/test_vec/mod.rs
+++ b/crates/daphne/src/pine/test_vec/mod.rs
@@ -53,7 +53,7 @@ struct TestVec {
     agg_result: Vec<f64>,
 }
 
-impl<F: FftFriendlyFieldElement, const PROOFS: u8> Pine<F, PROOFS> {
+impl<F: FftFriendlyFieldElement> Pine<F> {
     fn run_test_vec(&self, test_vec: &TestVec) {
         // Check that the test vector parameters have the values we expect.
         //
@@ -65,7 +65,7 @@ impl<F: FftFriendlyFieldElement, const PROOFS: u8> Pine<F, PROOFS> {
         assert_eq!(test_vec.num_wr_checks, NUM_WR_TESTS);
         assert_eq!(test_vec.num_wr_successes, NUM_WR_SUCCESSES);
         assert_eq!(test_vec.shares, 2);
-        assert_eq!(test_vec.proofs, usize::from(PROOFS));
+        assert_eq!(test_vec.proofs, usize::from(self.flp.cfg.num_proofs));
 
         let mut out_shares_0 = Vec::new();
         let mut out_shares_1 = Vec::new();
@@ -176,13 +176,13 @@ impl<F: FftFriendlyFieldElement, const PROOFS: u8> Pine<F, PROOFS> {
 mod tests {
     use super::*;
 
-    use crate::pine::{Pine128, Pine64};
+    use crate::pine::Pine;
 
     #[test]
     fn run_64() {
         let test_vec =
             serde_json::from_str::<TestVec>(include_str!("00/Pine_Field64.json")).unwrap();
-        Pine64::new(
+        Pine::new_64(
             test_vec.l2_norm_bound,
             test_vec.dimension,
             test_vec.num_frac_bits,
@@ -196,7 +196,7 @@ mod tests {
     fn run_128() {
         let test_vec =
             serde_json::from_str::<TestVec>(include_str!("00/Pine_Field128.json")).unwrap();
-        Pine128::new(
+        Pine::new_128(
             test_vec.l2_norm_bound,
             test_vec.dimension,
             test_vec.num_frac_bits,


### PR DESCRIPTION
Based on #629 (merge that first).
Partially addresses #618.

Currently the number of FLPs to generate is a generic constant and thus determined at compile time. For taskprov, the number of proofs will be configured at runtime. To make this easier, move this parameter into `PineConfig`.

This change also moves the VDAF algorithm ID to `PineConfig`. This is needed for a different reason however: we will have more than one instance of PINE, for different field sizes and XOFs.