### PR TITLE
pine:  Represent norm bound as integer rather than float

### DIFF
--- a/crates/daphne/src/pine/flp.rs
+++ b/crates/daphne/src/pine/flp.rs
@@ -502,7 +502,7 @@ mod tests {
     use rand::prelude::*;
     use std::iter;
 
-    use crate::pine::Pine;
+    use crate::pine::{norm_bound_f64_to_u64, Pine};
 
     use super::*;
 
@@ -510,7 +510,8 @@ mod tests {
     fn encode_gradient() {
         let dimension = 10;
         let frac_bits = 4;
-        let pine = Pine::new_128(100.0, dimension, frac_bits, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, frac_bits);
+        let pine = Pine::new_128(norm_bound, dimension, frac_bits, 4).unwrap();
 
         // We use whole numbers here so that we can test gradient decoding without losing any
         // precision.
@@ -551,7 +552,8 @@ mod tests {
     #[test]
     fn encode_wr_tests() {
         let mut rng = thread_rng();
-        let pine = Pine::new_128(10.0, 10, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(10.0, 15);
+        let pine = Pine::new_128(norm_bound, 10, 15, 4).unwrap();
         let gradient = iter::repeat_with(|| rng.gen_range(-0.1..0.1)).take(10);
 
         let (input, wr_test_results) = pine
@@ -597,28 +599,32 @@ mod tests {
     #[test]
     fn valid() {
         const DIM: usize = 1000;
-        let pine = Pine::new_128(1000.0, DIM, 15, 27).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 27).unwrap();
         pine.run_valid_test_case((0..DIM).map(|i| i as f64 * 0.01));
     }
 
     #[test]
     fn valid_small_dimension() {
         const DIM: usize = 1;
-        let pine = Pine::new_128(1.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         pine.run_valid_test_case([0.75].into_iter());
     }
 
     #[test]
     fn valid_negative_values() {
         const DIM: usize = 1337;
-        let pine = Pine::new_128(1000.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         pine.run_valid_test_case((0..DIM).map(|i| i as f64 * -0.01));
     }
 
     #[test]
     fn valid_random_values() {
         const DIM: usize = 1000;
-        let pine = Pine::new_128(100.0, DIM, 15, 99).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 99).unwrap();
         let mut rng = thread_rng();
         pine.run_valid_test_case(iter::repeat_with(|| rng.gen_range(-0.1..0.1)).take(DIM));
     }
@@ -626,7 +632,8 @@ mod tests {
     #[test]
     fn invalid_mutated_gradient() {
         const DIM: usize = 10;
-        let pine = Pine::new_128(100.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         let (mut input, wr_test_results) = pine
             .flp
             .encode_with_wr_joint_rand([0.0; DIM].into_iter(), &Seed::generate().unwrap())
@@ -642,7 +649,8 @@ mod tests {
     #[test]
     fn invalid_mutated_sq_norm() {
         const DIM: usize = 10;
-        let pine = Pine::new_128(100.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         let (mut input, wr_test_results) = pine
             .flp
             .encode_with_wr_joint_rand([0.0; DIM].into_iter(), &Seed::generate().unwrap())
@@ -662,7 +670,8 @@ mod tests {
     #[test]
     fn invalid_mutated_wr_result() {
         const DIM: usize = 10;
-        let pine = Pine::new_128(100.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         let (mut input, wr_test_results) = pine
             .flp
             .encode_with_wr_joint_rand([0.0; DIM].into_iter(), &Seed::generate().unwrap())
@@ -683,7 +692,8 @@ mod tests {
     #[test]
     fn invalid_mutated_success_bit() {
         const DIM: usize = 10;
-        let pine = Pine::new_128(100.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         let (mut input, wr_test_results) = pine
             .flp
             .encode_with_wr_joint_rand([0.0; DIM].into_iter(), &Seed::generate().unwrap())
@@ -705,7 +715,8 @@ mod tests {
     #[test]
     fn invalid_dot_prod_mismatch() {
         const DIM: usize = 10;
-        let pine = Pine::new_128(100.0, DIM, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(100.0, 15);
+        let pine = Pine::new_128(norm_bound, DIM, 15, 4).unwrap();
         let (mut input, wr_test_results) = pine
             .flp
             .encode_with_wr_joint_rand([0.1; DIM].into_iter(), &Seed::generate().unwrap())

--- a/crates/daphne/src/pine/test_vec/mod.rs
+++ b/crates/daphne/src/pine/test_vec/mod.rs
@@ -176,14 +176,15 @@ impl<F: FftFriendlyFieldElement> Pine<F> {
 mod tests {
     use super::*;
 
-    use crate::pine::Pine;
+    use crate::pine::{norm_bound_f64_to_u64, Pine};
 
     #[test]
     fn run_64() {
         let test_vec =
             serde_json::from_str::<TestVec>(include_str!("00/Pine_Field64.json")).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(test_vec.l2_norm_bound, test_vec.num_frac_bits);
         Pine::new_64(
-            test_vec.l2_norm_bound,
+            norm_bound,
             test_vec.dimension,
             test_vec.num_frac_bits,
             test_vec.chunk_length,
@@ -196,8 +197,9 @@ mod tests {
     fn run_128() {
         let test_vec =
             serde_json::from_str::<TestVec>(include_str!("00/Pine_Field128.json")).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(test_vec.l2_norm_bound, test_vec.num_frac_bits);
         Pine::new_128(
-            test_vec.l2_norm_bound,
+            norm_bound,
             test_vec.dimension,
             test_vec.num_frac_bits,
             test_vec.chunk_length,

--- a/crates/daphne/src/pine/vdaf.rs
+++ b/crates/daphne/src/pine/vdaf.rs
@@ -594,14 +594,15 @@ mod tests {
         },
     };
 
-    use crate::pine::{msg, vdaf::PineVec, Pine};
+    use crate::pine::{msg, norm_bound_f64_to_u64, vdaf::PineVec, Pine};
 
     use assert_matches::assert_matches;
 
     #[test]
     fn run_128() {
         let dimension = 100;
-        let pine = Pine::new_128(1000.0, dimension, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 4).unwrap();
         let result = run_vdaf(
             &pine,
             &(),
@@ -620,7 +621,8 @@ mod tests {
     #[test]
     fn run_64() {
         let dimension = 100;
-        let pine = Pine::new_64(1000.0, dimension, 15, 100).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_64(norm_bound, dimension, 15, 100).unwrap();
         let result = run_vdaf(
             &pine,
             &(),
@@ -641,7 +643,8 @@ mod tests {
     fn aggregate() {
         let dimension = 100;
         let reports = 5;
-        let pine = Pine::new_128(1000.0, dimension, 15, 100).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 100).unwrap();
 
         let mut out_shares_0 = Vec::new();
         let mut out_shares_1 = Vec::new();
@@ -674,7 +677,8 @@ mod tests {
     #[test]
     fn prep_failure_mutated_pub_share_wr_joint_rand() {
         let dimension = 100;
-        let pine = Pine::new_128(1000.0, dimension, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 4).unwrap();
 
         let nonce = [0; 16];
         let (mut public_share, input_shares) = pine.shard(&vec![1.0; dimension], &nonce).unwrap();
@@ -693,7 +697,8 @@ mod tests {
     #[test]
     fn prep_failure_mutated_pub_share_vf_joint_rand() {
         let dimension = 100;
-        let pine = Pine::new_128(1000.0, dimension, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 4).unwrap();
 
         let nonce = [0; 16];
         let (mut public_share, input_shares) = pine.shard(&vec![1.0; dimension], &nonce).unwrap();
@@ -712,7 +717,8 @@ mod tests {
     #[test]
     fn prep_failure_mutated_input_share_proof() {
         let dimension = 100;
-        let pine = Pine::new_128(1000.0, dimension, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 4).unwrap();
 
         let nonce = [0; 16];
         let (public_share, mut input_shares) = pine.shard(&vec![1.0; dimension], &nonce).unwrap();
@@ -731,7 +737,8 @@ mod tests {
     #[test]
     fn prep_failure_mutated_input_share_meas() {
         let dimension = 100;
-        let pine = Pine::new_128(1000.0, dimension, 15, 4).unwrap();
+        let norm_bound = norm_bound_f64_to_u64(1000.0, 15);
+        let pine = Pine::new_128(norm_bound, dimension, 15, 4).unwrap();
 
         let nonce = [0; 16];
         let (public_share, mut input_shares) = pine.shard(&vec![1.0; dimension], &nonce).unwrap();

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -15,54 +15,15 @@ use prio::{codec::ParameterizedDecode, field::FftFriendlyFieldElement, vdaf::Agg
 use serde::{Deserialize, Serialize};
 
 /// [Pine](crate::pine::Pine) parameters.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub struct PineConfig {
-    pub norm_bound: f64,
+    pub norm_bound: u64,
     pub dimension: usize,
     pub frac_bits: usize,
     pub chunk_len: usize,
     pub var: PineVariant,
-}
-
-impl PartialEq for PineConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.norm_bound.total_cmp(&other.norm_bound).is_eq()
-            && self.dimension == other.dimension
-            && self.frac_bits == other.frac_bits
-            && self.chunk_len == other.chunk_len
-            && self.var == other.var
-    }
-}
-
-impl Eq for PineConfig {}
-
-impl Ord for PineConfig {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.norm_bound
-            .total_cmp(&other.norm_bound)
-            .then(self.dimension.cmp(&other.dimension))
-            .then(self.frac_bits.cmp(&other.frac_bits))
-            .then(self.chunk_len.cmp(&other.chunk_len))
-            .then(self.var.cmp(&self.var))
-    }
-}
-
-impl PartialOrd for PineConfig {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::hash::Hash for PineConfig {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.norm_bound.to_bits().hash(state);
-        self.dimension.hash(state);
-        self.frac_bits.hash(state);
-        self.chunk_len.hash(state);
-        self.var.hash(state);
-    }
 }
 
 impl std::fmt::Display for PineConfig {
@@ -278,7 +239,7 @@ mod test {
     async fn roundtrip_128(version: DapVersion) {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Pine(PineConfig {
-                norm_bound: 1.0,
+                norm_bound: 32_000,
                 dimension: 1_000,
                 frac_bits: 20,
                 chunk_len: 50,


### PR DESCRIPTION
Partially addresses #618.

Change the type of the `norm_bound` parameter of `Pine::new()` from `f64` and `u64`. The caller is expected to compute this as `b * 2^frac_bits`, where `b: 64` is the real-valued, L2-norm bound.

All parties must agree on the algorithm used to derive Pine's internal parameters from `norm_bound` parameter. Representing it this way is intended to the complexity of this algorithm.