### PR TITLE
Don't require async when decrypting reports

### DIFF
--- a/crates/dapf/src/main.rs
+++ b/crates/dapf/src/main.rs
@@ -588,18 +588,15 @@ async fn handle_leader_actions(
             })?;
             let version = deduce_dap_version_from_url(&uri)?;
             let collect_resp = Collection::get_decoded_with_param(&version, &resp.bytes().await?)?;
-            let agg_res = vdaf_config
-                .into_vdaf()
-                .consume_encrypted_agg_shares(
-                    receiver,
-                    &task_id,
-                    &batch_selector,
-                    collect_resp.report_count,
-                    &DapAggregationParam::Empty,
-                    collect_resp.encrypted_agg_shares.to_vec(),
-                    version,
-                )
-                .await?;
+            let agg_res = vdaf_config.into_vdaf().consume_encrypted_agg_shares(
+                receiver,
+                &task_id,
+                &batch_selector,
+                collect_resp.report_count,
+                &DapAggregationParam::Empty,
+                collect_resp.encrypted_agg_shares.to_vec(),
+                version,
+            )?;
 
             print!("{}", serde_json::to_string(&agg_res)?);
             Ok(())

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -554,7 +554,6 @@ async fn leader_collect_ok(version: DapVersion) {
             collection.encrypted_agg_shares.to_vec(),
             version,
         )
-        .await
         .unwrap();
     assert_eq!(
         agg_res,
@@ -998,7 +997,6 @@ async fn fixed_size() {
             collection.encrypted_agg_shares.to_vec(),
             version,
         )
-        .await
         .unwrap();
     assert_eq!(
         agg_res,
@@ -1210,7 +1208,6 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
             collection.encrypted_agg_shares.to_vec(),
             version,
         )
-        .await
         .unwrap();
     assert_eq!(
         agg_res,

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -97,7 +97,7 @@ pub enum EarlyReportStateConsumed {
 }
 
 impl EarlyReportStateConsumed {
-    pub(crate) async fn consume(
+    pub(crate) fn consume(
         decrypter: &impl HpkeDecrypter,
         initializer: &impl DapReportInitializer,
         is_leader: bool,
@@ -463,22 +463,19 @@ impl DapTaskConfig {
 
                 let [leader_share, helper_share] = report.encrypted_input_shares;
 
-                consumed_reports.push(
-                    EarlyReportStateConsumed::consume(
-                        &decrypter,
-                        initializer,
-                        true,
-                        task_id,
-                        self,
-                        ReportShare {
-                            report_metadata: report.report_metadata,
-                            public_share: report.public_share,
-                            encrypted_input_share: leader_share,
-                        },
-                        None,
-                    )
-                    .await?,
-                );
+                consumed_reports.push(EarlyReportStateConsumed::consume(
+                    &decrypter,
+                    initializer,
+                    true,
+                    task_id,
+                    self,
+                    ReportShare {
+                        report_metadata: report.report_metadata,
+                        public_share: report.public_share,
+                        encrypted_input_share: leader_share,
+                    },
+                    None,
+                )?);
                 helper_shares.push(helper_share);
             }
         }
@@ -611,18 +608,15 @@ impl DapTaskConfig {
                     processed.insert(prep_init.report_share.report_metadata.id);
                 }
 
-                consumed_reports.push(
-                    EarlyReportStateConsumed::consume(
-                        decrypter,
-                        initializer,
-                        false,
-                        task_id,
-                        self,
-                        prep_init.report_share,
-                        Some(prep_init.payload),
-                    )
-                    .await?,
-                );
+                consumed_reports.push(EarlyReportStateConsumed::consume(
+                    decrypter,
+                    initializer,
+                    false,
+                    task_id,
+                    self,
+                    prep_init.report_share,
+                    Some(prep_init.payload),
+                )?);
             }
             Ok::<_, DapError>(())
         }

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -31,7 +31,7 @@ impl VdafConfig {
     ///
     /// * `version` is the `DapVersion` to use.
     #[allow(clippy::too_many_arguments)]
-    pub async fn consume_encrypted_agg_shares(
+    pub fn consume_encrypted_agg_shares(
         &self,
         decrypter: &impl HpkeDecrypter,
         task_id: &TaskId,

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -68,9 +68,7 @@ impl VdafConfig {
                 CTX_ROLE_HELPER
             };
 
-            let agg_share_data = decrypter
-                .hpke_decrypt(task_id, &info, &aad, agg_share_ciphertext)
-                .await?;
+            let agg_share_data = decrypter.hpke_decrypt(&info, &aad, agg_share_ciphertext)?;
             agg_shares.push(agg_share_data);
         }
 

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -47,7 +47,7 @@ mod test {
 
     const TEST_VDAF: &VdafConfig = &VdafConfig::Prio3(Prio3Config::Count);
 
-    async fn roundtrip_report(version: DapVersion) {
+    fn roundtrip_report(version: DapVersion) {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let report = t
             .task_config
@@ -76,7 +76,6 @@ mod test {
             },
             None,
         )
-        .await
         .unwrap();
         let EarlyReportStateInitialized::Ready {
             prep_share: leader_prep_share,
@@ -107,7 +106,6 @@ mod test {
             },
             None,
         )
-        .await
         .unwrap();
         let EarlyReportStateInitialized::Ready {
             prep_share: helper_prep_share,
@@ -166,7 +164,7 @@ mod test {
         }
     }
 
-    async_test_versions! { roundtrip_report }
+    test_versions! { roundtrip_report }
 
     fn roundtrip_report_unsupported_hpke_suite(version: DapVersion) {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
@@ -654,7 +652,7 @@ mod test {
         assert_eq!(leader_agg_span.report_count(), 2);
     }
 
-    async fn encrypted_agg_share(version: DapVersion) {
+    fn encrypted_agg_share(version: DapVersion) {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let leader_agg_share = DapAggregateShare {
             report_count: 50,
@@ -691,21 +689,19 @@ mod test {
             &DapAggregationParam::Empty,
             &helper_agg_share,
         );
-        let agg_res = t
-            .consume_encrypted_agg_shares(
-                &batch_selector,
-                50,
-                &DapAggregationParam::Empty,
-                vec![leader_encrypted_agg_share, helper_encrypted_agg_share],
-            )
-            .await;
+        let agg_res = t.consume_encrypted_agg_shares(
+            &batch_selector,
+            50,
+            &DapAggregationParam::Empty,
+            vec![leader_encrypted_agg_share, helper_encrypted_agg_share],
+        );
 
         assert_eq!(agg_res, DapAggregateResult::U64(32));
     }
 
-    async_test_versions! { encrypted_agg_share }
+    test_versions! { encrypted_agg_share }
 
-    async fn handle_unrecognized_report_extensions(version: DapVersion) {
+    fn handle_unrecognized_report_extensions(version: DapVersion) {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let report = t
             .task_config
@@ -738,7 +734,6 @@ mod test {
             },
             None,
         )
-        .await
         .unwrap();
 
         assert_eq!(consumed_report.metadata(), &report_metadata);
@@ -747,9 +742,9 @@ mod test {
         assert!(!consumed_report.is_ready());
     }
 
-    async_test_versions! { handle_unrecognized_report_extensions }
+    test_versions! { handle_unrecognized_report_extensions }
 
-    async fn handle_repeated_report_extensions(version: DapVersion) {
+    fn handle_repeated_report_extensions(version: DapVersion) {
         let t = AggregationJobTest::new(TEST_VDAF, HpkeKemId::X25519HkdfSha256, version);
         let report = t
             .task_config
@@ -788,14 +783,13 @@ mod test {
             },
             None,
         )
-        .await
         .unwrap();
 
         assert_eq!(consumed_report.metadata(), &report_metadata);
         assert!(!consumed_report.is_ready());
     }
 
-    async_test_versions! { handle_repeated_report_extensions }
+    test_versions! { handle_repeated_report_extensions }
 
     impl AggregationJobTest {
         // Tweak the Helper's share so that decoding succeeds but preparation fails.

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -68,7 +68,7 @@ pub async fn handle_agg_job_init_req<A: DapHelper>(
     let version = req.version;
     let initialized_reports = task_config
         .consume_agg_job_req(
-            aggregator,
+            &aggregator.get_receiver_configs(task_config.version).await?,
             aggregator,
             &task_id,
             req.payload,

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -323,10 +323,9 @@ async fn run_agg_job<A: DapLeader>(
 
     // Prepare AggregationJobInitReq.
     let agg_job_id = AggregationJobId(thread_rng().gen());
-    let decrypter = aggregator.get_receiver_configs(task_config.version).await?;
     let (agg_job_state, agg_job_init_req) = task_config
         .produce_agg_job_req(
-            decrypter,
+            aggregator.get_receiver_configs(task_config.version).await?,
             aggregator,
             task_id,
             part_batch_sel,

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -323,9 +323,10 @@ async fn run_agg_job<A: DapLeader>(
 
     // Prepare AggregationJobInitReq.
     let agg_job_id = AggregationJobId(thread_rng().gen());
+    let decrypter = aggregator.get_receiver_configs(task_config.version).await?;
     let (agg_job_state, agg_job_init_req) = task_config
         .produce_agg_job_req(
-            aggregator,
+            decrypter,
             aggregator,
             task_id,
             part_batch_sel,

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -460,7 +460,7 @@ mod test {
 
             let (leader_state, agg_job_init_req) = task_config
                 .produce_agg_job_req(
-                    &*self.leader,
+                    &*self.leader.hpke_receiver_config_list,
                     &*self.leader,
                     task_id,
                     &part_batch_sel,

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -371,7 +371,7 @@ impl AggregationJobTest {
     }
 
     /// Collector: Consume the aggregate shares.
-    pub async fn consume_encrypted_agg_shares(
+    pub fn consume_encrypted_agg_shares(
         &self,
         batch_selector: &BatchSelector,
         report_count: u64,
@@ -389,7 +389,6 @@ impl AggregationJobTest {
                 enc_agg_shares,
                 self.task_config.version,
             )
-            .await
             .unwrap()
     }
 
@@ -439,7 +438,6 @@ impl AggregationJobTest {
             &agg_param,
             vec![leader_encrypted_agg_share, helper_encrypted_agg_share],
         )
-        .await
     }
 }
 


### PR DESCRIPTION
Decrypting reports usually happens as they are consumed, which is a CPU bound
task. Not requiring async for this has a few advantages:
- it can be more easily offloaded to a thread outside the async runtime to
    prevent it from blocking the runtime
- it can be more easily benchmarked and flamegraphed, as flamegraphing async
    functions is almost impossible
