### PR TITLE
Fix mtls usage in dapf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "reqwest 0.12.7",
  "rustls 0.23.12",
  "rustls-native-certs 0.7.2",
+ "rustls-pemfile 2.1.3",
  "sentry",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ reqwest-wasm = "0.11.16"
 ring = "0.17.8"
 rustls = "0.23.10"
 rustls-native-certs = "0.7"
+rustls-pemfile = "2.1.3"
 serde = { version = "1.0.203", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.118"

--- a/crates/dapf/Cargo.toml
+++ b/crates/dapf/Cargo.toml
@@ -30,6 +30,7 @@ rayon.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 rustls.workspace = true
 rustls-native-certs.workspace = true
+rustls-pemfile.workspace = true
 sentry.workspace = true
 serde_json.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
When SSLKEYLOGFILE support was introduced it silently drops support for
mtls. This commit re enables support for mtls without loosing support
for SSLKEYLOGFILE
