### PR TITLE
Ensure benches build

### DIFF
--- a/crates/daphne/Cargo.toml
+++ b/crates/daphne/Cargo.toml
@@ -64,6 +64,7 @@ harness = false
 [[bench]]
 name = "aggregation"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "pine"


### PR DESCRIPTION
The aggregation benchmark requires "test-utils" feature to build.