### PR TITLE
pine: Use a generic `Xof`

### DIFF
--- a/crates/daphne/src/pine/mod.rs
+++ b/crates/daphne/src/pine/mod.rs
@@ -13,9 +13,11 @@
 //!
 //! PINE is based on the scheme from [Rothblum et al. 2023](https://arxiv.org/abs/2311.10237).
 
+use std::marker::PhantomData;
+
 use prio::{
     field::{FftFriendlyFieldElement, Field128, Field64},
-    vdaf::VdafError,
+    vdaf::{xof::XofTurboShake128, VdafError},
 };
 
 use flp::{PineType, PineTypeSquaredNormEqual};
@@ -39,12 +41,13 @@ const USAGE_WR_JOINT_RAND_PART: u16 = 10;
 
 /// The PINE VDAF.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Pine<F> {
+pub struct Pine<F, X, const SEED_SIZE: usize> {
     pub flp: PineType<F>,
     pub flp_sq_norm_equal: PineTypeSquaredNormEqual<F>,
+    phantom_data: PhantomData<X>,
 }
 
-pub type Pine128 = Pine<Field128>;
+pub type Pine128 = Pine<Field128, XofTurboShake128, 16>;
 
 impl Pine128 {
     /// Construct an instance of [`Pine128`] with the provided parameters.
@@ -67,7 +70,7 @@ impl Pine128 {
     }
 }
 
-pub type Pine64 = Pine<Field64>;
+pub type Pine64 = Pine<Field64, XofTurboShake128, 16>;
 
 impl Pine64 {
     /// Construct an instance of [`Pine64`] with the provided parameters.
@@ -128,7 +131,7 @@ impl<F> PineConfig<F> {
     }
 }
 
-impl<F: FftFriendlyFieldElement> Pine<F> {
+impl<F: FftFriendlyFieldElement, X, const SEED_SIZE: usize> Pine<F, X, SEED_SIZE> {
     /// Construct an instance of the Pine VDAF.
     ///
     /// # Parameters
@@ -276,6 +279,7 @@ impl<F: FftFriendlyFieldElement> Pine<F> {
         Ok(Self {
             flp: PineType { cfg: cfg.clone() },
             flp_sq_norm_equal: PineTypeSquaredNormEqual { cfg },
+            phantom_data: PhantomData,
         })
     }
 }

--- a/crates/daphne/src/pine/test_vec/mod.rs
+++ b/crates/daphne/src/pine/test_vec/mod.rs
@@ -5,7 +5,7 @@
 use prio::{
     codec::Encode,
     field::FftFriendlyFieldElement,
-    vdaf::{Aggregator, Collector, PrepareTransition},
+    vdaf::{xof::XofTurboShake128, Aggregator, Collector, PrepareTransition},
 };
 use serde::Deserialize;
 
@@ -54,7 +54,7 @@ struct TestVec {
     agg_result: Vec<f64>,
 }
 
-impl<F: FftFriendlyFieldElement> Pine<F> {
+impl<F: FftFriendlyFieldElement> Pine<F, XofTurboShake128, 16> {
     fn run_test_vec(&self, test_vec: &TestVec) {
         // Check that the test vector parameters have the values we expect.
         //

--- a/crates/daphne/src/vdaf/mod.rs
+++ b/crates/daphne/src/vdaf/mod.rs
@@ -207,7 +207,7 @@ pub enum VdafPrepState {
         out_share: Vec<Field64>,
     },
     #[cfg(feature = "experimental")]
-    Pine128(PinePrepState<Field128>),
+    Pine128(PinePrepState<Field128, 16>),
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -277,7 +277,7 @@ pub enum VdafPrepMessage {
     #[cfg(feature = "experimental")]
     MasticShare(Field64),
     #[cfg(feature = "experimental")]
-    Pine128Share(crate::pine::msg::PrepShare<Field128>),
+    Pine128Share(crate::pine::msg::PrepShare<Field128, 16>),
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -11,7 +11,11 @@ use crate::{
 use super::{
     shard_then_encode, VdafAggregateShare, VdafError, VdafPrepMessage, VdafPrepState, VdafVerifyKey,
 };
-use prio::{codec::ParameterizedDecode, field::FftFriendlyFieldElement, vdaf::Aggregator};
+use prio::{
+    codec::ParameterizedDecode,
+    field::FftFriendlyFieldElement,
+    vdaf::{xof::Xof, Aggregator},
+};
 use serde::{Deserialize, Serialize};
 
 /// [Pine](crate::pine::Pine) parameters.
@@ -258,14 +262,14 @@ impl PineConfig {
     }
 }
 
-fn prep_init<F: FftFriendlyFieldElement>(
-    vdaf: Pine<F>,
-    verify_key: &[u8; 16],
+fn prep_init<F: FftFriendlyFieldElement, X: Xof<SEED_SIZE>, const SEED_SIZE: usize>(
+    vdaf: Pine<F, X, SEED_SIZE>,
+    verify_key: &[u8; SEED_SIZE],
     agg_id: usize,
     nonce: &[u8; 16],
     public_share_data: &[u8],
     input_share_data: &[u8],
-) -> Result<(PinePrepState<F>, msg::PrepShare<F>), VdafError> {
+) -> Result<(PinePrepState<F, SEED_SIZE>, msg::PrepShare<F, SEED_SIZE>), VdafError> {
     // Parse the public share.
     let public_share = msg::PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
 


### PR DESCRIPTION
Partially addresses #618.

The spec uses `XofTurboShake128`, but we will also need to support `XofHmacSha256Aes128`.