### PR TITLE
Rename query type to batch mode.

### DIFF
--- a/crates/dapf/README.md
+++ b/crates/dapf/README.md
@@ -90,7 +90,7 @@ issue requests to `internal/test/add_task`
   "leader_authentication_token": "I-am-the-leader",
   "role": "helper",
   "vdaf_verify_key": "dJXXtUfRAdIJ7z87revcZpqXZ16nbF9HB9OyZ1CMHxM",
-  "query_type": 2,
+  "batch_mode": 2,
   "min_batch_size": 10,
   "time_precision": 3600,
   "collector_hpke_config": "gwAgAAEAAQAgPMw62iLcCzNn0DHqSwKHanelnvMrWhwGEJVSpRpzmhM",

--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -29,7 +29,7 @@ use daphne::{
     metrics::DaphneMetrics,
     testing::report_generator::ReportGenerator,
     vdaf::VdafConfig,
-    DapAggregateShare, DapAggregateSpan, DapAggregationParam, DapMeasurement, DapQueryConfig,
+    DapAggregateShare, DapAggregateSpan, DapAggregationParam, DapBatchMode, DapMeasurement,
     DapTaskConfig, DapTaskParameters, DapVersion, ReplayProtection,
 };
 use daphne_service_utils::bearer_token::BearerToken;
@@ -380,7 +380,7 @@ impl Test {
             time_precision: 3600,
             lifetime: 60,
             min_batch_size: reports_per_batch.try_into().unwrap(),
-            query: DapQueryConfig::LeaderSelected {
+            query: DapBatchMode::LeaderSelected {
                 max_batch_size: NonZeroU32::new(reports_per_batch.try_into().unwrap()),
             },
             vdaf: self.vdaf_config,

--- a/crates/dapf/src/cli_parsers.rs
+++ b/crates/dapf/src/cli_parsers.rs
@@ -16,7 +16,7 @@ use daphne::{
     hpke::HpkeKemId,
     messages::{Base64Encode, CollectionJobId, TaskId},
     vdaf::{Prio3Config, VdafConfig},
-    DapQueryConfig,
+    DapBatchMode,
 };
 
 /// Some defaults for ease of use from the CLI. Instead of specifying the entire vdaf config json
@@ -128,37 +128,37 @@ impl CliVdafConfig {
 }
 
 #[derive(Clone, Debug)]
-pub struct CliDapQueryConfig(pub DapQueryConfig);
+pub struct CliDapBatchMode(pub DapBatchMode);
 
-impl fmt::Display for CliDapQueryConfig {
+impl fmt::Display for CliDapBatchMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <DapQueryConfig as fmt::Display>::fmt(&self.0, f)
+        <DapBatchMode as fmt::Display>::fmt(&self.0, f)
     }
 }
 
-impl From<CliDapQueryConfig> for DapQueryConfig {
-    fn from(CliDapQueryConfig(val): CliDapQueryConfig) -> Self {
+impl From<CliDapBatchMode> for DapBatchMode {
+    fn from(CliDapBatchMode(val): CliDapBatchMode) -> Self {
         val
     }
 }
 
-impl From<DapQueryConfig> for CliDapQueryConfig {
-    fn from(value: DapQueryConfig) -> Self {
+impl From<DapBatchMode> for CliDapBatchMode {
+    fn from(value: DapBatchMode) -> Self {
         Self(value)
     }
 }
 
-impl FromStr for CliDapQueryConfig {
+impl FromStr for CliDapBatchMode {
     type Err = String;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if s == "time-interval" {
-            Ok(Self(DapQueryConfig::TimeInterval))
+            Ok(Self(DapBatchMode::TimeInterval))
         } else if let Some(size) = s.strip_prefix("leader-selected") {
-            Ok(Self(DapQueryConfig::LeaderSelected {
+            Ok(Self(DapBatchMode::LeaderSelected {
                 max_batch_size: if let Some(size) = size.strip_prefix("-") {
                     Some(
                         size.parse()
-                            .map_err(|e| format!("{s} is an invalid query config: {e:?}"))?,
+                            .map_err(|e| format!("{s} is an invalid max batch size: {e:?}"))?,
                     )
                 } else if size.is_empty() {
                     None

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -113,7 +113,7 @@ mod test_utils {
         messages::decode_base64url_vec,
         roles::DapAggregator,
         vdaf::{Prio3Config, VdafConfig},
-        DapError, DapQueryConfig, DapTaskConfig, DapVersion,
+        DapBatchMode, DapError, DapTaskConfig, DapVersion,
     };
     use daphne_service_utils::{
         bearer_token::BearerToken,
@@ -276,17 +276,17 @@ mod test_utils {
             };
 
             // Query configuraiton.
-            let query = match (cmd.query_type, cmd.max_batch_size) {
-                (1, None) => DapQueryConfig::TimeInterval,
+            let query = match (cmd.batch_mode, cmd.max_batch_size) {
+                (1, None) => DapBatchMode::TimeInterval,
                 (1, Some(..)) => {
                     return Err(fatal_error!(
                         err = "command failed: unexpected max batch size"
                     ))
                 }
-                (2, max_batch_size) => DapQueryConfig::LeaderSelected { max_batch_size },
+                (2, max_batch_size) => DapBatchMode::LeaderSelected { max_batch_size },
                 _ => {
                     return Err(fatal_error!(
-                        err = "command failed: unrecognized query type"
+                        err = "command failed: unrecognized batch mode"
                     ))
                 }
             };

--- a/crates/daphne-server/src/router/extractor.rs
+++ b/crates/daphne-server/src/router/extractor.rs
@@ -663,7 +663,7 @@ mod test {
                 time_precision: 1,
                 max_batch_query_count: 1,
                 min_batch_size: 1,
-                var: daphne::messages::taskprov::QueryConfigVar::TimeInterval,
+                batch_mode: daphne::messages::taskprov::BatchMode::TimeInterval,
             },
             task_expiration: 1,
             vdaf_config: daphne::messages::taskprov::VdafConfig {

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -10,7 +10,7 @@ use daphne::{
         decode_base64url_vec, Base64Encode, BatchSelector, Collection, CollectionReq, Extension,
         HpkeCiphertext, Interval, Query, Report, ReportId, ReportMetadata, TaskId,
     },
-    DapAggregateResult, DapAggregationParam, DapMeasurement, DapQueryConfig, DapTaskParameters,
+    DapAggregateResult, DapAggregationParam, DapBatchMode, DapMeasurement, DapTaskParameters,
     DapVersion,
 };
 use daphne_service_utils::http_headers;
@@ -395,7 +395,7 @@ async fn leader_upload_taskprov() {
     let (task_config, task_id, taskprov_advertisement) = DapTaskParameters {
         version,
         min_batch_size: 10,
-        query: DapQueryConfig::TimeInterval,
+        query: DapBatchMode::TimeInterval,
         leader_url: t.task_config.leader_url.clone(),
         helper_url: t.task_config.helper_url.clone(),
         ..Default::default()
@@ -487,7 +487,7 @@ async fn leader_upload_taskprov_wrong_version(version: DapVersion) {
     let (task_config, task_id, taskprov_advertisement) = DapTaskParameters {
         version,
         min_batch_size: 10,
-        query: DapQueryConfig::TimeInterval,
+        query: DapBatchMode::TimeInterval,
         leader_url: t.task_config.leader_url.clone(),
         helper_url: t.task_config.helper_url.clone(),
         ..Default::default()
@@ -1354,7 +1354,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let (task_config, task_id, taskprov_advertisement) = DapTaskParameters {
         version,
         min_batch_size: 10,
-        query: DapQueryConfig::TimeInterval,
+        query: DapBatchMode::TimeInterval,
         leader_url: t.task_config.leader_url.clone(),
         helper_url: t.task_config.helper_url.clone(),
         ..Default::default()

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -85,7 +85,7 @@ pub struct InternalTestAddTask {
     pub collector_authentication_token: Option<String>,
     pub role: DapAggregatorRole,
     pub vdaf_verify_key: String, // base64url
-    pub query_type: u8,
+    pub batch_mode: u8,
     pub min_batch_size: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_batch_size: Option<NonZeroU32>,

--- a/crates/daphne/src/error/aborts.rs
+++ b/crates/daphne/src/error/aborts.rs
@@ -55,7 +55,7 @@ pub enum DapAbort {
     /// Query mismatch. Sent in response to a [`CollectionReq`](crate::messages::CollectionReq) or
     /// [`AggregateShareReq`](crate::messages::AggregateShareReq).
     #[error("queryMismatch")]
-    QueryMismatch { detail: String, task_id: TaskId },
+    BatchModeMismatch { detail: String, task_id: TaskId },
 
     /// Report rejected. Sent in response to an upload request containing a Report that the Leader
     /// would reject during the aggregation sub-protocol.
@@ -114,7 +114,7 @@ impl DapAbort {
             | Self::BatchMismatch { detail, task_id }
             | Self::BatchOverlap { detail, task_id }
             | Self::InvalidBatchSize { detail, task_id }
-            | Self::QueryMismatch { detail, task_id }
+            | Self::BatchModeMismatch { detail, task_id }
             | Self::UnauthorizedRequest { detail, task_id }
             | Self::InvalidMessage { detail, task_id } => (
                 Some(task_id),
@@ -225,13 +225,13 @@ impl DapAbort {
     }
 
     #[inline]
-    pub(crate) fn query_mismatch(
+    pub(crate) fn batch_mode_mismatch(
         task_id: &TaskId,
-        query_type_for_task: impl std::fmt::Display,
-        query_type_for_request: impl std::fmt::Display,
+        batch_mode_for_task: impl std::fmt::Display,
+        batch_mode_for_request: impl std::fmt::Display,
     ) -> Self {
-        Self::QueryMismatch {
-            detail: format!("The task's query type is \"{query_type_for_task}\", but the request indicates \"{query_type_for_request}\"."),
+        Self::BatchModeMismatch {
+            detail: format!("The task's batch mode is \"{batch_mode_for_task}\", but the request indicates \"{batch_mode_for_request}\"."),
             task_id: *task_id,
         }
     }
@@ -274,8 +274,8 @@ impl DapAbort {
             ),
             Self::InvalidBatchSize { .. } => ("Batch size is invalid", Some(self.to_string())),
             Self::InvalidTask { .. } => ("Opted out of Taskprov task", Some(self.to_string())),
-            Self::QueryMismatch { .. } => {
-                ("Query type does not match the task", Some(self.to_string()))
+            Self::BatchModeMismatch { .. } => {
+                ("Batch Mode does not match the task", Some(self.to_string()))
             }
             Self::RoundMismatch { .. } => (
                 "Aggregation round indicated by peer does not match host",
@@ -377,7 +377,7 @@ mod test {
                 task_id,
             },
             DapAbort::MissingTaskId,
-            DapAbort::QueryMismatch {
+            DapAbort::BatchModeMismatch {
                 detail: detail.clone(),
                 task_id,
             },

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -184,7 +184,7 @@ fn check_part_batch(
     agg_param: &[u8],
 ) -> Result<(), DapAbort> {
     if !task_config.query.is_valid_part_batch_sel(part_batch_sel) {
-        return Err(DapAbort::query_mismatch(
+        return Err(DapAbort::batch_mode_mismatch(
             task_id,
             &task_config.query,
             part_batch_sel,

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -24,8 +24,8 @@ use crate::{
         DapAggregator, DapHelper, DapLeader,
     },
     taskprov, DapAbort, DapAggregateResult, DapAggregateShare, DapAggregateSpan,
-    DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapCollectionJob, DapError,
-    DapGlobalConfig, DapMeasurement, DapQueryConfig, DapRequest, DapRequestMeta, DapResponse,
+    DapAggregationJobState, DapAggregationParam, DapBatchBucket, DapBatchMode, DapCollectionJob,
+    DapError, DapGlobalConfig, DapMeasurement, DapRequest, DapRequestMeta, DapResponse,
     DapTaskConfig, DapVersion, ReplayProtection, VdafConfig,
 };
 use async_trait::async_trait;
@@ -116,7 +116,7 @@ impl AggregationJobTest {
                 not_before: now,
                 not_after: now + 500,
                 min_batch_size: 10,
-                query: DapQueryConfig::TimeInterval,
+                query: DapBatchMode::TimeInterval,
                 vdaf: *vdaf,
                 vdaf_verify_key,
                 collector_hpke_config,


### PR DESCRIPTION
Draft 12 renames "query type" to "batch mode". This PR mirrors that change. 
Doing so has lead to some changes in the naming of various structs.
`QueryConfigVar` is now simply `BatchMode`, and `DapQueryConfig` is now `DapBatchMode`.
You can see from the conversion functions that this makes more sense.
We preserve the format of the `BatchMode` structs from draft-09, rather than storing an `opaque batch_config<1..2^16-1>`, because it doesn't make sense to store unparsed/encoded data.