### PR TITLE
Force fatal_error invocations to include a handwritten message

### DIFF
--- a/crates/daphne/src/auth.rs
+++ b/crates/daphne/src/auth.rs
@@ -99,7 +99,7 @@ pub trait BearerTokenProvider {
                 .get_leader_bearer_token_for(task_id, task_config)
                 .await?
                 .ok_or_else(|| {
-                    fatal_error!(err = "attempted to authorize request with unknown task ID")
+                    fatal_error!(err = "attempted to authorize request with unknown task ID",)
                 })?;
             return Ok(token);
         }

--- a/crates/daphne/src/hpke.rs
+++ b/crates/daphne/src/hpke.rs
@@ -49,7 +49,7 @@ fn check_suite<T: HpkeCrypto>(
         u16::from(kdf_id),
         u16::from(aead_id)
     );
-    let maperr = |_| fatal_error!(err = s);
+    let maperr = |_| fatal_error!(err = s, "invalid hpke suite");
     let kem = KemAlgorithm::try_from(u16::from(kem_id)).map_err(maperr)?;
     let kdf = KdfAlgorithm::try_from(u16::from(kdf_id)).map_err(maperr)?;
     let aead = AeadAlgorithm::try_from(u16::from(aead_id)).map_err(maperr)?;
@@ -59,7 +59,10 @@ fn check_suite<T: HpkeCrypto>(
             KdfAlgorithm::HkdfSha256,
             AeadAlgorithm::Aes128Gcm,
         ) => Ok(Hpke::new(Mode::Base, kem, kdf, aead)),
-        _ => Err(fatal_error!(err = s)),
+        _ => Err(fatal_error!(
+            err = s,
+            "unsuported suite: {kem} + {kdf} + {aead}"
+        )),
     }
 }
 

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -984,19 +984,24 @@ impl DapAggregateShare {
                 self.data = Some(data);
             }
             (Some(VdafAggregateShare::Field64(left)), Some(VdafAggregateShare::Field64(right))) => {
-                left.merge(&right).map_err(|e| fatal_error!(err = ?e))?;
+                left.merge(&right).map_err(
+                    |e| fatal_error!(err = ?e, "failed to merge 64bit wide vdaf shares"),
+                )?;
             }
             (
                 Some(VdafAggregateShare::Field128(left)),
                 Some(VdafAggregateShare::Field128(right)),
             ) => {
-                left.merge(&right).map_err(|e| fatal_error!(err = ?e))?;
+                left.merge(&right).map_err(
+                    |e| fatal_error!(err = ?e, "failed to merge 128bit wide vdaf shares"),
+                )?;
             }
             (
                 Some(VdafAggregateShare::FieldPrio2(left)),
                 Some(VdafAggregateShare::FieldPrio2(right)),
             ) => {
-                left.merge(&right).map_err(|e| fatal_error!(err = ?e))?;
+                left.merge(&right)
+                    .map_err(|e| fatal_error!(err = ?e, "failed to merge prio2 vdaf shares"))?;
             }
 
             _ => return Err(fatal_error!(err = "invalid aggregate share merge")),

--- a/crates/daphne/src/roles/leader/in_memory_leader.rs
+++ b/crates/daphne/src/roles/leader/in_memory_leader.rs
@@ -132,7 +132,7 @@ impl InMemoryLeaderState {
                 task_id.to_base64url(),
                 coll_job_id.to_base64url(),
             ))
-            .map_err(|e| fatal_error!(err = ?e))?;
+            .map_err(|e| fatal_error!(err = ?e, "failed to calculate coll_job_uri"))?;
 
         // Store the collection job in the pending state.
         if per_task.coll_jobs.contains_key(coll_job_id) {

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -64,7 +64,7 @@ async fn leader_send_http_request<S: Sync>(
     let url = task_config
         .helper_url
         .join(path)
-        .map_err(|e| fatal_error!(err = ?e))?;
+        .map_err(|e| fatal_error!(err = ?e, "failed to helper url {:?} with {path:?}", task_config.helper_url))?;
 
     let req = DapRequest {
         version: task_config.version,
@@ -473,7 +473,7 @@ async fn run_coll_job<S: Sync, A: DapLeader<S>>(
         batch_sel: batch_sel.clone(),
         agg_param: agg_param
             .get_encoded()
-            .map_err(|e| fatal_error!(err = ?e))?,
+            .map_err(|e| fatal_error!(err = ?e, "failed to decode agg param"))?,
         report_count: leader_agg_share.report_count,
         checksum: leader_agg_share.checksum,
     };

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -86,7 +86,9 @@ impl PineConfig {
                     *chunk_len,
                     *chunk_len_sq_norm_equal,
                 )
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                .map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "failed to create pine field"))
+                })?;
                 shard_then_encode(&vdaf, gradient, nonce)
             }
         }
@@ -118,7 +120,9 @@ impl PineConfig {
                     *chunk_len,
                     *chunk_len_sq_norm_equal,
                 )
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                .map_err(
+                    |e| VdafError::Dap(fatal_error!(err = ?e, "failed to create pine from norm_bound({norm_bound}), dimension{dimension}, frac_bits({frac_bits}), chunk_len({chunk_len})"))
+                )?;
                 let (state, share) = prep_init(
                     vdaf,
                     verify_key,
@@ -167,7 +171,9 @@ impl PineConfig {
                     *chunk_len,
                     *chunk_len_sq_norm_equal,
                 )
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                .map_err(
+                    |e| VdafError::Dap(fatal_error!(err = ?e, "failed to create pine from norm_bound({norm_bound}), dimension{dimension}, frac_bits({frac_bits}), chunk_len({chunk_len})")),
+                )?;
                 let (out_share, outbound) =
                     prep_finish_from_shares(&vdaf, agg_id, state, share, peer_share_data)?;
                 let agg_share = VdafAggregateShare::Field128(prio::vdaf::AggregateShare::from(
@@ -204,7 +210,9 @@ impl PineConfig {
                     *chunk_len,
                     *chunk_len_sq_norm_equal,
                 )
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                .map_err(
+                    |e| VdafError::Dap(fatal_error!(err = ?e, "failed to create pine from norm_bound({norm_bound}), dimension{dimension}, frac_bits({frac_bits}), chunk_len({chunk_len})"))
+                )?;
                 let out_share = prep_finish(&vdaf, state, peer_message_data)?;
                 let agg_share = VdafAggregateShare::Field128(prio::vdaf::AggregateShare::from(
                     prio::vdaf::OutputShare::from(out_share.0),
@@ -240,7 +248,9 @@ impl PineConfig {
                     *chunk_len,
                     *chunk_len_sq_norm_equal,
                 )
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+                .map_err(
+                    |e| VdafError::Dap(fatal_error!(err = ?e, "failed to create pine from norm_bound({norm_bound}), dimension{dimension}, frac_bits({frac_bits}), chunk_len({chunk_len})"))
+                )?;
                 let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
                 Ok(DapAggregateResult::F64Vec(agg_res))
             }

--- a/crates/daphne/src/vdaf/prio2.rs
+++ b/crates/daphne/src/vdaf/prio2.rs
@@ -24,7 +24,9 @@ pub(crate) fn prio2_shard(
     measurement: DapMeasurement,
     nonce: &[u8; 16],
 ) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     let (public_share, input_shares) = match measurement {
         DapMeasurement::U32Vec(ref data) => vdaf.shard(data, nonce)?,
         _ => {
@@ -64,7 +66,9 @@ pub(crate) fn prio2_prep_init(
         )));
     };
 
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     <()>::get_decoded_with_param(&vdaf, public_share_data)?;
     let input_share: Share<FieldPrio2, 32> =
         Share::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
@@ -82,7 +86,9 @@ pub(crate) fn prio2_prep_finish_from_shares(
     host_share: VdafPrepMessage,
     peer_share_data: &[u8],
 ) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     let (out_share, outbound) = match (host_state, host_share) {
         (VdafPrepState::Prio2(state), VdafPrepMessage::Prio2Share(share)) => {
             let peer_share = Prio2PrepareShare::get_decoded_with_param(&state, peer_share_data)?;
@@ -112,7 +118,9 @@ pub(crate) fn prio2_prep_finish(
     host_state: VdafPrepState,
     peer_message_data: &[u8],
 ) -> Result<VdafAggregateShare, VdafError> {
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     <()>::get_decoded(peer_message_data)?;
     let out_share = match host_state {
         VdafPrepState::Prio2(state) => match vdaf.prepare_next(state, ())? {
@@ -139,7 +147,9 @@ pub(crate) fn prio2_decode_prep_state(
     agg_id: usize,
     bytes: &mut Cursor<&[u8]>,
 ) -> Result<VdafPrepState, VdafError> {
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     Ok(VdafPrepState::Prio2(Prio2PrepareState::decode_with_param(
         &(&vdaf, agg_id),
         bytes,
@@ -152,7 +162,9 @@ pub(crate) fn prio2_unshard<M: IntoIterator<Item = Vec<u8>>>(
     num_measurements: usize,
     encoded_agg_shares: M,
 ) -> Result<DapAggregateResult, VdafError> {
-    let vdaf = Prio2::new(dimension).map_err(|e| VdafError::Dap(fatal_error!(err = ?e)))?;
+    let vdaf = Prio2::new(dimension).map_err(|e| {
+        VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
+    })?;
     let mut agg_shares = Vec::with_capacity(vdaf.num_aggregators());
     for encoded in encoded_agg_shares {
         let agg_share = AggregateShare::get_decoded_with_param(&(&vdaf, &()), encoded.as_ref())?;


### PR DESCRIPTION
By forcing a handwritten message we can get better logs and avoid logs that lack
a message, like these ones:
![image](https://github.com/user-attachments/assets/baf4dfbb-2665-4179-8eae-5c0956300581)
