### PR TITLE
vdaf: Add support for `Pine32HmacSha256Aes128`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "prio"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f86ecfd264aa77241b69044a91e7627b7cfdf88fb771835a7663eeec4543f75"
+checksum = "2e139374dfbada620828b9736ecef3959c8fea97caa8d9ba39d3e84966380978"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ matchit = "0.7.3"
 p256 = { version = "0.13.2", features = ["ecdsa-core", "ecdsa", "pem"] }
 paste = "1.0.15"
 pin-project = "1.1.5"
-prio = "0.16.5"
+prio = "0.16.7"
 prometheus = "0.13.4"
 rand = "0.8.5"
 rayon = "1.10.0"

--- a/crates/daphne-service-utils/src/durable_requests/bindings/aggregate_store.rs
+++ b/crates/daphne-service-utils/src/durable_requests/bindings/aggregate_store.rs
@@ -126,7 +126,7 @@ impl DurableRequestPayload for AggregateStoreMergeReq {
                     Some(VdafAggregateShare::Field128(field)) => {
                         encode(field, |len| data.init_field128(len));
                     }
-                    Some(VdafAggregateShare::FieldPrio2(field)) => {
+                    Some(VdafAggregateShare::Field32(field)) => {
                         encode(field, |len| data.init_field_prio2(len));
                     }
                     None => data.set_none(()),
@@ -174,7 +174,7 @@ impl DurableRequestPayload for AggregateStoreMergeReq {
                         Some(VdafAggregateShare::Field128(decode(field?)?))
                     }
                     dap_aggregate_share::data::Which::FieldPrio2(field) => {
-                        Some(VdafAggregateShare::FieldPrio2(decode(field?)?))
+                        Some(VdafAggregateShare::Field32(decode(field?)?))
                     }
                     dap_aggregate_share::data::Which::None(()) => None,
                 }
@@ -259,7 +259,7 @@ mod test {
                         })
                         .collect::<Vec<_>>(),
                 )),
-                VdafAggregateShare::FieldPrio2(AggregateShare::from(
+                VdafAggregateShare::Field32(AggregateShare::from(
                     (0..len)
                         .map(|_| {
                             // idk how to consistently generate a valid FieldPrio2 value, so I just

--- a/crates/daphne-worker/src/durable/aggregate_store.rs
+++ b/crates/daphne-worker/src/durable/aggregate_store.rs
@@ -66,9 +66,9 @@ const COLLECTED_KEY: &str = "collected";
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 enum VdafKind {
+    Field32,
     Field64,
     Field128,
-    FieldPrio2,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -88,9 +88,9 @@ impl DapAggregateShareMetadata {
             max_time: share.max_time,
             checksum: share.checksum,
             kind: share.data.as_ref().map(|data| match data {
+                daphne::vdaf::VdafAggregateShare::Field32(_) => VdafKind::Field32,
                 daphne::vdaf::VdafAggregateShare::Field64(_) => VdafKind::Field64,
                 daphne::vdaf::VdafAggregateShare::Field128(_) => VdafKind::Field128,
-                daphne::vdaf::VdafAggregateShare::FieldPrio2(_) => VdafKind::FieldPrio2,
             }),
         }
     }
@@ -299,11 +299,9 @@ impl AggregateStore {
                     }
 
                     let data = match kind {
+                        VdafKind::Field32 => VdafAggregateShare::Field32(from_slices(chunks)?),
                         VdafKind::Field64 => VdafAggregateShare::Field64(from_slices(chunks)?),
                         VdafKind::Field128 => VdafAggregateShare::Field128(from_slices(chunks)?),
-                        VdafKind::FieldPrio2 => {
-                            VdafAggregateShare::FieldPrio2(from_slices(chunks)?)
-                        }
                     };
 
                     meta.into_agg_share_with_data(data)

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -996,10 +996,7 @@ impl DapAggregateShare {
                     |e| fatal_error!(err = ?e, "failed to merge 128bit wide vdaf shares"),
                 )?;
             }
-            (
-                Some(VdafAggregateShare::FieldPrio2(left)),
-                Some(VdafAggregateShare::FieldPrio2(right)),
-            ) => {
+            (Some(VdafAggregateShare::Field32(left)), Some(VdafAggregateShare::Field32(right))) => {
                 left.merge(&right)
                     .map_err(|e| fatal_error!(err = ?e, "failed to merge prio2 vdaf shares"))?;
             }

--- a/crates/daphne/src/messages/taskprov.rs
+++ b/crates/daphne/src/messages/taskprov.rs
@@ -21,7 +21,9 @@ use super::{decode_u16_prefixed, encode_u16_prefixed};
 const VDAF_TYPE_PRIO2: u32 = 0xFFFF_0000;
 pub(crate) const VDAF_TYPE_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMAC_SHA256_AES128: u32 = 0xFFFF_1003;
 #[cfg(feature = "experimental")]
-pub(crate) const VDAF_TYPE_PINE_FIELD64_HMAC_SHA256_AES128: u32 = 0xffff_1005;
+pub(crate) const VDAF_TYPE_PINE_FIELD64_HMAC_SHA256_AES128: u32 = 0xffff_1004;
+#[cfg(feature = "experimental")]
+pub(crate) const VDAF_TYPE_PINE_FIELD32_HMAC_SHA256_AES128: u32 = 0xffff_1005;
 
 // Differential privacy mechanism types.
 const DP_MECHANISM_NONE: u8 = 0x01;

--- a/crates/daphne/src/vdaf/prio2.rs
+++ b/crates/daphne/src/vdaf/prio2.rs
@@ -108,7 +108,7 @@ pub(crate) fn prio2_prep_finish_from_shares(
             )))
         }
     };
-    let agg_share = VdafAggregateShare::FieldPrio2(vdaf.aggregate(&(), [out_share])?);
+    let agg_share = VdafAggregateShare::Field32(vdaf.aggregate(&(), [out_share])?);
     Ok((agg_share, outbound))
 }
 
@@ -137,7 +137,7 @@ pub(crate) fn prio2_prep_finish(
             )))
         }
     };
-    let agg_share = VdafAggregateShare::FieldPrio2(vdaf.aggregate(&(), [out_share])?);
+    let agg_share = VdafAggregateShare::Field32(vdaf.aggregate(&(), [out_share])?);
     Ok(agg_share)
 }
 


### PR DESCRIPTION
Partially addresses #618.
Based on #664.

This is a variant of PINE that uses the existing 32-bit field. Related changes:

* Update the `prio` crate to `0.16.7` in order to take advantage of the faster implementation of the 32-bit field arithmetic.

* Use the correct codepoint for `Pine64HmacSha256Aes128`.