### PR TITLE
Trim daphne-server-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,22 +987,12 @@ dependencies = [
 name = "daphne-service-utils"
 version = "0.3.0"
 dependencies = [
- "async-trait",
  "capnp",
  "capnpc",
  "daphne",
- "futures",
- "hex",
- "itertools 0.12.1",
- "p256",
  "prio",
- "prometheus",
  "rand",
- "rayon",
- "ring",
  "serde",
- "serde_json",
- "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ base64 = "0.21.7"
 bytes = "1"
 cap = "0.1.2"
 capnp = "0.18.13"
+capnpc = "0.18.1"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "wasmbind"] }
 clap = { version = "4.5.7", features = ["derive"] }

--- a/crates/daphne-server/Cargo.toml
+++ b/crates/daphne-server/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 repository.workspace = true
 description = "Workers backend for Daphne"
 
+[package.metadata."docs.rs"]
+all-features = true
+
 [dependencies]
 axum = "0.6.0" # held back to use http 0.2
 daphne = { path = "../daphne" }
@@ -24,6 +27,7 @@ hyper.workspace = true
 mappable-rc.workspace = true
 p256.workspace = true
 prio.workspace = true
+prometheus = { workspace = true, optional = true }
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -44,7 +48,7 @@ assert_matches.workspace = true
 clap.workspace = true
 config.workspace = true
 daphne = { path = "../daphne", features = ["test-utils"] }
-daphne-service-utils = { path = "../daphne-service-utils", features = ["prometheus", "test-utils"] }
+daphne-service-utils = { path = "../daphne-service-utils", features = ["test-utils"] }
 dhat.workspace = true
 hpke-rs.workspace = true
 paste.workspace = true
@@ -58,8 +62,10 @@ webpki.workspace = true
 x509-parser.workspace = true
 
 [features]
+default = ["prometheus"]
 test-utils = ["daphne/test-utils", "daphne-service-utils/test-utils"]
 test_e2e = []
+prometheus = ["dep:prometheus", "daphne/prometheus"]
 
 [lints]
 workspace = true

--- a/crates/daphne-server/examples/service.rs
+++ b/crates/daphne-server/examples/service.rs
@@ -4,8 +4,10 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use daphne_server::{metrics::DaphnePromServiceMetrics, router, App, StorageProxyConfig};
-use daphne_service_utils::{config::DaphneServiceConfig, DapRole};
+use daphne_server::{
+    config::DaphneServiceConfig, metrics::DaphnePromServiceMetrics, router, App, StorageProxyConfig,
+};
+use daphne_service_utils::DapRole;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::EnvFilter;
 use url::Url;

--- a/crates/daphne-server/examples/service.rs
+++ b/crates/daphne-server/examples/service.rs
@@ -4,10 +4,8 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use daphne_server::{router, App, StorageProxyConfig};
-use daphne_service_utils::{
-    config::DaphneServiceConfig, metrics::DaphnePromServiceMetrics, DapRole,
-};
+use daphne_server::{metrics::DaphnePromServiceMetrics, router, App, StorageProxyConfig};
+use daphne_service_utils::{config::DaphneServiceConfig, DapRole};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::EnvFilter;
 use url::Url;

--- a/crates/daphne-server/src/config.rs
+++ b/crates/daphne-server/src/config.rs
@@ -5,11 +5,10 @@ use daphne::{
     hpke::{HpkeConfig, HpkeReceiverConfig},
     DapGlobalConfig, DapVersion,
 };
+use daphne_service_utils::{bearer_token::BearerToken, DapRole};
 use p256::ecdsa::SigningKey;
 use serde::{Deserialize, Serialize};
 use url::Url;
-
-use crate::{bearer_token::BearerToken, DapRole};
 
 /// draft-wang-ppm-dap-taskprov: Long-lived parameters for the taskprov extension.
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/daphne-server/src/lib.rs
+++ b/crates/daphne-server/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use config::{DaphneServiceConfig, PeerBearerToken};
 use daphne::{
     audit_log::{AuditLog, NoopAuditLog},
     fatal_error,
@@ -10,10 +11,7 @@ use daphne::{
     roles::{leader::in_memory_leader::InMemoryLeaderState, DapAggregator},
     DapError, DapSender,
 };
-use daphne_service_utils::{
-    bearer_token::BearerToken,
-    config::{DaphneServiceConfig, PeerBearerToken},
-};
+use daphne_service_utils::bearer_token::BearerToken;
 use either::Either::{self, Left, Right};
 use futures::lock::Mutex;
 use metrics::DaphneServiceMetrics;
@@ -23,6 +21,7 @@ use storage_proxy_connection::{kv, Do, Kv};
 use tokio::sync::RwLock;
 use url::Url;
 
+pub mod config;
 pub mod metrics;
 mod roles;
 pub mod router;
@@ -50,11 +49,9 @@ mod storage_proxy_connection;
 ///     router,
 ///     StorageProxyConfig,
 ///     metrics::DaphnePromServiceMetrics,
-/// };
-/// use daphne_service_utils::{
 ///     config::DaphneServiceConfig,
-///     DapRole,
 /// };
+/// use daphne_service_utils::DapRole;
 ///
 /// let storage_proxy_settings = StorageProxyConfig {
 ///     url: Url::parse("http://example.com").unwrap(),

--- a/crates/daphne-server/src/lib.rs
+++ b/crates/daphne-server/src/lib.rs
@@ -13,16 +13,17 @@ use daphne::{
 use daphne_service_utils::{
     bearer_token::BearerToken,
     config::{DaphneServiceConfig, PeerBearerToken},
-    metrics::DaphneServiceMetrics,
 };
 use either::Either::{self, Left, Right};
 use futures::lock::Mutex;
+use metrics::DaphneServiceMetrics;
 use roles::BearerTokens;
 use serde::{Deserialize, Serialize};
 use storage_proxy_connection::{kv, Do, Kv};
 use tokio::sync::RwLock;
 use url::Url;
 
+pub mod metrics;
 mod roles;
 pub mod router;
 mod storage_proxy_connection;
@@ -44,11 +45,15 @@ mod storage_proxy_connection;
 /// use std::num::NonZeroUsize;
 /// use url::Url;
 /// use daphne::{DapGlobalConfig, hpke::HpkeKemId, DapVersion};
-/// use daphne_server::{App, router, StorageProxyConfig};
+/// use daphne_server::{
+///     App,
+///     router,
+///     StorageProxyConfig,
+///     metrics::DaphnePromServiceMetrics,
+/// };
 /// use daphne_service_utils::{
 ///     config::DaphneServiceConfig,
 ///     DapRole,
-///     metrics::DaphnePromServiceMetrics
 /// };
 ///
 /// let storage_proxy_settings = StorageProxyConfig {

--- a/crates/daphne-server/src/metrics.rs
+++ b/crates/daphne-server/src/metrics.rs
@@ -18,7 +18,7 @@ pub enum AuthMethod {
     TlsClientAuth,
 }
 
-#[cfg(any(feature = "prometheus", feature = "test-utils", test))]
+#[cfg(any(feature = "prometheus", test))]
 mod prometheus {
     use super::DaphneServiceMetrics;
     use daphne::{
@@ -131,5 +131,5 @@ mod prometheus {
     }
 }
 
-#[cfg(any(feature = "prometheus", feature = "test-utils", test))]
+#[cfg(any(feature = "prometheus", test))]
 pub use prometheus::DaphnePromServiceMetrics;

--- a/crates/daphne-server/src/router/extractor.rs
+++ b/crates/daphne-server/src/router/extractor.rs
@@ -18,10 +18,12 @@ use daphne::{
     },
     DapError, DapRequest, DapRequestMeta, DapResource, DapVersion,
 };
-use daphne_service_utils::{bearer_token::BearerToken, http_headers, metrics};
+use daphne_service_utils::{bearer_token::BearerToken, http_headers};
 use http::{header::CONTENT_TYPE, HeaderMap, Request};
 use prio::codec::ParameterizedDecode;
 use serde::Deserialize;
+
+use crate::metrics;
 
 use super::{AxumDapResponse, DaphneService};
 
@@ -265,9 +267,7 @@ mod test {
         messages::{AggregationJobId, Base64Encode, CollectionJobId, TaskId},
         DapError, DapRequestMeta, DapResource, DapSender, DapVersion,
     };
-    use daphne_service_utils::{
-        bearer_token::BearerToken, http_headers, metrics::DaphnePromServiceMetrics,
-    };
+    use daphne_service_utils::{bearer_token::BearerToken, http_headers};
     use either::Either::{self, Left};
     use futures::{future::BoxFuture, FutureExt};
     use rand::{thread_rng, Rng};
@@ -276,6 +276,8 @@ mod test {
         time::timeout,
     };
     use tower::ServiceExt;
+
+    use crate::metrics::{DaphnePromServiceMetrics, DaphneServiceMetrics};
 
     const BEARER_TOKEN: &str = "test-token";
 
@@ -303,7 +305,7 @@ mod test {
 
         #[axum::async_trait]
         impl super::DaphneService for Channel {
-            fn server_metrics(&self) -> &dyn daphne_service_utils::metrics::DaphneServiceMetrics {
+            fn server_metrics(&self) -> &dyn DaphneServiceMetrics {
                 // These tests don't care about metrics so we just store a static instance here so I
                 // can implement the DaphneService trait for Channel.
                 static METRICS: OnceLock<DaphnePromServiceMetrics> = OnceLock::new();

--- a/crates/daphne-server/src/router/mod.rs
+++ b/crates/daphne-server/src/router/mod.rs
@@ -22,11 +22,11 @@ use daphne::{
     error::DapAbort, fatal_error, messages::TaskId, DapError, DapRequestMeta, DapResponse,
     DapSender,
 };
-use daphne_service_utils::{bearer_token::BearerToken, metrics::DaphneServiceMetrics, DapRole};
+use daphne_service_utils::{bearer_token::BearerToken, DapRole};
 use either::Either;
 use http::Request;
 
-use crate::App;
+use crate::{metrics::DaphneServiceMetrics, App};
 use extractor::{DapRequestExtractor, UnauthenticatedDapRequestExtractor};
 
 type Router<A, B> = axum::Router<Arc<A>, B>;

--- a/crates/daphne-server/src/storage_proxy_connection/kv/mod.rs
+++ b/crates/daphne-server/src/storage_proxy_connection/kv/mod.rs
@@ -42,8 +42,10 @@ pub mod prefix {
         messages::{Base64Encode, TaskId},
         taskprov, DapSender, DapTaskConfig, DapVersion,
     };
-    use daphne_service_utils::{bearer_token::BearerToken, config::HpkeRecieverConfigList};
+    use daphne_service_utils::bearer_token::BearerToken;
     use serde::{de::DeserializeOwned, Serialize};
+
+    use crate::config::HpkeRecieverConfigList;
 
     use super::KvPrefix;
 

--- a/crates/daphne-service-utils/Cargo.toml
+++ b/crates/daphne-service-utils/Cargo.toml
@@ -12,32 +12,22 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-async-trait.workspace = true
 capnp = { workspace = true, optional = true }
 daphne = { path = "../daphne", default-features = false }
-futures.workspace = true
-itertools.workspace = true
-hex.workspace = true
-p256.workspace = true
-prio.workspace = true
-ring.workspace = true
+prio = { workspace = true, optional = true }
 serde.workspace = true
-serde_json.workspace = true
-url.workspace = true
-tracing.workspace = true
-rayon.workspace = true
+url = { workspace = true, optional = true }
 
 [dev-dependencies]
 daphne = { path = "../daphne", default-features = false, features = ["prometheus"] }
-prometheus.workspace = true
 rand.workspace = true
 
 [build-dependencies]
-capnpc = { version = "0.18.1", optional = true }
+capnpc = { workspace = true, optional = true }
 
 [features]
-test-utils = ["daphne/prometheus", "daphne/test-utils"]
-durable_requests = ["dep:capnp", "dep:capnpc"]
+test-utils = ["dep:url", "daphne/prometheus", "daphne/test-utils"]
+durable_requests = ["dep:capnp", "dep:capnpc", "dep:prio"]
 
 [lints]
 workspace = true

--- a/crates/daphne-service-utils/Cargo.toml
+++ b/crates/daphne-service-utils/Cargo.toml
@@ -19,7 +19,6 @@ futures.workspace = true
 itertools.workspace = true
 hex.workspace = true
 p256.workspace = true
-prometheus = { workspace = true, optional = true }
 prio.workspace = true
 ring.workspace = true
 serde.workspace = true
@@ -37,8 +36,7 @@ rand.workspace = true
 capnpc = { version = "0.18.1", optional = true }
 
 [features]
-test-utils = ["dep:prometheus", "daphne/prometheus", "daphne/test-utils"]
-prometheus = ["dep:prometheus", "daphne/prometheus"]
+test-utils = ["daphne/prometheus", "daphne/test-utils"]
 durable_requests = ["dep:capnp", "dep:capnpc"]
 
 [lints]

--- a/crates/daphne-service-utils/src/lib.rs
+++ b/crates/daphne-service-utils/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#![cfg_attr(not(test), deny(unused_crate_dependencies))]
+
 use core::fmt;
 use std::str::FromStr;
 

--- a/crates/daphne-service-utils/src/lib.rs
+++ b/crates/daphne-service-utils/src/lib.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 pub mod bearer_token;
-pub mod config;
 #[cfg(feature = "durable_requests")]
 pub mod durable_requests;
 pub mod http_headers;

--- a/crates/daphne-service-utils/src/lib.rs
+++ b/crates/daphne-service-utils/src/lib.rs
@@ -11,7 +11,6 @@ pub mod config;
 #[cfg(feature = "durable_requests")]
 pub mod durable_requests;
 pub mod http_headers;
-pub mod metrics;
 #[cfg(feature = "test-utils")]
 pub mod test_route_types;
 

--- a/crates/daphne-worker/Cargo.toml
+++ b/crates/daphne-worker/Cargo.toml
@@ -46,7 +46,7 @@ tower-service.workspace = true
 
 [dependencies.daphne-service-utils]
 path = "../daphne-service-utils"
-features = ["prometheus", "durable_requests"]
+features = ["durable_requests"]
 
 [dev-dependencies]
 daphne = { path = "../daphne", features = ["test-utils"] }


### PR DESCRIPTION
This crate was created during the transition from the 100% worker implementation
to the native version. It contained types that both implementations needed. Now
some of it's code can be merged into the daphne-server implementation. Reducing
it's size and making more obvious the types that are actually shared by other
members of the workspace.

