### PR TITLE
storage: add undocumented environment variable for location hinting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
  "reqwest-wasm",
  "ring",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "tracing",
  "tracing-core",
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa130f6f7e5a0b716e0f5472d412fe97962ded204d76ddaf3eeba7360dfcae93"
+checksum = "3cda58fc54ac88c54387c3a48f46fa066ccb48f2d81f7514dc6c240a2a13bf4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4129,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0f7f15151a77dca96813d0eff10ab9b29114533fae0267d00c466c13081e69"
+checksum = "cc9b615cb8673627508ceab81cd3a6080ff53d8de696bd5f5a08ac8bb1491a9c"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -4145,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ee9baa2ef3c7dea0e2165ff8aaad15e4c4cedb2d30a7deefd4999cd0ae96a3"
+checksum = "3ef1e184943d021cf4511d29ddf411a8e75ee511d4fc587f207b60ddcb9698a2"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.3.0"
 authors = [
-  "Christopher Patton <cpatton@cloudflare.com>",
-  "Armando Faz Hernandez <armfazh@cloudflare.com>",
-  "Pedro Mendes <pmendes@cloudflare.com>",
+    "Christopher Patton <cpatton@cloudflare.com>",
+    "Armando Faz Hernandez <armfazh@cloudflare.com>",
+    "Pedro Mendes <pmendes@cloudflare.com>",
 ]
 edition = "2021"
 license = "BSD-3-Clause"
@@ -67,7 +67,7 @@ reqwest = { version = "0.11.27", default-features = false, features = ["rustls-t
 reqwest-wasm = "0.11.16"
 ring = "0.17.8"
 serde = { version = "1.0.203", features = ["derive"] }
-serde-wasm-bindgen = "0.5.0"
+serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.118"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.61"
@@ -78,7 +78,7 @@ tracing-core = "0.1.32"
 tracing-subscriber = "0.3.18"
 url = { version = "2.5.2", features = ["serde"] }
 webpki = "0.22.4"
-worker = "0.2.0"
+worker = "0.3.3"
 x509-parser = "0.15.1"
 
 [workspace.dependencies.sentry]

--- a/crates/daphne-worker/src/storage_proxy/mod.rs
+++ b/crates/daphne-worker/src/storage_proxy/mod.rs
@@ -342,7 +342,13 @@ async fn handle_do_request(ctx: &mut RequestContext<'_>, uri: &str) -> worker::R
     loop {
         tracing::warn!(id = obj.to_string(), "Getting DO stub");
 
-        match obj.get_stub()?.fetch_with_request(do_req.clone()?).await {
+        let stub = if let Some(loc) = option_env!("DAPHNE_DO_REGION") {
+            obj.get_stub_with_location_hint(loc)
+        } else {
+            obj.get_stub()
+        }?;
+
+        match stub.fetch_with_request(do_req.clone()?).await {
             Ok(ok) => {
                 ctx.metrics.durable_request_retry_count_inc(
                     (attempt - 1).try_into().unwrap(),


### PR DESCRIPTION
For some of our uses at Cloudflare, it would be useful to deploy instances of Daphne which use location hints to pin DOs to specific DO regions.

This change adds this support as an undocumented build-time environment variable, DAPHNE_DO_REGION.

We can eventually work out whether we want this to be exposed in a different way or not, and then either document this environment variable and stabilize it or expose this data to the worker another way.