### PR TITLE
vdaf: Replace Pine128 with Pine64HmacSha256Aes128

### DIFF
--- a/crates/daphne/src/messages/taskprov.rs
+++ b/crates/daphne/src/messages/taskprov.rs
@@ -20,6 +20,8 @@ use super::{decode_u16_prefixed, encode_u16_prefixed};
 // VDAF type codes.
 const VDAF_TYPE_PRIO2: u32 = 0xFFFF_0000;
 pub(crate) const VDAF_TYPE_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMAC_SHA256_AES128: u32 = 0xFFFF_1003;
+#[cfg(feature = "experimental")]
+pub(crate) const VDAF_TYPE_PINE_FIELD64_HMAC_SHA256_AES128: u32 = 0xffff_1005;
 
 // Differential privacy mechanism types.
 const DP_MECHANISM_NONE: u8 = 0x01;

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -257,6 +257,7 @@ impl EarlyReportState for EarlyReportStateConsumed {
 }
 
 /// Report state during aggregation initialization after the VDAF preparation step.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(deepsize::DeepSizeOf))]
 pub enum EarlyReportStateInitialized {


### PR DESCRIPTION
Partially addresses #618.
Based on #656.

The latter variant will be deployed first.