### PR TITLE
Begin renumbering errors

### DIFF
--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -727,6 +727,7 @@ impl DapReportInitializer for Test {
                             &vdaf,
                             &agg_param,
                             consumed,
+                            task_config.version,
                         )
                     })
                     .collect::<Result<Vec<_>, _>>()

--- a/crates/daphne-server/src/roles/aggregator.rs
+++ b/crates/daphne-server/src/roles/aggregator.rs
@@ -383,6 +383,7 @@ impl DapReportInitializer for crate::App {
                             &vdaf_config,
                             &agg_param,
                             consumed_report,
+                            task_config.version,
                         )
                     })
                     .collect::<Result<Vec<EarlyReportStateInitialized>, _>>()

--- a/crates/daphne-server/src/router/mod.rs
+++ b/crates/daphne-server/src/router/mod.rs
@@ -19,7 +19,7 @@ use axum::{
     Json,
 };
 use daphne::{
-    error::DapAbort, fatal_error, messages::TaskId, DapError, DapRequestMeta, DapResponse,
+    error::DapAbort, fatal_error, messages::{TaskId, TransitionFailure}, DapError, DapRequestMeta, DapResponse,
     DapSender,
 };
 use daphne_service_utils::{bearer_token::BearerToken, DapRole};
@@ -166,7 +166,7 @@ impl AxumDapResponse {
     pub fn new_error<E: Into<DapError>>(error: E, metrics: &dyn DaphneServiceMetrics) -> Self {
         // trigger abort if transition failures reach this point.
         let error = match error.into() {
-            DapError::Transition(failure) => DapAbort::report_rejected(failure),
+            DapError::Transition(failure) => DapAbort::report_rejected( failure),
             DapError::Fatal(e) => Err(e),
             DapError::Abort(abort) => Ok(abort),
         };

--- a/crates/daphne/src/hpke.rs
+++ b/crates/daphne/src/hpke.rs
@@ -3,6 +3,7 @@
 
 //! Hybrid Public-Key Encryption ([HPKE](https://datatracker.ietf.org/doc/rfc9180/)).
 
+use futures::sink::Drain;
 use hpke_rs::{Hpke, HpkeError, HpkePrivateKey, HpkePublicKey, Mode};
 use hpke_rs_crypto::{
     error::Error,
@@ -13,7 +14,7 @@ use hpke_rs_rust_crypto::HpkeRustCrypto as ImplHpkeCrypto;
 
 use crate::{
     fatal_error,
-    messages::{HpkeCiphertext, TaskId, TransitionFailure},
+    messages::{HpkeCiphertext, TaskId, Transition, TransitionFailure},
     DapError, DapVersion,
 };
 use async_trait::async_trait;

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -436,6 +436,7 @@ impl EarlyReportState for EarlyReportStateInitialized {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) enum ReportProcessedStatus {
     /// The report should be marked as aggregated. However it has already been committed to
     /// storage, so don't do so again.

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -50,7 +50,7 @@ impl VdafConfig {
         let report_id = ReportId(rng.gen());
         let (public_share, input_shares) = self
             .produce_input_shares(measurement, &report_id.0)
-            .map_err(DapError::from_vdaf)?;
+            .map_err(|e| DapError::from_vdaf_with_param(version, e))?;
         Self::produce_report_with_extensions_for_shares(
             public_share,
             input_shares,

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -21,7 +21,7 @@ mod test {
         messages::{
             AggregationJobInitReq, BatchSelector, Extension, Interval, PartialBatchSelector,
             PrepareInit, Report, ReportId, ReportShare, Transition, TransitionFailure,
-            TransitionVar,
+            TransitionFailureDraft09, TransitionFailureLatest, TransitionVar,
         },
         protocol::aggregator::{
             EarlyReportState, EarlyReportStateConsumed, EarlyReportStateInitialized,
@@ -87,6 +87,7 @@ mod test {
             &t.task_config.vdaf,
             &DapAggregationParam::Empty,
             early_report_state_consumed,
+            t.task_config.version,
         )
         .unwrap()
         else {
@@ -117,6 +118,7 @@ mod test {
             &t.task_config.vdaf,
             &DapAggregationParam::Empty,
             early_report_state_consumed,
+            t.task_config.version,
         )
         .unwrap()
         else {
@@ -346,10 +348,20 @@ mod test {
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
-        assert_matches!(
-            agg_job_resp.transitions[0].var,
-            TransitionVar::Failed(TransitionFailure::HpkeDecryptError)
-        );
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::HpkeDecryptError
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::HpkeDecryptError
+                ))
+            ),
+        }
     }
 
     async_test_versions! { handle_agg_job_req_hpke_decrypt_err }
@@ -382,10 +394,20 @@ mod test {
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
-        assert_matches!(
-            agg_job_resp.transitions[0].var,
-            TransitionVar::Failed(TransitionFailure::ReportDropped)
-        );
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::ReportDropped
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::ReportDropped
+                ))
+            ),
+        }
     }
 
     async_test_versions! { handle_agg_job_req_skip_time_too_stale }
@@ -418,10 +440,20 @@ mod test {
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
-        assert_matches!(
-            agg_job_resp.transitions[0].var,
-            TransitionVar::Failed(TransitionFailure::ReportTooEarly)
-        );
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::ReportTooEarly
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::ReportTooEarly
+                ))
+            ),
+        }
     }
 
     async_test_versions! { handle_agg_job_req_skip_time_too_early }
@@ -439,10 +471,20 @@ mod test {
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
         assert_eq!(agg_job_resp.transitions.len(), 1);
-        assert_matches!(
-            agg_job_resp.transitions[0].var,
-            TransitionVar::Failed(TransitionFailure::HpkeUnknownConfigId)
-        );
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::HpkeUnknownConfigId
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::HpkeUnknownConfigId
+                ))
+            ),
+        }
     }
 
     async_test_versions! { handle_agg_job_req_hpke_unknown_config_id }
@@ -480,14 +522,34 @@ mod test {
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req).await;
 
         assert_eq!(agg_job_resp.transitions.len(), 2);
-        assert_matches!(
-            agg_job_resp.transitions[0].var,
-            TransitionVar::Failed(TransitionFailure::VdafPrepError)
-        );
-        assert_matches!(
-            agg_job_resp.transitions[1].var,
-            TransitionVar::Failed(TransitionFailure::VdafPrepError)
-        );
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::VdafPrepError
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[0].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::VdafPrepError
+                ))
+            ),
+        }
+        match version {
+            DapVersion::Draft09 => assert_matches!(
+                agg_job_resp.transitions[1].var,
+                TransitionVar::Failed(TransitionFailure::Draft09(
+                    TransitionFailureDraft09::VdafPrepError
+                ))
+            ),
+            DapVersion::Latest => assert_matches!(
+                agg_job_resp.transitions[1].var,
+                TransitionVar::Failed(TransitionFailure::DraftLatest(
+                    TransitionFailureLatest::VdafPrepError
+                ))
+            ),
+        }
     }
 
     async_test_versions! { handle_agg_job_req_vdaf_prep_error }

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -336,8 +336,9 @@ async fn run_agg_job<A: DapLeader>(
         },
     )
     .await?;
-    let agg_job_resp = AggregationJobResp::get_decoded(&resp.payload)
-        .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
+    let agg_job_resp =
+        AggregationJobResp::get_decoded_with_param(&task_config.version, &resp.payload)
+            .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     // Handle AggregationJobResp.
     let agg_span =

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -91,6 +91,7 @@ async fn initialize_reports(
                     &vdaf,
                     &agg_param,
                     consumed,
+                    DapVersion::Latest,
                 )
             })
             .collect()
@@ -117,6 +118,7 @@ async fn initialize_reports(
                 &vdaf,
                 agg_param,
                 consumed,
+                DapVersion::Latest,
             )
         })
         .collect()


### PR DESCRIPTION
Draft 09 and Draft 13 use different numbers to indicate the same errors.
To make this code backwards compatible we need to support both sets at the same time.