### PR TITLE
Rewrite benchmarks and other small refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -962,6 +962,7 @@ dependencies = [
  "config",
  "daphne",
  "daphne-service-utils",
+ "dhat",
  "futures",
  "hex",
  "hpke-rs",
@@ -1131,6 +1132,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -2064,6 +2081,12 @@ checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
@@ -3425,6 +3448,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3755,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ config = "0.13.4"
 constcat = "0.5.0"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 deepsize = { version = "0.2.0" }
+dhat = "0.3.3"
 futures = "0.3.30"
 getrandom = "0.2.15"
 headers = "0.4"

--- a/crates/dapf/src/acceptance/load_testing.rs
+++ b/crates/dapf/src/acceptance/load_testing.rs
@@ -449,6 +449,7 @@ pub async fn execute_single_combination_from_env(
                             VERSION,
                             system_now.0,
                             vec![messages::Extension::Taskprov],
+                            t.replay_reports,
                         )
                     },
                 )

--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -492,7 +492,7 @@ impl Test {
         let agg_job_id = AggregationJobId(rngs::OsRng.gen());
         let report_count = reports_for_agg_job.len();
         let (agg_job_state, agg_job_init_req) = task_config
-            .produce_agg_job_req_allowing_replayed_reports(
+            .test_produce_agg_job_req(
                 fake_leader_hpke_receiver_config,
                 self,
                 task_id,
@@ -501,7 +501,7 @@ impl Test {
                 reports_for_agg_job,
                 self.metrics(),
                 if self.replay_reports {
-                    ReplayProtection::Disabled
+                    ReplayProtection::InsecureDisabled
                 } else {
                     ReplayProtection::Enabled
                 },

--- a/crates/dapf/src/http_client.rs
+++ b/crates/dapf/src/http_client.rs
@@ -150,7 +150,7 @@ impl HttpClient {
     }
 
     pub fn put<U: IntoUrl>(&self, url: U) -> RequestBuilder {
-        self.client().post(url)
+        self.client().put(url)
     }
 
     pub async fn get_hpke_config(

--- a/crates/dapf/src/main.rs
+++ b/crates/dapf/src/main.rs
@@ -399,10 +399,6 @@ async fn main() -> Result<()> {
         HttpClient::new_no_reuse(cli.enable_ssl_key_log_file)?
     };
 
-    if std::env::var("REPLAY_REPORTS").unwrap_or_default() == "1" {
-        daphne::testing::report_generator::replay_reports(true);
-    }
-
     match cli.action {
         Action::Leader(leader) => handle_leader_actions(leader, http_client).await,
         Action::Hpke(hpke) => handle_hpke_actions(hpke, http_client).await,

--- a/crates/daphne-server/Cargo.toml
+++ b/crates/daphne-server/Cargo.toml
@@ -44,11 +44,13 @@ clap.workspace = true
 config.workspace = true
 daphne = { path = "../daphne", features = ["test-utils"] }
 daphne-service-utils = { path = "../daphne-service-utils", features = ["prometheus"] }
+dhat.workspace = true
 hpke-rs.workspace = true
 paste.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 rcgen.workspace = true
+tokio = { workspace = true, features = ["signal"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 webpki.workspace = true
 x509-parser.workspace = true

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -26,7 +26,7 @@ pub async fn fetch_replay_protection_override(kv: Kv<'_>) -> ReplayProtection {
         .unwrap_or_default(); // treat missing as false
     if skip_replay_protection {
         tracing::debug!("replay protection is disabled");
-        ReplayProtection::Disabled
+        ReplayProtection::InsecureDisabled
     } else {
         ReplayProtection::Enabled
     }

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -387,7 +387,7 @@ pub(crate) enum ReportProcessedStatus {
 pub enum ReplayProtection {
     #[default]
     Enabled,
-    Disabled,
+    InsecureDisabled,
 }
 
 impl ReplayProtection {
@@ -396,7 +396,7 @@ impl ReplayProtection {
     }
 
     pub const fn disabled(&self) -> bool {
-        matches!(self, ReplayProtection::Disabled)
+        matches!(self, ReplayProtection::InsecureDisabled)
     }
 }
 
@@ -555,7 +555,7 @@ impl DapTaskConfig {
 
     #[allow(clippy::too_many_arguments)]
     #[cfg(any(test, feature = "test-utils"))]
-    pub async fn produce_agg_job_req_allowing_replayed_reports<S>(
+    pub async fn test_produce_agg_job_req<S>(
         &self,
         decrypter: &impl HpkeDecrypter,
         initializer: &impl DapReportInitializer,

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -383,7 +383,7 @@ pub(crate) enum ReportProcessedStatus {
     Rejected(TransitionFailure),
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum ReplayProtection {
     #[default]
     Enabled,

--- a/crates/daphne/src/roles/leader/in_memory_leader.rs
+++ b/crates/daphne/src/roles/leader/in_memory_leader.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 #[derive(Default)]
+#[cfg_attr(feature = "test-utils", derive(deepsize::DeepSizeOf))]
 pub struct InMemoryLeaderState {
     work_queue: VecDeque<WorkItem>,
     per_task: HashMap<TaskId, MockLeaderMemoryPerTask>,
@@ -232,6 +233,7 @@ impl InMemoryLeaderState {
 }
 
 #[derive(Default)]
+#[cfg_attr(feature = "test-utils", derive(deepsize::DeepSizeOf))]
 struct MockLeaderMemoryPerTask {
     pending_reports: HashMap<DapBatchBucket, VecDeque<Report>>,
     coll_jobs: HashMap<CollectionJobId, DapCollectionJob>,

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -146,7 +146,7 @@ async fn resolve_taskprov<S: Sync>(
 
 #[cfg(test)]
 mod test {
-    use super::{aggregator, helper, leader, DapAuthorizedSender, DapLeader};
+    use super::{aggregator, helper, leader, DapAggregator, DapAuthorizedSender, DapLeader};
     #[cfg(feature = "experimental")]
     use crate::vdaf::{mastic::MasticWeight, MasticWeightConfig};
     use crate::{
@@ -501,7 +501,7 @@ mod test {
                     &part_batch_sel,
                     &agg_param,
                     futures::stream::iter(reports),
-                    &self.leader.metrics,
+                    self.leader.metrics(),
                 )
                 .await
                 .unwrap();

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -146,7 +146,7 @@ async fn resolve_taskprov<S: Sync>(
 
 #[cfg(test)]
 mod test {
-    use super::{aggregator, helper, leader, DapAggregator, DapAuthorizedSender, DapLeader};
+    use super::{aggregator, helper, leader, DapAuthorizedSender, DapLeader};
     #[cfg(feature = "experimental")]
     use crate::vdaf::{mastic::MasticWeight, MasticWeightConfig};
     use crate::{
@@ -160,7 +160,7 @@ mod test {
             Extension, HpkeCiphertext, Interval, PartialBatchSelector, Query, Report, TaskId, Time,
             TransitionFailure, TransitionVar,
         },
-        roles::leader::WorkItem,
+        roles::{leader::WorkItem, DapAggregator},
         testing::InMemoryAggregator,
         vdaf::{Prio3Config, VdafConfig},
         DapAbort, DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapCollectionJob,
@@ -1625,8 +1625,8 @@ mod test {
         .to_config_with_taskprov(
             b"cool task".to_vec(),
             t.now,
-            &t.leader.taskprov_vdaf_verify_key_init,
-            &t.leader.collector_hpke_config,
+            t.leader.taskprov_vdaf_verify_key_init().unwrap(),
+            t.leader.taskprov_collector_hpke_config().unwrap(),
         )
         .unwrap();
 

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -204,7 +204,7 @@ impl AggregationJobTest {
     }
 
     pub fn disable_replay_protection(&mut self) {
-        self.replay_protection = ReplayProtection::Disabled;
+        self.replay_protection = ReplayProtection::InsecureDisabled;
     }
 
     pub fn change_vdaf(&mut self, vdaf: VdafConfig) {
@@ -262,7 +262,7 @@ impl AggregationJobTest {
         reports: impl IntoIterator<Item = Report>,
     ) -> (DapAggregationJobState, AggregationJobInitReq) {
         self.task_config
-            .produce_agg_job_req_allowing_replayed_reports(
+            .test_produce_agg_job_req(
                 &self.leader_hpke_receiver_config,
                 self,
                 &self.task_id,

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -262,7 +262,7 @@ impl AggregationJobTest {
         reports: impl IntoIterator<Item = Report>,
     ) -> (DapAggregationJobState, AggregationJobInitReq) {
         self.task_config
-            .produce_agg_job_req(
+            .produce_agg_job_req_allowing_replayed_reports(
                 &self.leader_hpke_receiver_config,
                 self,
                 &self.task_id,
@@ -270,6 +270,7 @@ impl AggregationJobTest {
                 agg_param,
                 futures::stream::iter(reports),
                 &self.leader_metrics,
+                self.replay_protection,
             )
             .await
             .unwrap()


### PR DESCRIPTION
- Rewrite the aggregation benchmark
- Stop using a global variable to control replay protection in tests and dapf
- Make more fields in InMemoryAggregator private
- Fix dapf http client
- Add dhat profiling to helper
- Add benchmark results
