### PR TITLE
Remove the http_status_code metric from the worker library

### DIFF
--- a/crates/daphne-worker/src/storage_proxy/metrics.rs
+++ b/crates/daphne-worker/src/storage_proxy/metrics.rs
@@ -7,9 +7,6 @@ pub struct Metrics {
     /// Number of retries done in durable object requests before returning (whether by success
     /// or failure).
     durable_request_retry_count: IntCounterVec,
-
-    /// HTTP response status.
-    http_status_code_counter: IntCounterVec,
 }
 
 impl Metrics {
@@ -21,29 +18,14 @@ impl Metrics {
             registry,
         ).unwrap();
 
-        let http_status_code_counter = register_int_counter_vec_with_registry!(
-            "http_status_code",
-            "HTTP response status code.",
-            &["code"],
-            registry
-        )
-        .unwrap();
-
         Self {
             durable_request_retry_count,
-            http_status_code_counter,
         }
     }
 
     pub fn durable_request_retry_count_inc(&self, number_of_retries: i8, object: &str, path: &str) {
         self.durable_request_retry_count
             .with_label_values(&[&number_of_retries.to_string(), object, path])
-            .inc();
-    }
-
-    pub fn count_http_status_code(&self, status_code: u16) {
-        self.http_status_code_counter
-            .with_label_values(&[&status_code.to_string()])
             .inc();
     }
 }


### PR DESCRIPTION
This should not be the responsability of this library, callers of it
should be allowed to choose how they count http status codes
