### PR TITLE
Remove per-task HPKE config

### DIFF
--- a/crates/daphne-server/src/roles/aggregator.rs
+++ b/crates/daphne-server/src/roles/aggregator.rs
@@ -380,6 +380,7 @@ impl HpkeProvider for crate::App {
         version: DapVersion,
         _task_id: Option<&TaskId>,
     ) -> Result<Self::WrappedHpkeConfig<'static>, DapError> {
+        // TODO(draft-09) Remove `_task_id` parameter, as task id is no longer passed from draft-12.
         self.kv()
             .get_mapped::<kv::prefix::HpkeReceiverConfigSet, _, _>(
                 &version,

--- a/crates/daphne/src/roles/aggregator.rs
+++ b/crates/daphne/src/roles/aggregator.rs
@@ -145,6 +145,13 @@ where
 {
     let metrics = aggregator.metrics();
 
+    if version == DapVersion::Latest && task_id.is_some() {
+        return Err(DapAbort::BadRequest(
+            "Task ID may not be specified in draft 12 or later".to_string(),
+        )
+        .into());
+    }
+
     let hpke_config = aggregator
         .get_hpke_config_for(version, task_id.as_ref())
         .await?;

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -629,21 +629,35 @@ mod test {
     //    }
     //
     //    async_test_versions! { handle_agg_job_req_init_expired_task }
-
-    async fn handle_hpke_config_req_unrecognized_task(version: DapVersion) {
-        let t = Test::new(version);
+    #[tokio::test]
+    async fn handle_hpke_config_req_unrecognized_task_draft09() {
+        let t = Test::new(DapVersion::Draft09);
         let mut rng = thread_rng();
         let task_id = TaskId(rng.gen());
 
         assert_eq!(
-            aggregator::handle_hpke_config_req(&*t.leader, version, Some(task_id))
+            aggregator::handle_hpke_config_req(&*t.leader, DapVersion::Draft09, Some(task_id))
                 .await
                 .unwrap_err(),
             DapError::Abort(DapAbort::UnrecognizedTask { task_id })
         );
     }
 
-    async_test_versions! { handle_hpke_config_req_unrecognized_task }
+    #[tokio::test]
+    async fn handle_hpke_config_req_task_latest() {
+        let t = Test::new(DapVersion::Latest);
+        let mut rng = thread_rng();
+        let task_id = TaskId(rng.gen());
+
+        assert_eq!(
+            aggregator::handle_hpke_config_req(&*t.leader, DapVersion::Latest, Some(task_id))
+                .await
+                .unwrap_err(),
+            DapError::Abort(DapAbort::BadRequest(
+                "Task ID may not be specified in draft 12 or later".to_string()
+            ))
+        );
+    }
 
     async fn handle_hpke_config_req_missing_task_id(version: DapVersion) {
         let t = Test::new(version);


### PR DESCRIPTION
In draft-12 per-task HPKE configs were removed. The aggregator can simply return a list of configs in preference order.