### PR TITLE
protocol: Enable Pine128

### DIFF
--- a/crates/daphne/Cargo.toml
+++ b/crates/daphne/Cargo.toml
@@ -51,6 +51,7 @@ strum.workspace = true
 tokio.workspace = true
 
 [features]
+experimental = []
 test-utils = ["dep:deepsize", "dep:prometheus", "dep:pin-project"]
 report-generator = ["test-utils", "dep:tokio", "dep:rayon", "tokio/sync"]
 default = []

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -862,6 +862,8 @@ pub enum DapMeasurement {
         input: Vec<u8>,
         weight: MasticWeight,
     },
+    #[cfg(any(test, feature = "test-utils"))]
+    F64Vec(Vec<f64>),
 }
 
 /// An aggregation parameter.
@@ -909,7 +911,7 @@ impl ParameterizedDecode<VdafConfig> for DapAggregationParam {
 }
 
 /// The aggregate result computed by the Collector.
-#[derive(Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DapAggregateResult {
     U32Vec(Vec<u32>),
@@ -917,6 +919,8 @@ pub enum DapAggregateResult {
     U64Vec(Vec<u64>),
     U128(u128),
     U128Vec(Vec<u128>),
+    #[cfg(any(test, feature = "test-utils"))]
+    F64Vec(Vec<f64>),
 }
 
 #[derive(Clone)]

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -71,7 +71,7 @@ pub use error::DapError;
 use error::FatalDapError;
 use hpke::{HpkeConfig, HpkeKemId};
 use messages::encode_base64url;
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "experimental")]
 use prio::vdaf::poplar1::Poplar1AggregationParam;
 use prio::{
     codec::{CodecError, Decode, Encode, ParameterizedDecode, ParameterizedEncode},
@@ -87,7 +87,7 @@ use std::{
     str::FromStr,
 };
 use url::Url;
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "experimental")]
 use vdaf::mastic::MasticWeight;
 
 pub use protocol::aggregator::{
@@ -857,12 +857,12 @@ pub enum DapMeasurement {
     U32Vec(Vec<u32>),
     U64Vec(Vec<u64>),
     U128Vec(Vec<u128>),
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(feature = "experimental")]
     Mastic {
         input: Vec<u8>,
         weight: MasticWeight,
     },
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(feature = "experimental")]
     F64Vec(Vec<f64>),
 }
 
@@ -870,7 +870,7 @@ pub enum DapMeasurement {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DapAggregationParam {
     Empty,
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(feature = "experimental")]
     Mastic(Poplar1AggregationParam),
 }
 
@@ -890,7 +890,7 @@ impl Encode for DapAggregationParam {
         let _ = bytes;
         match self {
             Self::Empty => Ok(()),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             Self::Mastic(agg_param) => agg_param.encode(bytes),
         }
     }
@@ -903,7 +903,7 @@ impl ParameterizedDecode<VdafConfig> for DapAggregationParam {
     ) -> Result<Self, CodecError> {
         let _ = bytes;
         match vdaf_config {
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Mastic { .. } => Ok(Self::Mastic(Poplar1AggregationParam::decode(bytes)?)),
             _ => Ok(Self::Empty),
         }
@@ -919,7 +919,7 @@ pub enum DapAggregateResult {
     U64Vec(Vec<u64>),
     U128(u128),
     U128Vec(Vec<u128>),
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(feature = "experimental")]
     F64Vec(Vec<f64>),
 }
 

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "experimental")]
 use crate::vdaf::mastic::{mastic_prep_finish, mastic_prep_finish_from_shares, mastic_prep_init};
 use crate::{
     error::DapAbort,
@@ -284,8 +284,8 @@ impl EarlyReportStateInitialized {
         agg_param: &DapAggregationParam,
         early_report_state_consumed: EarlyReportStateConsumed,
     ) -> Result<Self, DapError> {
-        // We need to use this variable for Mastic, which is currently only enabled in tests or
-        // when the feature "test-utils" is enabled.
+        // We need to use this variable for Mastic, which is currently fenced by the "experimental
+        // feature".
         let _ = agg_param;
 
         let (metadata, public_share, input_share, peer_prep_share) =
@@ -319,7 +319,7 @@ impl EarlyReportStateInitialized {
                 &public_share,
                 &input_share,
             ),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Mastic {
                 input_size,
                 weight_config,
@@ -331,7 +331,7 @@ impl EarlyReportStateInitialized {
                 &public_share,
                 input_share.as_ref(),
             ),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Pine(pine) => pine.prep_init(
                 vdaf_verify_key,
                 agg_id,
@@ -625,7 +625,7 @@ impl DapTaskConfig {
                                 helper_prep_share.clone(),
                                 leader_prep_share,
                             ),
-                            #[cfg(any(test, feature = "test-utils"))]
+                            #[cfg(feature = "experimental")]
                             VdafConfig::Mastic {
                                 input_size: _,
                                 weight_config,
@@ -635,7 +635,7 @@ impl DapTaskConfig {
                                 helper_prep_share.clone(),
                                 leader_prep_share,
                             ),
-                            #[cfg(any(test, feature = "test-utils"))]
+                            #[cfg(feature = "experimental")]
                             VdafConfig::Pine(pine) => pine.prep_finish_from_shares(
                                 1,
                                 helper_prep_state.clone(),
@@ -764,9 +764,9 @@ impl DapTaskConfig {
                 VdafConfig::Prio2 { dimension } => {
                     prio2_prep_finish(*dimension, leader.prep_state, prep_msg)
                 }
-                #[cfg(any(test, feature = "test-utils"))]
+                #[cfg(feature = "experimental")]
                 VdafConfig::Mastic { .. } => mastic_prep_finish(leader.prep_state, prep_msg),
-                #[cfg(any(test, feature = "test-utils"))]
+                #[cfg(feature = "experimental")]
                 VdafConfig::Pine(pine) => pine.prep_finish(leader.prep_state, prep_msg),
             };
 

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -331,6 +331,14 @@ impl EarlyReportStateInitialized {
                 &public_share,
                 input_share.as_ref(),
             ),
+            #[cfg(any(test, feature = "test-utils"))]
+            VdafConfig::Pine(pine) => pine.prep_init(
+                vdaf_verify_key,
+                agg_id,
+                &metadata.id.0,
+                &public_share,
+                &input_share,
+            ),
         };
 
         let early_report_state_initialized = match res {
@@ -627,6 +635,13 @@ impl DapTaskConfig {
                                 helper_prep_share.clone(),
                                 leader_prep_share,
                             ),
+                            #[cfg(any(test, feature = "test-utils"))]
+                            VdafConfig::Pine(pine) => pine.prep_finish_from_shares(
+                                1,
+                                helper_prep_state.clone(),
+                                helper_prep_share.clone(),
+                                leader_prep_share,
+                            ),
                         };
 
                         match res {
@@ -751,6 +766,8 @@ impl DapTaskConfig {
                 }
                 #[cfg(any(test, feature = "test-utils"))]
                 VdafConfig::Mastic { .. } => mastic_prep_finish(leader.prep_state, prep_msg),
+                #[cfg(any(test, feature = "test-utils"))]
+                VdafConfig::Pine(pine) => pine.prep_finish(leader.prep_state, prep_msg),
             };
 
             match res {

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "experimental")]
 use crate::vdaf::mastic::mastic_shard;
 use crate::{
     hpke::HpkeConfig,
@@ -138,12 +138,12 @@ impl VdafConfig {
         match self {
             Self::Prio3(prio3_config) => Ok(prio3_shard(prio3_config, measurement, nonce)?),
             Self::Prio2 { dimension } => Ok(prio2_shard(*dimension, measurement, nonce)?),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Mastic {
                 input_size,
                 weight_config,
             } => Ok(mastic_shard(*input_size, *weight_config, measurement)?),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Pine(pine) => Ok(pine.shard(measurement, nonce)?),
         }
     }

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -143,6 +143,8 @@ impl VdafConfig {
                 input_size,
                 weight_config,
             } => Ok(mastic_shard(*input_size, *weight_config, measurement)?),
+            #[cfg(any(test, feature = "test-utils"))]
+            VdafConfig::Pine(pine) => Ok(pine.shard(measurement, nonce)?),
         }
     }
 

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -89,6 +89,8 @@ impl VdafConfig {
                 input_size: _,
                 weight_config,
             } => mastic_unshard(*weight_config, agg_param, agg_shares),
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Pine(pine) => pine.unshard(num_measurements, agg_shares),
         }
         .map_err(DapError::from_vdaf)
     }

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "experimental")]
 use crate::vdaf::mastic::mastic_unshard;
 use crate::{
     fatal_error,
@@ -84,12 +84,12 @@ impl VdafConfig {
         match self {
             Self::Prio3(prio3_config) => prio3_unshard(prio3_config, num_measurements, agg_shares),
             Self::Prio2 { dimension } => prio2_unshard(*dimension, num_measurements, agg_shares),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             Self::Mastic {
                 input_size: _,
                 weight_config,
             } => mastic_unshard(*weight_config, agg_param, agg_shares),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             Self::Pine(pine) => pine.unshard(num_measurements, agg_shares),
         }
         .map_err(DapError::from_vdaf)

--- a/crates/daphne/src/taskprov.rs
+++ b/crates/daphne/src/taskprov.rs
@@ -370,7 +370,7 @@ impl TryFrom<&VdafConfig> for messages::taskprov::VdafTypeVar {
             VdafConfig::Prio3(..) => Err(fatal_error!(
                 err = format!("{vdaf_config} is not currently supported for taskprov")
             )),
-            #[cfg(any(test, feature = "test-utils"))]
+            #[cfg(feature = "experimental")]
             VdafConfig::Mastic { .. } | VdafConfig::Pine(..) => Err(fatal_error!(
                 err = format!("{vdaf_config} is not currently supported for taskprov")
             )),

--- a/crates/daphne/src/taskprov.rs
+++ b/crates/daphne/src/taskprov.rs
@@ -371,7 +371,7 @@ impl TryFrom<&VdafConfig> for messages::taskprov::VdafTypeVar {
                 err = format!("{vdaf_config} is not currently supported for taskprov")
             )),
             #[cfg(any(test, feature = "test-utils"))]
-            VdafConfig::Mastic { .. } => Err(fatal_error!(
+            VdafConfig::Mastic { .. } | VdafConfig::Pine(..) => Err(fatal_error!(
                 err = format!("{vdaf_config} is not currently supported for taskprov")
             )),
         }

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -1216,6 +1216,7 @@ macro_rules! assert_metrics_include {
 
 impl VdafConfig {
     pub fn gen_measurement(&self) -> Result<DapMeasurement, DapError> {
+        #[allow(clippy::match_wildcard_for_single_variants)]
         match self {
             Self::Prio2 { dimension } => Ok(DapMeasurement::U32Vec(vec![1; *dimension])),
             Self::Prio3(crate::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {

--- a/crates/daphne/src/vdaf/mastic.rs
+++ b/crates/daphne/src/vdaf/mastic.rs
@@ -22,19 +22,8 @@ use prio::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Deserialize,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    deepsize::DeepSizeOf,
-)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 /// The type of each input's weight.
 pub enum MasticWeightConfig {
     /// Each weight is a `0` or `1`.
@@ -50,8 +39,7 @@ impl std::fmt::Display for MasticWeightConfig {
 }
 
 /// A weight.
-#[derive(Clone, Deserialize, Serialize)]
-#[cfg_attr(any(test, feature = "test-utils"), derive(Debug))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MasticWeight {
     Bool(bool),
 }

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -1,0 +1,312 @@
+// Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use crate::{
+    fatal_error,
+    pine::{msg, vdaf::PinePrepState, Pine},
+    vdaf::{prep_finish, prep_finish_from_shares, unshard},
+    DapAggregateResult, DapMeasurement,
+};
+
+use super::{
+    shard_then_encode, VdafAggregateShare, VdafError, VdafPrepMessage, VdafPrepState, VdafVerifyKey,
+};
+use prio::{codec::ParameterizedDecode, field::FftFriendlyFieldElement, vdaf::Aggregator};
+use serde::{Deserialize, Serialize};
+
+/// [Pine](crate::pine::Pine) parameters.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
+pub struct PineConfig {
+    pub norm_bound: f64,
+    pub dimension: usize,
+    pub frac_bits: usize,
+    pub chunk_len: usize,
+    pub var: PineVariant,
+}
+
+impl PartialEq for PineConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.norm_bound.total_cmp(&other.norm_bound).is_eq()
+            && self.dimension == other.dimension
+            && self.frac_bits == other.frac_bits
+            && self.chunk_len == other.chunk_len
+            && self.var == other.var
+    }
+}
+
+impl Eq for PineConfig {}
+
+impl Ord for PineConfig {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.norm_bound
+            .total_cmp(&other.norm_bound)
+            .then(self.dimension.cmp(&other.dimension))
+            .then(self.frac_bits.cmp(&other.frac_bits))
+            .then(self.chunk_len.cmp(&other.chunk_len))
+            .then(self.var.cmp(&self.var))
+    }
+}
+
+impl PartialOrd for PineConfig {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::hash::Hash for PineConfig {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.norm_bound.to_bits().hash(state);
+        self.dimension.hash(state);
+        self.frac_bits.hash(state);
+        self.chunk_len.hash(state);
+        self.var.hash(state);
+    }
+}
+
+impl std::fmt::Display for PineConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        let var_suffix = match var {
+            PineVariant::Field128 => "128",
+        };
+
+        write!(
+            f,
+            "Pine{var_suffix}({norm_bound},{dimension},{frac_bits},{chunk_len})"
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
+pub enum PineVariant {
+    Field128,
+}
+
+impl PineConfig {
+    pub(crate) fn shard(
+        &self,
+        measurement: DapMeasurement,
+        nonce: &[u8; 16],
+    ) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        let DapMeasurement::F64Vec(gradient) = &measurement else {
+            return Err(VdafError::Dap(fatal_error!(err = "XXX")));
+        };
+
+        match var {
+            PineVariant::Field128 => {
+                let vdaf = Pine::new_128(*norm_bound, *dimension, *frac_bits, *chunk_len)
+                    .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                shard_then_encode(&vdaf, gradient, nonce)
+            }
+        }
+    }
+
+    pub(crate) fn prep_init(
+        &self,
+        verify_key: &VdafVerifyKey,
+        agg_id: usize,
+        nonce: &[u8; 16],
+        public_share_data: &[u8],
+        input_share_data: &[u8],
+    ) -> Result<(VdafPrepState, VdafPrepMessage), VdafError> {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        match (var, verify_key) {
+            (PineVariant::Field128, VdafVerifyKey::L16(verify_key)) => {
+                let vdaf = Pine::new_128(*norm_bound, *dimension, *frac_bits, *chunk_len)
+                    .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                let (state, share) = prep_init(
+                    vdaf,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Pine128(state),
+                    VdafPrepMessage::Pine128Share(share),
+                ))
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err = "unhandled config and verify key combination",
+            ))),
+        }
+    }
+
+    pub(crate) fn prep_finish_from_shares(
+        &self,
+        agg_id: usize,
+        host_state: VdafPrepState,
+        host_share: VdafPrepMessage,
+        peer_share_data: &[u8],
+    ) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        match (var, host_state, host_share) {
+            (
+                PineVariant::Field128,
+                VdafPrepState::Pine128(state),
+                VdafPrepMessage::Pine128Share(share),
+            ) => {
+                let vdaf = Pine::new_128(*norm_bound, *dimension, *frac_bits, *chunk_len)
+                    .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                let (out_share, outbound) =
+                    prep_finish_from_shares(&vdaf, agg_id, state, share, peer_share_data)?;
+                let agg_share = VdafAggregateShare::Field128(prio::vdaf::AggregateShare::from(
+                    prio::vdaf::OutputShare::from(out_share.0),
+                ));
+                Ok((agg_share, outbound))
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err = format!("pine_prep_finish_from_shares: unexpected host state or share")
+            ))),
+        }
+    }
+
+    pub(crate) fn prep_finish(
+        &self,
+        host_state: VdafPrepState,
+        peer_message_data: &[u8],
+    ) -> Result<VdafAggregateShare, VdafError> {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        match (var, host_state) {
+            (PineVariant::Field128, VdafPrepState::Pine128(state)) => {
+                let vdaf = Pine::new_128(*norm_bound, *dimension, *frac_bits, *chunk_len)
+                    .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                let out_share = prep_finish(&vdaf, state, peer_message_data)?;
+                let agg_share = VdafAggregateShare::Field128(prio::vdaf::AggregateShare::from(
+                    prio::vdaf::OutputShare::from(out_share.0),
+                ));
+                Ok(agg_share)
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err = format!("pine_prep_finish: unexpected host state")
+            ))),
+        }
+    }
+
+    pub(crate) fn unshard<M: IntoIterator<Item = Vec<u8>>>(
+        &self,
+        num_measurements: usize,
+        agg_shares: M,
+    ) -> Result<DapAggregateResult, VdafError> {
+        let PineConfig {
+            norm_bound,
+            dimension,
+            frac_bits,
+            chunk_len,
+            var,
+        } = self;
+
+        match var {
+            PineVariant::Field128 => {
+                let vdaf = Pine::new_128(*norm_bound, *dimension, *frac_bits, *chunk_len)
+                    .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::F64Vec(agg_res))
+            }
+        }
+    }
+}
+
+fn prep_init<F: FftFriendlyFieldElement>(
+    vdaf: Pine<F>,
+    verify_key: &[u8; 16],
+    agg_id: usize,
+    nonce: &[u8; 16],
+    public_share_data: &[u8],
+    input_share_data: &[u8],
+) -> Result<(PinePrepState<F>, msg::PrepShare<F>), VdafError> {
+    // Parse the public share.
+    let public_share = msg::PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
+
+    // Parse the input share.
+    let input_share = msg::InputShare::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
+
+    // Run the prepare-init algorithm, returning the initial state.
+    Ok(vdaf.prepare_init(verify_key, agg_id, &(), nonce, &public_share, &input_share)?)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        async_test_versions, hpke::HpkeKemId, testing::AggregationJobTest, vdaf::VdafConfig,
+        DapAggregateResult, DapAggregationParam, DapMeasurement, DapVersion,
+    };
+
+    use super::{PineConfig, PineVariant};
+
+    async fn roundtrip_128(version: DapVersion) {
+        let mut t = AggregationJobTest::new(
+            &VdafConfig::Pine(PineConfig {
+                norm_bound: 1.0,
+                dimension: 1_000,
+                frac_bits: 20,
+                chunk_len: 50,
+                var: PineVariant::Field128,
+            }),
+            HpkeKemId::X25519HkdfSha256,
+            version,
+        );
+        let DapAggregateResult::F64Vec(got) = t
+            .roundtrip(
+                DapAggregationParam::Empty,
+                vec![
+                    DapMeasurement::F64Vec(vec![0.0001; 1_000]),
+                    DapMeasurement::F64Vec(vec![0.0001; 1_000]),
+                    DapMeasurement::F64Vec(vec![0.0001; 1_000]),
+                ],
+            )
+            .await
+        else {
+            panic!("unexpected result type");
+        };
+        for x in &got {
+            assert!(
+                (x - 0.0003).abs() > f64::EPSILON,
+                "unexpected result value: {got:?}"
+            );
+        }
+    }
+
+    async_test_versions! { roundtrip_128 }
+}


### PR DESCRIPTION
Based on #630 (merge that first).
Partially addresses #618.

Plumb Pine128 into daphne on an experimental basis (i.e., when the "test-utils" feature is used). Along the way, refactor 
some of the code shared by Pine and Prio3.