### PR TITLE
Populate ProblemDetails::instance

### DIFF
--- a/crates/daphne-server/src/roles/aggregator.rs
+++ b/crates/daphne-server/src/roles/aggregator.rs
@@ -88,7 +88,9 @@ impl DapAggregator<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
 
         let durable = self.durable();
         let mut requests = Vec::new();
@@ -122,7 +124,9 @@ impl DapAggregator<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
 
         let durable = self.durable();
         let mut requests = Vec::new();
@@ -322,7 +326,9 @@ impl DapAggregator<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
 
         // Check whether the request overlaps with previous requests. This is done by
         // checking the AggregateStore and seeing whether it requests for aggregate
@@ -351,7 +357,9 @@ impl DapAggregator<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
         let version = task_config.as_ref().version;
 
         let agg_span = task_config.batch_span_for_sel(&BatchSelector::FixedSizeByBatchId {
@@ -466,7 +474,9 @@ impl HpkeProvider for crate::App {
         let version = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?
             .version;
 
         Ok(self
@@ -495,7 +505,7 @@ impl HpkeDecrypter for crate::App {
             .get_task_config_for(task_id)
             .await?
             .as_ref()
-            .ok_or(DapAbort::UnrecognizedTask)?
+            .ok_or(DapAbort::UnrecognizedTask { task_id: *task_id })?
             .version;
         self.kv()
             .peek::<kv::prefix::HpkeReceiverConfigSet, _, _>(

--- a/crates/daphne-server/src/roles/leader.rs
+++ b/crates/daphne-server/src/roles/leader.rs
@@ -49,7 +49,7 @@ impl DapLeader<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapAbort::UnrecognizedTask)?;
+            .ok_or(DapAbort::UnrecognizedTask { task_id: *task_id })?;
 
         self.test_leader_state
             .lock()
@@ -61,7 +61,9 @@ impl DapLeader<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
 
         self.test_leader_state
             .lock()
@@ -79,7 +81,7 @@ impl DapLeader<DaphneAuth> for crate::App {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapAbort::UnrecognizedTask)?;
+            .ok_or(DapAbort::UnrecognizedTask { task_id: *task_id })?;
 
         self.test_leader_state.lock().await.init_collect_job(
             task_id,

--- a/crates/daphne/src/error/mod.rs
+++ b/crates/daphne/src/error/mod.rs
@@ -53,16 +53,7 @@ impl DapError {
             "encountered fatal error during encoding: {e}"
         )))
     }
-}
 
-impl FatalDapError {
-    #[doc(hidden)]
-    pub fn __use_the_macro(s: String) -> Self {
-        FatalDapError(s)
-    }
-}
-
-impl DapError {
     pub(crate) fn from_vdaf(e: VdafError) -> Self {
         match e {
             VdafError::Codec(..) | VdafError::Vdaf(..) => {
@@ -88,6 +79,13 @@ impl Display for FatalDapError {
 impl Debug for FatalDapError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+impl FatalDapError {
+    #[doc(hidden)]
+    pub fn __use_the_macro(s: String) -> Self {
+        FatalDapError(s)
     }
 }
 

--- a/crates/daphne/src/error/mod.rs
+++ b/crates/daphne/src/error/mod.rs
@@ -12,7 +12,7 @@ use prio::codec::CodecError;
 use self::aborts::ProblemDetails;
 
 /// DAP errors.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum DapError {
     /// Fatal error. If this triggers an abort, then treat this as an internal error.
     ///

--- a/crates/daphne/src/error/mod.rs
+++ b/crates/daphne/src/error/mod.rs
@@ -42,7 +42,7 @@ impl DapError {
             title: "Internal server error".into(),
             agg_job_id: None,
             task_id: None,
-            instance: None,
+            instance: "/problem-details/internal-server-error".into(),
             detail: None,
         }
     }

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -551,7 +551,7 @@ impl DapTaskConfig {
                             "report ID {} appears twice in the same aggregation job",
                             prep_init.report_share.report_metadata.id.to_base64url()
                         ),
-                        task_id: Some(*task_id),
+                        task_id: *task_id,
                     }
                     .into());
                 }
@@ -713,7 +713,7 @@ impl DapTaskConfig {
                     agg_job_resp.transitions.len(),
                     state.seq.len(),
                 ),
-                task_id: Some(*task_id),
+                task_id: *task_id,
             }
             .into());
         }
@@ -726,7 +726,7 @@ impl DapTaskConfig {
                         "report ID {} appears out of order in aggregation job response",
                         helper.report_id.to_base64url()
                     ),
-                    task_id: Some(*task_id),
+                    task_id: *task_id,
                 }
                 .into());
             }
@@ -743,7 +743,7 @@ impl DapTaskConfig {
                         // inevitable.
                         return Err(DapAbort::InvalidMessage {
                             detail: "The Helper's AggregationJobResp is invalid, but it may have already committed its state change. A batch mismatch is inevitable.".to_string(),
-                            task_id: Some(*task_id),
+                            task_id: *task_id,
                         }.into());
                     };
 

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -92,6 +92,6 @@ impl VdafConfig {
             #[cfg(feature = "experimental")]
             Self::Pine(pine) => pine.unshard(num_measurements, agg_shares),
         }
-        .map_err(DapError::from_vdaf)
+        .map_err(|e| fatal_error!(err = ?e, "failed to unshard agg_shares"))
     }
 }

--- a/crates/daphne/src/roles/aggregator.rs
+++ b/crates/daphne/src/roles/aggregator.rs
@@ -183,7 +183,7 @@ where
         let task_config = aggregator
             .get_task_config_for(&task_id)
             .await?
-            .ok_or(DapAbort::UnrecognizedTask)?;
+            .ok_or(DapAbort::UnrecognizedTask { task_id })?;
 
         // Check whether the DAP version in the request matches the task config.
         if task_config.as_ref().version != req.version {

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -48,7 +48,7 @@ pub async fn handle_agg_job_init_req<'req, S: Sync, A: DapHelper<S>>(
     let wrapped_task_config = aggregator
         .get_task_config_for(task_id)
         .await?
-        .ok_or(DapAbort::UnrecognizedTask)?;
+        .ok_or(DapAbort::UnrecognizedTask { task_id: *task_id })?;
     let task_config = wrapped_task_config.as_ref();
 
     if let Some(reason) = aggregator.unauthorized_reason(task_config, req).await? {
@@ -153,7 +153,7 @@ pub async fn handle_agg_share_req<'req, S: Sync, A: DapHelper<S>>(
     let wrapped_task_config = aggregator
         .get_task_config_for(req.task_id()?)
         .await?
-        .ok_or(DapAbort::UnrecognizedTask)?;
+        .ok_or(DapAbort::UnrecognizedTask { task_id: *task_id })?;
     let task_config = wrapped_task_config.as_ref();
 
     if let Some(reason) = aggregator.unauthorized_reason(task_config, req).await? {

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -269,7 +269,7 @@ fn check_part_batch(
         // TODO spec: Define this behavior.
         return Err(DapAbort::InvalidMessage {
             detail: "invalid aggregation parameter".into(),
-            task_id: Some(*task_id),
+            task_id: *task_id,
         });
     }
 

--- a/crates/daphne/src/roles/leader/in_memory_leader.rs
+++ b/crates/daphne/src/roles/leader/in_memory_leader.rs
@@ -88,7 +88,9 @@ impl InMemoryLeaderState {
         }
 
         let Some(per_task) = self.per_task.get(task_id) else {
-            return Err(DapError::Abort(DapAbort::UnrecognizedTask));
+            return Err(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }));
         };
 
         per_task
@@ -193,7 +195,9 @@ impl InMemoryLeaderState {
                 .cloned()
                 .unwrap_or(DapCollectionJob::Unknown))
         } else {
-            Err(DapError::Abort(DapAbort::UnrecognizedTask))
+            Err(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))
         }
     }
 

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -230,7 +230,10 @@ pub async fn handle_upload_req<S: Sync, A: DapLeader<S>>(
 
     // Check that the task has not expired.
     if report.report_metadata.time >= task_config.as_ref().not_after {
-        return Err(DapAbort::ReportTooLate.into());
+        return Err(DapAbort::ReportTooLate {
+            report_id: report.report_metadata.id,
+        }
+        .into());
     }
     if report.report_metadata.time
         < task_config.as_ref().not_before - task_config.as_ref().time_precision

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -212,7 +212,7 @@ pub async fn handle_upload_req<S: Sync, A: DapLeader<S>>(
                 "expected exactly two encrypted input shares; got {}",
                 report.encrypted_input_shares.len()
             ),
-            task_id: Some(*task_id),
+            task_id: *task_id,
         }
         .into());
     }

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -1069,7 +1069,7 @@ mod test {
         assert_eq!(
             leader::handle_upload_req(&*t.leader, &req).await,
             Err(DapError::Abort(DapAbort::UnrecognizedTask {
-                task_id: *task_id
+                task_id: TaskId([0; 32])
             }))
         );
     }

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -32,7 +32,7 @@ async fn check_batch<S: Sync>(
         // TODO spec: Define this behavior.
         return Err(DapAbort::InvalidMessage {
             detail: "invalid aggregation parameter".into(),
-            task_id: Some(*task_id),
+            task_id: *task_id,
         }
         .into());
     }

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -749,9 +749,11 @@ mod test {
             ..Default::default()
         };
 
-        assert_matches!(
-            aggregator::handle_hpke_config_req(&*t.leader, &req, Some(task_id)).await,
-            Err(DapError::Abort(DapAbort::UnrecognizedTask))
+        assert_eq!(
+            aggregator::handle_hpke_config_req(&*t.leader, &req, Some(task_id))
+                .await
+                .unwrap_err(),
+            DapError::Abort(DapAbort::UnrecognizedTask { task_id })
         );
     }
 
@@ -1064,9 +1066,11 @@ mod test {
         };
 
         // Expect failure due to invalid task ID in report.
-        assert_matches!(
+        assert_eq!(
             leader::handle_upload_req(&*t.leader, &req).await,
-            Err(DapError::Abort(DapAbort::UnrecognizedTask))
+            Err(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id
+            }))
         );
     }
 

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -1092,11 +1092,13 @@ mod test {
             ..Default::default()
         };
 
-        assert_matches!(
+        assert_eq!(
             leader::handle_upload_req(&*t.leader, &req)
                 .await
                 .unwrap_err(),
-            DapError::Abort(DapAbort::ReportTooLate)
+            DapError::Abort(DapAbort::ReportTooLate {
+                report_id: report.report_metadata.id
+            })
         );
     }
 

--- a/crates/daphne/src/taskprov.rs
+++ b/crates/daphne/src/taskprov.rs
@@ -139,7 +139,7 @@ fn get_taskprov_task_config<S>(
 
     if compute_task_id(taskprov_data.as_ref()) != *task_id {
         // Return unrecognizedTask following section 5.1 of the taskprov draft.
-        return Err(DapAbort::UnrecognizedTask);
+        return Err(DapAbort::UnrecognizedTask { task_id: *task_id });
     }
 
     // Return unrecognizedMessage if parsing fails following section 5.1 of the taskprov draft.

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -872,7 +872,9 @@ impl DapAggregator<BearerToken> for InMemoryAggregator {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
         let mut agg_store = self
             .agg_store
             .lock()
@@ -891,7 +893,9 @@ impl DapAggregator<BearerToken> for InMemoryAggregator {
         let task_config = self
             .get_task_config_for(task_id)
             .await?
-            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask))?;
+            .ok_or(DapError::Abort(DapAbort::UnrecognizedTask {
+                task_id: *task_id,
+            }))?;
 
         let aggregated = {
             let mut agg_store = self


### PR DESCRIPTION
- Add task id to DapAbort::UnrecognizedTask
- Add report id to DapAbort::ReportToLate
- Make task id mandatory in DapAbort::InvalidMessage
- Make ProblemDetails::instance mandatory per RFC9457
- Merge DapError impl blocks
