### PR TITLE
Make more use of DapRole enums

### DIFF
--- a/crates/dapf/src/main.rs
+++ b/crates/dapf/src/main.rs
@@ -14,6 +14,7 @@ use dapf::{
     HttpClient,
 };
 use daphne::{
+    constants::DapAggregatorRole,
     hpke::HpkeReceiverConfig,
     messages::{
         self, encode_base64url, BatchSelector, CollectionReq, PartialBatchSelector, Query, TaskId,
@@ -23,7 +24,6 @@ use daphne::{
 use daphne_service_utils::{
     bearer_token::BearerToken,
     test_route_types::{InternalTestAddTask, InternalTestVdaf},
-    DapRole,
 };
 use prio::codec::{ParameterizedDecode, ParameterizedEncode};
 use rand::{thread_rng, Rng};
@@ -236,7 +236,7 @@ enum TestAction {
         #[arg(long)]
         collector_auth_token: Option<String>,
         #[arg(long)]
-        role: Option<DapRole>,
+        role: Option<DapAggregatorRole>,
         #[arg(long)]
         query: Option<CliDapQueryConfig>,
         #[arg(long)]
@@ -866,11 +866,11 @@ async fn handle_test_routes(action: TestAction, http_client: HttpClient) -> anyh
                     "leader auth token",
                 )?,
                 collector_authentication_token: match role {
-                    DapRole::Leader => Some(use_or_request_from_user(
+                    DapAggregatorRole::Leader => Some(use_or_request_from_user(
                         collector_auth_token,
                         "collector auth token",
                     )?),
-                    DapRole::Helper => None,
+                    DapAggregatorRole::Helper => None,
                 },
                 role,
                 vdaf_verify_key,

--- a/crates/daphne-server/examples/service.rs
+++ b/crates/daphne-server/examples/service.rs
@@ -4,10 +4,10 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use daphne::constants::DapAggregatorRole;
 use daphne_server::{
     config::DaphneServiceConfig, metrics::DaphnePromServiceMetrics, router, App, StorageProxyConfig,
 };
-use daphne_service_utils::DapRole;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
@@ -47,8 +47,8 @@ impl TryFrom<Args> for Config {
                     config::Value::new(
                         Some(&String::from("args.role")),
                         match role {
-                            DapRole::Leader => "leader",
-                            DapRole::Helper => "helper",
+                            DapAggregatorRole::Leader => "leader",
+                            DapAggregatorRole::Helper => "helper",
                         },
                     )
                 }),
@@ -81,7 +81,7 @@ struct Args {
     // --- command line overridable parameters ---
     /// One of `leader` or `helper`.
     #[arg(short, long)]
-    role: Option<DapRole>,
+    role: Option<DapAggregatorRole>,
     /// The port to listen on.
     #[arg(short, long)]
     port: Option<u16>,

--- a/crates/daphne-server/src/config.rs
+++ b/crates/daphne-server/src/config.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use daphne::{
+    constants::DapAggregatorRole,
     hpke::{HpkeConfig, HpkeReceiverConfig},
     DapGlobalConfig, DapVersion,
 };
-use daphne_service_utils::{bearer_token::BearerToken, DapRole};
+use daphne_service_utils::bearer_token::BearerToken;
 use p256::ecdsa::SigningKey;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -45,7 +46,7 @@ pub type HpkeRecieverConfigList = Vec<HpkeReceiverConfig>;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DaphneServiceConfig {
     /// Indicates the role the service should play.
-    pub role: DapRole,
+    pub role: DapAggregatorRole,
 
     /// Global DAP configuration.
     #[serde(flatten)]

--- a/crates/daphne-server/src/lib.rs
+++ b/crates/daphne-server/src/lib.rs
@@ -42,7 +42,7 @@ mod storage_proxy_connection;
 /// ```
 /// use std::num::NonZeroUsize;
 /// use url::Url;
-/// use daphne::{DapGlobalConfig, hpke::HpkeKemId, DapVersion};
+/// use daphne::{DapGlobalConfig, constants::DapAggregatorRole, hpke::HpkeKemId, DapVersion};
 /// use daphne_server::{
 ///     App,
 ///     router,
@@ -50,7 +50,6 @@ mod storage_proxy_connection;
 ///     metrics::DaphnePromServiceMetrics,
 ///     config::DaphneServiceConfig,
 /// };
-/// use daphne_service_utils::DapRole;
 ///
 /// let storage_proxy_settings = StorageProxyConfig {
 ///     url: Url::parse("http://example.com").unwrap(),
@@ -66,7 +65,7 @@ mod storage_proxy_connection;
 ///     default_num_agg_span_shards: NonZeroUsize::new(2).unwrap(),
 /// };
 /// let service_config = DaphneServiceConfig {
-///     role: DapRole::Helper,
+///     role: DapAggregatorRole::Helper,
 ///     global,
 ///     base_url: None,
 ///     taskprov: None,
@@ -77,7 +76,7 @@ mod storage_proxy_connection;
 /// };
 /// let app = App::new(storage_proxy_settings, daphne_service_metrics, service_config)?;
 ///
-/// let router = router::new(DapRole::Helper, app);
+/// let router = router::new(DapAggregatorRole::Helper, app);
 ///
 /// # Ok::<(), daphne::DapError>(())
 /// ```

--- a/crates/daphne-server/src/roles/aggregator.rs
+++ b/crates/daphne-server/src/roles/aggregator.rs
@@ -8,7 +8,7 @@ use daphne::{
     audit_log::AuditLog,
     error::DapAbort,
     fatal_error,
-    hpke::{self, HpkeConfig, HpkeProvider, HpkeReceiverConfig},
+    hpke::{self, info_and_aad, HpkeConfig, HpkeProvider, HpkeReceiverConfig},
     messages::{self, BatchId, BatchSelector, HpkeCiphertext, TaskId, Time},
     metrics::DaphneMetrics,
     roles::{
@@ -363,11 +363,10 @@ pub struct HpkeDecrypter(Marc<Vec<HpkeReceiverConfig>>);
 impl hpke::HpkeDecrypter for HpkeDecrypter {
     fn hpke_decrypt(
         &self,
-        info: &[u8],
-        aad: &[u8],
+        info: impl info_and_aad::InfoAndAad,
         ciphertext: &HpkeCiphertext,
     ) -> Result<Vec<u8>, DapError> {
-        self.0.hpke_decrypt(info, aad, ciphertext)
+        self.0.hpke_decrypt(info, ciphertext)
     }
 }
 

--- a/crates/daphne-server/src/roles/leader.rs
+++ b/crates/daphne-server/src/roles/leader.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, time::Instant};
 
 use axum::{async_trait, http::Method};
 use daphne::{
-    constants::DapMediaType,
+    constants::{DapMediaType, DapRole},
     error::DapAbort,
     fatal_error,
     messages::{BatchId, BatchSelector, Collection, CollectionJobId, Report, TaskId},
@@ -171,7 +171,7 @@ impl crate::App {
             }
         } else if let Some(bearer_token) = self
             .bearer_tokens()
-            .get(daphne::DapSender::Leader, meta.task_id)
+            .get(DapRole::Leader, meta.task_id)
             .await
             .map_err(|e| fatal_error!(err = ?e, "failed to get leader bearer token"))?
         {

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -107,6 +107,7 @@ impl BearerTokens<'_> {
 #[cfg(feature = "test-utils")]
 mod test_utils {
     use daphne::{
+        constants::DapAggregatorRole,
         fatal_error,
         hpke::{HpkeConfig, HpkeReceiverConfig},
         messages::decode_base64url_vec,
@@ -117,7 +118,6 @@ mod test_utils {
     use daphne_service_utils::{
         bearer_token::BearerToken,
         test_route_types::{InternalTestAddTask, InternalTestEndpointForTask},
-        DapRole,
     };
     use prio::codec::Decode;
     use std::num::NonZeroUsize;
@@ -248,7 +248,7 @@ mod test_utils {
 
             // Collector authentication token.
             match (cmd.role, cmd.collector_authentication_token) {
-                (DapRole::Leader, Some(token_string)) => {
+                (DapAggregatorRole::Leader, Some(token_string)) => {
                     let token = BearerToken::from(token_string);
                     if self
                         .bearer_tokens()
@@ -262,13 +262,13 @@ mod test_utils {
                         )));
                     }
                 }
-                (DapRole::Leader, None) => {
+                (DapAggregatorRole::Leader, None) => {
                     return Err(fatal_error!(
                         err = "command failed: missing collector authentication token",
                     ))
                 }
-                (DapRole::Helper, None) => (),
-                (DapRole::Helper, Some(..)) => {
+                (DapAggregatorRole::Helper, None) => (),
+                (DapAggregatorRole::Helper, Some(..)) => {
                     return Err(fatal_error!(
                         err = "command failed: unexpected collector authentication token",
                     ));

--- a/crates/daphne-server/src/router/extractor.rs
+++ b/crates/daphne-server/src/router/extractor.rs
@@ -224,12 +224,12 @@ pub mod dap_sender {
     pub const FROM_HELPER: DapSender = 1 << 2;
     pub const FROM_LEADER: DapSender = 1 << 3;
 
-    pub const fn to_enum(id: DapSender) -> daphne::DapSender {
+    pub const fn to_enum(id: DapSender) -> daphne::constants::DapRole {
         match id {
-            FROM_CLIENT => daphne::DapSender::Client,
-            FROM_COLLECTOR => daphne::DapSender::Collector,
-            FROM_HELPER => daphne::DapSender::Helper,
-            FROM_LEADER => daphne::DapSender::Leader,
+            FROM_CLIENT => daphne::constants::DapRole::Client,
+            FROM_COLLECTOR => daphne::constants::DapRole::Collector,
+            FROM_HELPER => daphne::constants::DapRole::Helper,
+            FROM_LEADER => daphne::constants::DapRole::Leader,
             _ => panic!("invalid dap sender. Please specify a valid dap_sender from the crate::extractor::dap_sender module"),
         }
     }
@@ -344,14 +344,14 @@ mod test {
     };
     use daphne::{
         async_test_versions,
-        constants::DapMediaType,
+        constants::{DapMediaType, DapRole},
         messages::{
             request::{CollectionPollReq, RequestBody},
             taskprov::TaskprovAdvertisement,
             AggregationJobId, AggregationJobInitReq, Base64Encode, CollectionJobId, CollectionReq,
             TaskId,
         },
-        DapError, DapRequest, DapRequestMeta, DapSender, DapVersion,
+        DapError, DapRequest, DapRequestMeta, DapVersion,
     };
     use daphne_service_utils::{bearer_token::BearerToken, http_headers};
     use either::Either::{self, Left};
@@ -409,7 +409,7 @@ mod test {
             async fn check_bearer_token(
                 &self,
                 token: &BearerToken,
-                _sender: DapSender,
+                _sender: DapRole,
                 _task_id: TaskId,
                 _is_taskprov: bool,
             ) -> Result<(), Either<String, DapError>> {

--- a/crates/daphne-server/src/router/mod.rs
+++ b/crates/daphne-server/src/router/mod.rs
@@ -18,8 +18,11 @@ use axum::{
     Json,
 };
 use daphne::{
-    constants::DapAggregatorRole, error::DapAbort, fatal_error, messages::TaskId, DapError,
-    DapRequestMeta, DapResponse, DapSender,
+    constants::{DapAggregatorRole, DapRole},
+    error::DapAbort,
+    fatal_error,
+    messages::TaskId,
+    DapError, DapRequestMeta, DapResponse,
 };
 use daphne_service_utils::bearer_token::BearerToken;
 use either::Either;
@@ -49,7 +52,7 @@ pub trait DaphneService {
     async fn check_bearer_token(
         &self,
         presented_token: &BearerToken,
-        sender: DapSender,
+        sender: DapRole,
         task_id: TaskId,
         is_taskprov: bool,
     ) -> Result<(), Either<String, DapError>>;
@@ -74,7 +77,7 @@ where
     async fn check_bearer_token(
         &self,
         presented_token: &BearerToken,
-        sender: DapSender,
+        sender: DapRole,
         task_id: TaskId,
         is_taskprov: bool,
     ) -> Result<(), Either<String, DapError>> {

--- a/crates/daphne-server/src/router/mod.rs
+++ b/crates/daphne-server/src/router/mod.rs
@@ -18,10 +18,10 @@ use axum::{
     Json,
 };
 use daphne::{
-    error::DapAbort, fatal_error, messages::TaskId, DapError, DapRequestMeta, DapResponse,
-    DapSender,
+    constants::DapAggregatorRole, error::DapAbort, fatal_error, messages::TaskId, DapError,
+    DapRequestMeta, DapResponse, DapSender,
 };
-use daphne_service_utils::{bearer_token::BearerToken, DapRole};
+use daphne_service_utils::bearer_token::BearerToken;
 use either::Either;
 
 use crate::{metrics::DaphneServiceMetrics, App};
@@ -86,14 +86,14 @@ where
     }
 }
 
-pub fn new(role: DapRole, aggregator: App) -> axum::Router<()> {
+pub fn new(role: DapAggregatorRole, aggregator: App) -> axum::Router<()> {
     let router = axum::Router::new();
 
     let router = aggregator::add_aggregator_routes(router);
 
     let router = match role {
-        DapRole::Leader => leader::add_leader_routes(router),
-        DapRole::Helper => helper::add_helper_routes(router),
+        DapAggregatorRole::Leader => leader::add_leader_routes(router),
+        DapAggregatorRole::Helper => helper::add_helper_routes(router),
     };
 
     #[cfg(feature = "test-utils")]

--- a/crates/daphne-server/src/router/test_routes.rs
+++ b/crates/daphne-server/src/router/test_routes.rs
@@ -11,23 +11,21 @@ use axum::{
     Json,
 };
 use daphne::{
+    constants::DapAggregatorRole,
     hpke::HpkeReceiverConfig,
     messages::{Base64Encode, TaskId},
     roles::{leader, DapLeader},
     DapVersion,
 };
-use daphne_service_utils::{
-    test_route_types::{InternalTestAddTask, InternalTestEndpointForTask},
-    DapRole,
-};
+use daphne_service_utils::test_route_types::{InternalTestAddTask, InternalTestEndpointForTask};
 use serde::Deserialize;
 
 use crate::App;
 
 use super::{AxumDapResponse, DaphneService};
 
-pub fn add_test_routes(router: super::Router<App>, role: DapRole) -> super::Router<App> {
-    let router = if role == DapRole::Leader {
+pub fn add_test_routes(router: super::Router<App>, role: DapAggregatorRole) -> super::Router<App> {
+    let router = if role == DapAggregatorRole::Leader {
         router
             .route("/internal/process", post(leader_process))
             .route(

--- a/crates/daphne-server/src/storage_proxy_connection/kv/mod.rs
+++ b/crates/daphne-server/src/storage_proxy_connection/kv/mod.rs
@@ -58,8 +58,9 @@ pub mod prefix {
     };
 
     use daphne::{
+        constants::DapRole,
         messages::{Base64Encode, TaskId},
-        taskprov, DapSender, DapTaskConfig, DapVersion,
+        taskprov, DapTaskConfig, DapVersion,
     };
     use daphne_service_utils::bearer_token::BearerToken;
     use serde::{de::DeserializeOwned, Serialize};
@@ -134,9 +135,9 @@ pub mod prefix {
     }
 
     #[derive(Debug)]
-    pub struct KvBearerTokenKey(DapSender, TaskId);
-    impl From<(DapSender, TaskId)> for KvBearerTokenKey {
-        fn from((s, t): (DapSender, TaskId)) -> Self {
+    pub struct KvBearerTokenKey(DapRole, TaskId);
+    impl From<(DapRole, TaskId)> for KvBearerTokenKey {
+        fn from((s, t): (DapRole, TaskId)) -> Self {
             Self(s, t)
         }
     }
@@ -145,10 +146,10 @@ pub mod prefix {
             let Self(sender, task_id) = self;
             let task_id = task_id.to_base64url();
             match sender {
-                DapSender::Client => write!(f, "client/task/{task_id}"),
-                DapSender::Collector => write!(f, "collector/task/{task_id}"),
-                DapSender::Helper => write!(f, "helper/task/{task_id}"),
-                DapSender::Leader => write!(f, "leader/task/{task_id}"),
+                DapRole::Client => write!(f, "client/task/{task_id}"),
+                DapRole::Collector => write!(f, "collector/task/{task_id}"),
+                DapRole::Helper => write!(f, "helper/task/{task_id}"),
+                DapRole::Leader => write!(f, "leader/task/{task_id}"),
             }
         }
     }

--- a/crates/daphne-service-utils/src/lib.rs
+++ b/crates/daphne-service-utils/src/lib.rs
@@ -3,11 +3,6 @@
 
 #![cfg_attr(not(test), deny(unused_crate_dependencies))]
 
-use core::fmt;
-use std::str::FromStr;
-
-use serde::{Deserialize, Serialize};
-
 pub mod bearer_token;
 #[cfg(feature = "durable_requests")]
 pub mod durable_requests;
@@ -24,42 +19,4 @@ mod durable_request_capnp {
         env!("OUT_DIR"),
         "/src/durable_requests/durable_request_capnp.rs"
     ));
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum DapRole {
-    Leader,
-    Helper,
-}
-
-impl DapRole {
-    pub fn is_leader(self) -> bool {
-        self == Self::Leader
-    }
-
-    pub fn is_helper(self) -> bool {
-        self == Self::Helper
-    }
-}
-
-impl FromStr for DapRole {
-    type Err = String;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s {
-            "leader" => Ok(Self::Leader),
-            "helper" => Ok(Self::Helper),
-            _ => Err(s.to_string()),
-        }
-    }
-}
-
-impl fmt::Display for DapRole {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Helper => "helper",
-            Self::Leader => "leader",
-        })
-    }
 }

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -6,6 +6,7 @@
 //! [interop]: https://divergentdave.github.io/draft-dcook-ppm-dap-interop-test-design/draft-dcook-ppm-dap-interop-test-design.html
 
 use daphne::{
+    constants::DapAggregatorRole,
     messages::{Duration, TaskId, Time},
     vdaf::{Prio3Config, VdafConfig},
 };
@@ -16,7 +17,7 @@ use url::Url;
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InternalTestEndpointForTask {
-    pub role: super::DapRole,
+    pub role: DapAggregatorRole,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -82,7 +83,7 @@ pub struct InternalTestAddTask {
     pub leader_authentication_token: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub collector_authentication_token: Option<String>,
-    pub role: super::DapRole,
+    pub role: DapAggregatorRole,
     pub vdaf_verify_key: String, // base64url
     pub query_type: u8,
     pub min_batch_size: u64,

--- a/crates/daphne/src/constants.rs
+++ b/crates/daphne/src/constants.rs
@@ -65,15 +65,14 @@ impl DapMediaType {
     }
 }
 
-/// A role in the DAP aggregation protocol. The numeric value associated with each variant is the
-/// numeric value used when serializing the sender and receiver roles in hpke encryption.
+/// A role in the DAP aggregation protocol.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DapRole {
-    Collector = 0,
-    Client = 1,
-    Leader = 2,
-    Helper = 3,
+    Collector,
+    Client,
+    Leader,
+    Helper,
 }
 
 impl DapRole {
@@ -116,8 +115,8 @@ impl fmt::Display for DapRole {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DapAggregatorRole {
-    Leader = 2,
-    Helper = 3,
+    Leader,
+    Helper,
 }
 
 impl DapAggregatorRole {

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -963,15 +963,6 @@ impl DapAggregateShare {
     }
 }
 
-/// DAP sender role.
-#[derive(Clone, Copy, Debug)]
-pub enum DapSender {
-    Client,
-    Collector,
-    Helper,
-    Leader,
-}
-
 /// Status of a collect job.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -818,6 +818,14 @@ impl Encode for DapAggregationParam {
             Self::Mastic(agg_param) => agg_param.encode(bytes),
         }
     }
+
+    fn encoded_len(&self) -> Option<usize> {
+        match self {
+            Self::Empty => Some(0),
+            #[cfg(feature = "experimental")]
+            Self::Mastic(agg_param) => agg_param.encoded_len(),
+        }
+    }
 }
 
 impl ParameterizedDecode<VdafConfig> for DapAggregationParam {

--- a/crates/daphne/src/messages/mod.rs
+++ b/crates/daphne/src/messages/mod.rs
@@ -71,6 +71,10 @@ macro_rules! id_struct {
                 bytes.extend_from_slice(&self.0);
                 Ok(())
             }
+
+            fn encoded_len(&self) -> Option<usize> {
+                Some(self.0.len())
+            }
         }
 
         impl Decode for $sname {

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -5,9 +5,6 @@ pub(crate) mod aggregator;
 mod client;
 mod collector;
 
-const CTX_INPUT_SHARE_DRAFT09: &[u8] = b"dap-09 input share";
-const CTX_AGG_SHARE_DRAFT09: &[u8] = b"dap-09 aggregate share";
-
 #[cfg(test)]
 mod test {
     use crate::{

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -7,15 +7,12 @@ mod collector;
 
 const CTX_INPUT_SHARE_DRAFT09: &[u8] = b"dap-09 input share";
 const CTX_AGG_SHARE_DRAFT09: &[u8] = b"dap-09 aggregate share";
-const CTX_ROLE_COLLECTOR: u8 = 0;
-const CTX_ROLE_CLIENT: u8 = 1;
-const CTX_ROLE_LEADER: u8 = 2;
-const CTX_ROLE_HELPER: u8 = 3;
 
 #[cfg(test)]
 mod test {
     use crate::{
         assert_metrics_include,
+        constants::DapAggregatorRole,
         error::DapAbort,
         hpke::{HpkeAeadId, HpkeConfig, HpkeKdfId, HpkeKemId},
         messages::{
@@ -67,7 +64,7 @@ mod test {
         } = InitializedReport::new(
             &t.leader_hpke_receiver_config,
             t.valid_report_time_range(),
-            true, // is_leader
+            DapAggregatorRole::Leader,
             &t.task_id,
             &t.task_config,
             ReportShare {
@@ -90,7 +87,7 @@ mod test {
         } = InitializedReport::new(
             &t.helper_hpke_receiver_config,
             t.valid_report_time_range(),
-            false, // is_helper
+            DapAggregatorRole::Helper,
             &t.task_id,
             &t.task_config,
             ReportShare {
@@ -691,7 +688,7 @@ mod test {
         let initialized_report = InitializedReport::new(
             &t.leader_hpke_receiver_config,
             t.valid_report_time_range(),
-            true,
+            DapAggregatorRole::Leader,
             &t.task_id,
             &t.task_config,
             ReportShare {
@@ -741,7 +738,7 @@ mod test {
         let initialized_report = InitializedReport::new(
             &t.leader_hpke_receiver_config,
             t.valid_report_time_range(),
-            true,
+            DapAggregatorRole::Leader,
             &t.task_id,
             &t.task_config,
             ReportShare {


### PR DESCRIPTION
The DapRole enum is underused and under featured, leading to code like `is_leader: bool` where an instance of the enum would make calling code more readable (there are places where `false /* helper */` can be see where `DapRole::Helper` would be much better)

This PR also factors out the calculation of the `info` and `aad` parameters needed for hpke encryption and decryption. Making this part both more type safe and taking it out of higher level code

This PR should be reviewed one commit at a time