### PR TITLE
Bump "latest" to "v13" from "v10"

### DIFF
--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -101,7 +101,7 @@ pub enum DapVersion {
     #[default]
     Draft09,
 
-    #[serde(rename = "v10")]
+    #[serde(rename = "v13")]
     Latest,
 }
 
@@ -110,7 +110,7 @@ impl FromStr for DapVersion {
     fn from_str(version: &str) -> Result<Self, Self::Err> {
         match version {
             "v09" => Ok(DapVersion::Draft09),
-            "v10" => Ok(DapVersion::Latest),
+            "v13" => Ok(DapVersion::Latest),
             _ => Err(DapAbort::version_unknown()),
         }
     }
@@ -120,7 +120,7 @@ impl AsRef<str> for DapVersion {
     fn as_ref(&self) -> &str {
         match self {
             DapVersion::Draft09 => "v09",
-            DapVersion::Latest => "v10",
+            DapVersion::Latest => "v13",
         }
     }
 }


### PR DESCRIPTION
When all of the wire format changes for v13 are in, we should bump the version number from "v10" to "v13". 