### PR TITLE
protocol: Handle invalid measurement for PINE more gracefully

### DIFF
--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -69,7 +69,9 @@ impl PineConfig {
         } = self;
 
         let DapMeasurement::F64Vec(gradient) = &measurement else {
-            return Err(VdafError::Dap(fatal_error!(err = "XXX")));
+            return Err(VdafError::Dap(fatal_error!(
+                err = "unexpected measurement type"
+            )));
         };
 
         match var {


### PR DESCRIPTION
Partially addresses #618.

It is fatal for the client to handle the wrong measurement type. When this happens for PINE, we currently output a useless error message. Replace this with a message that's more useful.