### PR TITLE
Don't request the entire Aggregate Share just to check if it exists

### DIFF
--- a/crates/daphne-service-utils/src/durable_requests/bindings/aggregate_store.rs
+++ b/crates/daphne-service-utils/src/durable_requests/bindings/aggregate_store.rs
@@ -25,6 +25,7 @@ super::define_do_binding! {
         Merge = "/internal/do/aggregate_store/merge",
         MarkCollected = "/internal/do/aggregate_store/mark_collected",
         CheckCollected = "/internal/do/aggregate_store/check_collected",
+        ReportCount = "/internal/do/aggregate_store/report_count"
     }
 
     fn name((version, task_id, bucket): (DapVersion, &'n TaskId, &'n DapBatchBucket)) -> ObjectIdFrom {


### PR DESCRIPTION
Fixes #581

- Add method for getting just the report count of an aggregate share
- Use AggregateStore::ReportCount to check if a batch exists instead of loading the entire aggregate share
