### PR TITLE
Rename fixed-size queries to leader-selected queries

### DIFF
--- a/crates/dapf/src/acceptance/load_testing.rs
+++ b/crates/dapf/src/acceptance/load_testing.rs
@@ -424,7 +424,7 @@ pub async fn execute_single_combination_from_env(
         println!("\t- load_control:        {load_control:?}");
 
         let batch_id = BatchId(thread_rng().gen());
-        let part_batch_sel = PartialBatchSelector::FixedSizeByBatchId { batch_id };
+        let part_batch_sel = PartialBatchSelector::LeaderSelectedByBatchId { batch_id };
 
         let run = async {
             let (test_task_config, hpke_config_fetch_time) = t

--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -380,7 +380,7 @@ impl Test {
             time_precision: 3600,
             lifetime: 60,
             min_batch_size: reports_per_batch.try_into().unwrap(),
-            query: DapQueryConfig::FixedSize {
+            query: DapQueryConfig::LeaderSelected {
                 max_batch_size: NonZeroU32::new(reports_per_batch.try_into().unwrap()),
             },
             vdaf: self.vdaf_config,
@@ -554,7 +554,7 @@ impl Test {
     ) -> Result<Duration> {
         // Prepare AggregateShareReq.
         let agg_share_req = AggregateShareReq {
-            batch_sel: BatchSelector::FixedSizeByBatchId { batch_id },
+            batch_sel: BatchSelector::LeaderSelectedByBatchId { batch_id },
             agg_param: Vec::new(),
             report_count: leader_agg_share.report_count,
             checksum: leader_agg_share.checksum,
@@ -636,7 +636,7 @@ impl Test {
         ////
 
         let batch_id = BatchId(rngs::OsRng.gen());
-        let part_batch_sel = PartialBatchSelector::FixedSizeByBatchId { batch_id };
+        let part_batch_sel = PartialBatchSelector::LeaderSelectedByBatchId { batch_id };
 
         let (leader_agg_share, agg_job_duration) = self
             .run_agg_jobs(

--- a/crates/dapf/src/cli_parsers.rs
+++ b/crates/dapf/src/cli_parsers.rs
@@ -153,8 +153,8 @@ impl FromStr for CliDapQueryConfig {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if s == "time-interval" {
             Ok(Self(DapQueryConfig::TimeInterval))
-        } else if let Some(size) = s.strip_prefix("fixed-size") {
-            Ok(Self(DapQueryConfig::FixedSize {
+        } else if let Some(size) = s.strip_prefix("leader-selected") {
+            Ok(Self(DapQueryConfig::LeaderSelected {
                 max_batch_size: if let Some(size) = size.strip_prefix("-") {
                     Some(
                         size.parse()
@@ -163,7 +163,9 @@ impl FromStr for CliDapQueryConfig {
                 } else if size.is_empty() {
                     None
                 } else {
-                    return Err(format!("{size} is an invalid fixed size max batch size"));
+                    return Err(format!(
+                        "{size} is an invalid leader selected max batch size"
+                    ));
                 },
             }))
         } else {

--- a/crates/dapf/src/main.rs
+++ b/crates/dapf/src/main.rs
@@ -771,8 +771,8 @@ async fn handle_decode_actions(action: DecodeAction) -> anyhow::Result<()> {
                     let batch_selector = batch_selector.unwrap_or_else(||
                         match message.part_batch_sel {
                             PartialBatchSelector::TimeInterval => panic!("can't deduce the time interval, please provide a batch selector"),
-                            PartialBatchSelector::FixedSizeByBatchId { batch_id } => {
-                                BatchSelector::FixedSizeByBatchId { batch_id }
+                            PartialBatchSelector::LeaderSelectedByBatchId { batch_id } => {
+                                BatchSelector::LeaderSelectedByBatchId { batch_id }
                             }
                         }
                     );
@@ -844,7 +844,7 @@ async fn handle_test_routes(action: TestAction, http_client: HttpClient) -> anyh
             let vdaf_verify_key = encode_base64url(vdaf.gen_verify_key());
             let CliDapQueryConfig(query) = use_or_request_from_user_or_default(
                 query,
-                || DapQueryConfig::FixedSize {
+                || DapQueryConfig::LeaderSelected {
                     max_batch_size: None,
                 },
                 "query",
@@ -876,7 +876,7 @@ async fn handle_test_routes(action: TestAction, http_client: HttpClient) -> anyh
                 vdaf_verify_key,
                 query_type: match query {
                     DapQueryConfig::TimeInterval => 1,
-                    DapQueryConfig::FixedSize { .. } => 2,
+                    DapQueryConfig::LeaderSelected { .. } => 2,
                 },
                 min_batch_size: use_or_request_from_user_or_default(
                     min_batch_size,
@@ -885,7 +885,7 @@ async fn handle_test_routes(action: TestAction, http_client: HttpClient) -> anyh
                 )?,
                 max_batch_size: match query {
                     DapQueryConfig::TimeInterval => None,
-                    DapQueryConfig::FixedSize { max_batch_size } => max_batch_size,
+                    DapQueryConfig::LeaderSelected { max_batch_size } => max_batch_size,
                 },
                 time_precision: use_or_request_from_user_or_default(
                     time_precision,

--- a/crates/daphne-server/src/roles/aggregator.rs
+++ b/crates/daphne-server/src/roles/aggregator.rs
@@ -294,7 +294,7 @@ impl DapAggregator for crate::App {
             }))?;
         let version = task_config.as_ref().version;
 
-        let agg_span = task_config.batch_span_for_sel(&BatchSelector::FixedSizeByBatchId {
+        let agg_span = task_config.batch_span_for_sel(&BatchSelector::LeaderSelectedByBatchId {
             batch_id: *batch_id,
         })?;
 

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -283,7 +283,7 @@ mod test_utils {
                         err = "command failed: unexpected max batch size"
                     ))
                 }
-                (2, max_batch_size) => DapQueryConfig::FixedSize { max_batch_size },
+                (2, max_batch_size) => DapQueryConfig::LeaderSelected { max_batch_size },
                 _ => {
                     return Err(fatal_error!(
                         err = "command failed: unrecognized query type"

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -1162,9 +1162,9 @@ async fn leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
 async_test_versions! { leader_collect_abort_overlapping_batch_interval }
 
 #[tokio::test]
-async fn fixed_size() {
+async fn leader_selected() {
     let version = DapVersion::Draft09;
-    let t = TestRunner::fixed_size(version).await;
+    let t = TestRunner::leader_selected(version).await;
     let path = t.upload_path();
     let client = t.http_client();
     let hpke_config_list = t.get_hpke_configs(version, client).await.unwrap();
@@ -1204,7 +1204,7 @@ async fn fixed_size() {
     // Collector: Get the collect URI.
     let agg_param = DapAggregationParam::Empty;
     let collect_req = CollectionReq {
-        query: Query::FixedSizeCurrentBatch,
+        query: Query::LeaderSelectedCurrentBatch,
         agg_param: agg_param.get_encoded().unwrap(),
     };
     let collect_uri = t
@@ -1247,7 +1247,7 @@ async fn fixed_size() {
         .consume_encrypted_agg_shares(
             &t.collector_hpke_receiver,
             &t.task_id,
-            &BatchSelector::FixedSizeByBatchId { batch_id },
+            &BatchSelector::LeaderSelectedByBatchId { batch_id },
             collection.report_count,
             &agg_param,
             collection.encrypted_agg_shares.to_vec(),
@@ -1302,7 +1302,7 @@ async fn fixed_size() {
     // Collector: Get the collect URI.
     let agg_param = DapAggregationParam::Empty;
     let collect_req = CollectionReq {
-        query: Query::FixedSizeCurrentBatch,
+        query: Query::LeaderSelectedCurrentBatch,
         agg_param: agg_param.get_encoded().unwrap(),
     };
     let collect_uri = t
@@ -1329,7 +1329,7 @@ async fn fixed_size() {
         DapMediaType::CollectionReq,
         None,
         CollectionReq {
-            query: Query::FixedSizeByBatchId {
+            query: Query::LeaderSelectedByBatchId {
                 batch_id: prev_batch_id,
             },
             agg_param: Vec::new(),

--- a/crates/daphne-server/tests/e2e/test_runner.rs
+++ b/crates/daphne-server/tests/e2e/test_runner.rs
@@ -62,10 +62,10 @@ impl TestRunner {
         Self::with(version, &DapQueryConfig::TimeInterval).await
     }
 
-    pub async fn fixed_size(version: DapVersion) -> Self {
+    pub async fn leader_selected(version: DapVersion) -> Self {
         Self::with(
             version,
-            &DapQueryConfig::FixedSize {
+            &DapQueryConfig::LeaderSelected {
                 max_batch_size: Some(NonZeroU32::new(MAX_BATCH_SIZE).unwrap()),
             },
         )
@@ -176,7 +176,7 @@ impl TestRunner {
 
         let (query_type, max_batch_size) = match t.task_config.query {
             DapQueryConfig::TimeInterval => (1, None),
-            DapQueryConfig::FixedSize { max_batch_size } => (2, Some(max_batch_size)),
+            DapQueryConfig::LeaderSelected { max_batch_size } => (2, Some(max_batch_size)),
         };
 
         const MAX_ATTEMPTS: usize = 10;

--- a/crates/daphne-service-utils/src/durable_requests/bindings/mod.rs
+++ b/crates/daphne-service-utils/src/durable_requests/bindings/mod.rs
@@ -144,7 +144,7 @@ mod tests {
             "batch/IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI",
             format!(
                 "{}",
-                DapBatchBucket::FixedSize {
+                DapBatchBucket::LeaderSelected {
                     batch_id: BatchId([34; 32]),
                     shard: 0,
                 }
@@ -164,7 +164,7 @@ mod tests {
             "batch/IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI/shard/2323",
             format!(
                 "{}",
-                DapBatchBucket::FixedSize {
+                DapBatchBucket::LeaderSelected {
                     batch_id: BatchId([34; 32]),
                     shard: 2323,
                 }

--- a/crates/daphne/src/hpke.rs
+++ b/crates/daphne/src/hpke.rs
@@ -629,7 +629,7 @@ mod test {
             sender: DapAggregatorRole::Leader,
             task_id: &crate::messages::TaskId(rand::random()),
             agg_param: &crate::DapAggregationParam::Empty,
-            batch_selector: &crate::messages::BatchSelector::FixedSizeByBatchId {
+            batch_selector: &crate::messages::BatchSelector::LeaderSelectedByBatchId {
                 batch_id: BatchId(rand::random()),
             },
         };
@@ -696,7 +696,7 @@ mod test {
                     duration: rand::random(),
                 },
             },
-            BatchSelector::FixedSizeByBatchId {
+            BatchSelector::LeaderSelectedByBatchId {
                 batch_id: BatchId(rand::random()),
             },
         ];

--- a/crates/daphne/src/roles/aggregator.rs
+++ b/crates/daphne/src/roles/aggregator.rs
@@ -85,7 +85,7 @@ pub trait DapAggregator: HpkeProvider + Sized {
     ) -> Result<bool, DapError>;
 
     /// Check whether the given batch ID has been observed before. This is called by the Leader
-    /// (resp. Helper) in response to a CollectReq (resp. AggregateShareReq) for fixed-size tasks.
+    /// (resp. Helper) in response to a CollectReq (resp. AggregateShareReq) for leader-selected tasks.
     async fn batch_exists(&self, task_id: &TaskId, batch_id: &BatchId) -> Result<bool, DapError>;
 
     /// Store a set of output shares and mark the corresponding reports as aggregated.

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -114,7 +114,7 @@ pub trait DapLeader: DapAggregator {
     /// Store a report for use later on.
     async fn put_report(&self, report: &Report, task_id: &TaskId) -> Result<(), DapError>;
 
-    /// Fixed-size tasks: Return the ID of the batch currently being filled.
+    /// Leader selected tasks: Return the ID of the batch currently being filled.
     //
     // TODO draft02 cleanup: Consider removing this.
     async fn current_batch(&self, task_id: &TaskId) -> Result<BatchId, DapError>;
@@ -269,8 +269,10 @@ pub async fn handle_coll_job_req<A: DapLeader>(
 
     let batch_sel = match coll_job_req.query {
         Query::TimeInterval { batch_interval } => BatchSelector::TimeInterval { batch_interval },
-        Query::FixedSizeByBatchId { batch_id } => BatchSelector::FixedSizeByBatchId { batch_id },
-        Query::FixedSizeCurrentBatch => BatchSelector::FixedSizeByBatchId {
+        Query::LeaderSelectedByBatchId { batch_id } => {
+            BatchSelector::LeaderSelectedByBatchId { batch_id }
+        }
+        Query::LeaderSelectedCurrentBatch => BatchSelector::LeaderSelectedByBatchId {
             batch_id: aggregator.current_batch(&task_id).await?,
         },
     };

--- a/crates/daphne/src/taskprov.rs
+++ b/crates/daphne/src/taskprov.rs
@@ -122,8 +122,8 @@ fn url_from_bytes(task_id: &TaskId, url_bytes: &[u8]) -> Result<Url, DapAbort> {
 impl DapQueryConfig {
     fn try_from_taskprov(task_id: &TaskId, var: QueryConfigVar) -> Result<Self, DapAbort> {
         match var {
-            QueryConfigVar::FixedSize { max_batch_size } => {
-                Ok(DapQueryConfig::FixedSize { max_batch_size })
+            QueryConfigVar::LeaderSelected { max_batch_size } => {
+                Ok(DapQueryConfig::LeaderSelected { max_batch_size })
             }
             QueryConfigVar::TimeInterval => Ok(DapQueryConfig::TimeInterval),
             QueryConfigVar::NotImplemented { typ, .. } => Err(DapAbort::InvalidTask {
@@ -354,8 +354,8 @@ impl TryFrom<&DapQueryConfig> for messages::taskprov::QueryConfigVar {
     fn try_from(query_config: &DapQueryConfig) -> Result<Self, DapError> {
         Ok(match query_config {
             DapQueryConfig::TimeInterval => messages::taskprov::QueryConfigVar::TimeInterval,
-            DapQueryConfig::FixedSize { max_batch_size } => {
-                messages::taskprov::QueryConfigVar::FixedSize {
+            DapQueryConfig::LeaderSelected { max_batch_size } => {
+                messages::taskprov::QueryConfigVar::LeaderSelected {
                     max_batch_size: *max_batch_size,
                 }
             }
@@ -472,7 +472,7 @@ mod test {
                 time_precision: 3600,
                 max_batch_query_count: 1,
                 min_batch_size: 1,
-                var: messages::taskprov::QueryConfigVar::FixedSize {
+                var: messages::taskprov::QueryConfigVar::LeaderSelected {
                     max_batch_size: Some(NonZeroU32::new(2).unwrap()),
                 },
             },
@@ -554,7 +554,7 @@ mod test {
                     time_precision: 3600,
                     max_batch_query_count: 1,
                     min_batch_size: 1,
-                    var: messages::taskprov::QueryConfigVar::FixedSize {
+                    var: messages::taskprov::QueryConfigVar::LeaderSelected {
                         max_batch_size: Some(NonZeroU32::new(2).unwrap()),
                     },
                 },
@@ -621,7 +621,7 @@ mod test {
                     time_precision: 3600,
                     max_batch_query_count: 1,
                     min_batch_size: 1,
-                    var: messages::taskprov::QueryConfigVar::FixedSize {
+                    var: messages::taskprov::QueryConfigVar::LeaderSelected {
                         max_batch_size: Some(NonZeroU32::new(2).unwrap()),
                     },
                 },

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -740,9 +740,11 @@ impl DapAggregator for InMemoryAggregator {
                 .lock()
                 .map_err(|_| fatal_error!(err = "agg_store poisoned"))?;
             let mut aggregated = false;
-            for bucket in task_config.batch_span_for_sel(&BatchSelector::FixedSizeByBatchId {
-                batch_id: *batch_id,
-            })? {
+            for bucket in
+                task_config.batch_span_for_sel(&BatchSelector::LeaderSelectedByBatchId {
+                    batch_id: *batch_id,
+                })?
+            {
                 if !agg_store.for_bucket(task_id, &bucket).agg_share.empty() {
                     aggregated = true;
                     break;


### PR DESCRIPTION
Draft-12 renames the "fixed-size" query type to "leader-selected". This PR makes this change in our codebase, rather than leaving the old names in place.
Even though we still have draft-09 code in place I renamed it here to keep the code consistent, given that this has no effect on the wire.