### PR TITLE
Bump VDAF to draft 13 for Prio2

### DIFF
--- a/crates/dapf/src/acceptance/load_testing.rs
+++ b/crates/dapf/src/acceptance/load_testing.rs
@@ -58,6 +58,7 @@ fn jobs_per_batch() -> impl Iterator<Item = usize> {
 
 fn vdaf_config_params() -> impl Iterator<Item = VdafConfig> {
     [
+        VdafConfig::Prio2Draft09 { dimension: 99_992 },
         VdafConfig::Prio2 { dimension: 99_992 },
         VdafConfig::Prio3Draft09(
             daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
@@ -68,6 +69,22 @@ fn vdaf_config_params() -> impl Iterator<Item = VdafConfig> {
             },
         ),
         VdafConfig::Prio3Draft09(
+            daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                bits: 1,
+                length: 100_000,
+                chunk_length: 320,
+                num_proofs: 3,
+            },
+        ),
+        VdafConfig::Prio3(
+            daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                bits: 1,
+                length: 100_000,
+                chunk_length: 320,
+                num_proofs: 2,
+            },
+        ),
+        VdafConfig::Prio3(
             daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                 bits: 1,
                 length: 100_000,

--- a/crates/dapf/src/cli_parsers.rs
+++ b/crates/dapf/src/cli_parsers.rs
@@ -24,7 +24,10 @@ use daphne::{
 /// names of these in the commandline.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum DefaultVdafConfigs {
+    Prio2Draft09Dimension99k,
     Prio2Dimension99k,
+    Prio3Draft09NumProofs2,
+    Prio3Draft09NumProofs3,
     #[default]
     Prio3NumProofs2,
     Prio3NumProofs3,
@@ -39,7 +42,10 @@ impl fmt::Display for DefaultVdafConfigs {
 impl ValueEnum for DefaultVdafConfigs {
     fn value_variants<'a>() -> &'a [Self] {
         &[
+            Self::Prio2Draft09Dimension99k,
             Self::Prio2Dimension99k,
+            Self::Prio3Draft09NumProofs2,
+            Self::Prio3Draft09NumProofs3,
             Self::Prio3NumProofs2,
             Self::Prio3NumProofs3,
         ]
@@ -47,7 +53,12 @@ impl ValueEnum for DefaultVdafConfigs {
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         match self {
+            Self::Prio2Draft09Dimension99k => {
+                Some(PossibleValue::new("prio2-draft09-dimension-99k"))
+            }
             Self::Prio2Dimension99k => Some(PossibleValue::new("prio2-dimension-99k")),
+            Self::Prio3Draft09NumProofs2 => Some(PossibleValue::new("prio3-draft09-num-proofs-2")),
+            Self::Prio3Draft09NumProofs3 => Some(PossibleValue::new("prio3-draft09-num-proofs-3")),
             Self::Prio3NumProofs2 => Some(PossibleValue::new("prio3-num-proofs-2")),
             Self::Prio3NumProofs3 => Some(PossibleValue::new("prio3-num-proofs-3")),
         }
@@ -57,8 +68,9 @@ impl ValueEnum for DefaultVdafConfigs {
 impl DefaultVdafConfigs {
     fn into_vdaf_config(self) -> VdafConfig {
         match self {
+            Self::Prio2Draft09Dimension99k => VdafConfig::Prio2Draft09 { dimension: 99_992 },
             Self::Prio2Dimension99k => VdafConfig::Prio2 { dimension: 99_992 },
-            Self::Prio3NumProofs2 => {
+            Self::Prio3Draft09NumProofs2 => {
                 VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                     bits: 1,
                     length: 100_000,
@@ -66,8 +78,24 @@ impl DefaultVdafConfigs {
                     num_proofs: 2,
                 })
             }
-            Self::Prio3NumProofs3 => {
+            Self::Prio3Draft09NumProofs3 => {
                 VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                    bits: 1,
+                    length: 100_000,
+                    chunk_length: 320,
+                    num_proofs: 3,
+                })
+            }
+            Self::Prio3NumProofs2 => {
+                VdafConfig::Prio3(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                    bits: 1,
+                    length: 100_000,
+                    chunk_length: 320,
+                    num_proofs: 2,
+                })
+            }
+            Self::Prio3NumProofs3 => {
+                VdafConfig::Prio3(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                     bits: 1,
                     length: 100_000,
                     chunk_length: 320,

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -36,24 +36,34 @@ impl From<VdafConfig> for InternalTestVdaf {
     fn from(vdaf: VdafConfig) -> Self {
         let (typ, bits, length, chunk_length) = match vdaf {
             VdafConfig::Prio3Draft09(prio3) => match prio3 {
-                Prio3Config::Count => ("Prio3Count", None, None, None),
-                Prio3Config::Sum { bits } => ("Prio3Sum", Some(bits), None, None),
+                Prio3Config::Count => ("Prio3Draft09Count", None, None, None),
+                Prio3Config::Sum { bits } => ("Prio3Draft09Sum", Some(bits), None, None),
                 Prio3Config::Histogram {
                     length,
                     chunk_length,
-                } => ("Prio3Histogram", None, Some(length), Some(chunk_length)),
+                } => (
+                    "Prio3Draft09Histogram",
+                    None,
+                    Some(length),
+                    Some(chunk_length),
+                ),
                 Prio3Config::SumVec {
                     bits,
                     length,
                     chunk_length,
-                } => ("Prio3SumVec", Some(bits), Some(length), Some(chunk_length)),
+                } => (
+                    "Prio3Draft09SumVec",
+                    Some(bits),
+                    Some(length),
+                    Some(chunk_length),
+                ),
                 Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                     bits,
                     length,
                     chunk_length,
                     num_proofs: _unimplemented,
                 } => (
-                    "Prio3SumVecField64MultiproofHmacSha256Aes128",
+                    "Prio3Draft09SumVecField64MultiproofHmacSha256Aes128",
                     Some(bits),
                     Some(length),
                     Some(chunk_length),
@@ -83,6 +93,7 @@ impl From<VdafConfig> for InternalTestVdaf {
                     Some(chunk_length),
                 ),
             },
+            VdafConfig::Prio2Draft09 { .. } => ("Prio2Draft09", None, None, None),
             VdafConfig::Prio2 { .. } => ("Prio2", None, None, None),
             VdafConfig::Pine(_) => ("Pine", None, None, None),
             #[cfg(feature = "experimental")]

--- a/crates/daphne/benches/aggregation.rs
+++ b/crates/daphne/benches/aggregation.rs
@@ -43,7 +43,7 @@ fn consume_reports_vary_vdaf_dimension(c: &mut Criterion) {
 
     let mut g = c.benchmark_group(function!());
     for vdaf_length in vdaf_lengths {
-        let vdaf = VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+        let vdaf = VdafConfig::Prio3(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
             bits: 1,
             length: vdaf_length,
             chunk_length: 320,
@@ -67,7 +67,7 @@ fn consume_reports_vary_vdaf_dimension(c: &mut Criterion) {
 
 fn consume_reports_vary_num_reports(c: &mut Criterion) {
     const VDAF: VdafConfig =
-        VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+        VdafConfig::Prio3(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
             bits: 1,
             length: 1000,
             chunk_length: 320,

--- a/crates/daphne/src/messages/taskprov.rs
+++ b/crates/daphne/src/messages/taskprov.rs
@@ -35,6 +35,9 @@ const DP_MECHANISM_NONE: u8 = 0x01;
 /// A VDAF type along with its type-specific data.
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum VdafTypeVar {
+    Prio2Draft09 {
+        dimension: u32,
+    },
     Prio2 {
         dimension: u32,
     },
@@ -135,7 +138,7 @@ impl ParameterizedEncode<DapVersion> for VdafTypeVar {
         bytes: &mut Vec<u8>,
     ) -> Result<(), CodecError> {
         match self {
-            Self::Prio2 { dimension } => {
+            Self::Prio2Draft09 { dimension } | Self::Prio2 { dimension } => {
                 VDAF_TYPE_PRIO2.encode(bytes)?;
                 dimension.encode(bytes)?;
             }

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -21,6 +21,7 @@ use crate::{
     protocol::{decode_ping_pong_framed, PingPongMessageType},
     vdaf::{
         prio2::{prio2_prep_finish, prio2_prep_finish_from_shares},
+        prio2_draft09::{prio2_draft09_prep_finish, prio2_draft09_prep_finish_from_shares},
         prio3::{prio3_prep_finish, prio3_prep_finish_from_shares},
         prio3_draft09::{prio3_draft09_prep_finish, prio3_draft09_prep_finish_from_shares},
         VdafError,
@@ -318,11 +319,20 @@ impl DapTaskConfig {
                                 helper_prep_share.clone(),
                                 leader_prep_share,
                             ),
+                            VdafConfig::Prio2Draft09 { dimension } => {
+                                prio2_draft09_prep_finish_from_shares(
+                                    *dimension,
+                                    helper_prep_state.clone(),
+                                    helper_prep_share.clone(),
+                                    leader_prep_share,
+                                )
+                            }
                             VdafConfig::Prio2 { dimension } => prio2_prep_finish_from_shares(
                                 *dimension,
                                 helper_prep_state.clone(),
                                 helper_prep_share.clone(),
                                 leader_prep_share,
+                                task_id,
                             ),
                             #[cfg(feature = "experimental")]
                             VdafConfig::Mastic {
@@ -462,8 +472,11 @@ impl DapTaskConfig {
                 VdafConfig::Prio3(prio3_config) => {
                     prio3_prep_finish(prio3_config, leader.prep_state, prep_msg, *task_id)
                 }
+                VdafConfig::Prio2Draft09 { dimension } => {
+                    prio2_draft09_prep_finish(*dimension, leader.prep_state, prep_msg)
+                }
                 VdafConfig::Prio2 { dimension } => {
-                    prio2_prep_finish(*dimension, leader.prep_state, prep_msg)
+                    prio2_prep_finish(*dimension, leader.prep_state, prep_msg, *task_id)
                 }
                 #[cfg(feature = "experimental")]
                 VdafConfig::Mastic { .. } => mastic_prep_finish(leader.prep_state, prep_msg),

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -7,7 +7,10 @@ use crate::{
     constants::DapAggregatorRole,
     hpke::{info_and_aad, HpkeConfig},
     messages::{Extension, PlaintextInputShare, Report, ReportId, ReportMetadata, TaskId, Time},
-    vdaf::{prio2::prio2_shard, prio3::prio3_shard, prio3_draft09::prio3_draft09_shard, VdafError},
+    vdaf::{
+        prio2::prio2_shard, prio2_draft09::prio2_draft09_shard, prio3::prio3_shard,
+        prio3_draft09::prio3_draft09_shard, VdafError,
+    },
     DapError, DapMeasurement, DapVersion, VdafConfig,
 };
 use prio::codec::ParameterizedEncode;
@@ -130,7 +133,10 @@ impl VdafConfig {
             Self::Prio3(prio3_config) => {
                 Ok(prio3_shard(prio3_config, measurement, nonce, *task_id)?)
             }
-            Self::Prio2 { dimension } => Ok(prio2_shard(*dimension, measurement, nonce)?),
+            Self::Prio2Draft09 { dimension } => {
+                Ok(prio2_draft09_shard(*dimension, measurement, nonce)?)
+            }
+            Self::Prio2 { dimension } => Ok(prio2_shard(*dimension, measurement, nonce, *task_id)?),
             #[cfg(feature = "experimental")]
             VdafConfig::Mastic {
                 input_size,

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -8,7 +8,10 @@ use crate::{
     fatal_error,
     hpke::{info_and_aad, HpkeDecrypter},
     messages::{BatchSelector, HpkeCiphertext, TaskId},
-    vdaf::{prio2::prio2_unshard, prio3::prio3_unshard, prio3_draft09::prio3_draft09_unshard},
+    vdaf::{
+        prio2::prio2_unshard, prio2_draft09::prio2_draft09_unshard, prio3::prio3_unshard,
+        prio3_draft09::prio3_draft09_unshard,
+    },
     DapAggregateResult, DapAggregationParam, DapError, DapVersion, VdafConfig,
 };
 
@@ -77,6 +80,9 @@ impl VdafConfig {
                 prio3_draft09_unshard(prio3_config, num_measurements, agg_shares)
             }
             Self::Prio3(prio3_config) => prio3_unshard(prio3_config, num_measurements, agg_shares),
+            Self::Prio2Draft09 { dimension } => {
+                prio2_draft09_unshard(*dimension, num_measurements, agg_shares)
+            }
             Self::Prio2 { dimension } => prio2_unshard(*dimension, num_measurements, agg_shares),
             #[cfg(feature = "experimental")]
             Self::Mastic {

--- a/crates/daphne/src/protocol/report_init.rs
+++ b/crates/daphne/src/protocol/report_init.rs
@@ -12,8 +12,8 @@ use crate::{
     },
     protocol::{decode_ping_pong_framed, no_duplicates, PingPongMessageType},
     vdaf::{
-        prio2::prio2_prep_init, prio3::prio3_prep_init, prio3_draft09::prio3_draft09_prep_init,
-        VdafConfig, VdafPrepShare, VdafPrepState,
+        prio2::prio2_prep_init, prio2_draft09::prio2_draft09_prep_init, prio3::prio3_prep_init,
+        prio3_draft09::prio3_draft09_prep_init, VdafConfig, VdafPrepShare, VdafPrepState,
     },
     DapAggregationParam, DapError, DapTaskConfig,
 };
@@ -215,6 +215,14 @@ impl<P> InitializedReport<P> {
                 &report_share.public_share,
                 &input_share,
             ),
+            VdafConfig::Prio2Draft09 { dimension } => prio2_draft09_prep_init(
+                *dimension,
+                &task_config.vdaf_verify_key,
+                agg_id,
+                &report_share.report_metadata.id.0,
+                &report_share.public_share,
+                &input_share,
+            ),
             VdafConfig::Prio2 { dimension } => prio2_prep_init(
                 *dimension,
                 &task_config.vdaf_verify_key,
@@ -222,6 +230,7 @@ impl<P> InitializedReport<P> {
                 &report_share.report_metadata.id.0,
                 &report_share.public_share,
                 &input_share,
+                *task_id,
             ),
             #[cfg(feature = "experimental")]
             VdafConfig::Mastic {

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -198,7 +198,7 @@ mod test {
             };
 
             // Task Parameters that the Leader and Helper must agree on.
-            let vdaf_config = VdafConfig::Prio3Draft09(Prio3Config::Count);
+            let vdaf_config = VdafConfig::Prio3(Prio3Config::Count);
             let leader_url = Url::parse("https://leader.com/v02/").unwrap();
             let helper_url = Url::parse("http://helper.org:8788/v02/").unwrap();
             let collector_hpke_receiver_config =
@@ -486,10 +486,7 @@ mod test {
             // Construct report. We expect the VDAF to be Prio3Count so that we know what type of
             // measurement to generate. However, we could extend the code to support more VDAFs.
             let task_config = self.leader.unchecked_get_task_config(task_id).await;
-            assert_matches!(
-                task_config.vdaf,
-                VdafConfig::Prio3Draft09(Prio3Config::Count)
-            );
+            assert_matches!(task_config.vdaf, VdafConfig::Prio3(Prio3Config::Count));
 
             self.gen_test_report_for_measurement(task_id, DapMeasurement::U64(1))
                 .await
@@ -1516,7 +1513,18 @@ mod test {
         });
     }
 
-    async fn e2e_taskprov_prio2(version: DapVersion) {
+    async fn e2e_taskprov_prio2_draft09(version: DapVersion) {
+        e2e_taskprov(
+            version,
+            VdafConfig::Prio2Draft09 { dimension: 10 },
+            DapMeasurement::U32Vec(vec![1; 10]),
+        )
+        .await;
+    }
+
+    async_test_versions! { e2e_taskprov_prio2_draft09 }
+
+    async fn e2e_taskprov_prio2_latest(version: DapVersion) {
         e2e_taskprov(
             version,
             VdafConfig::Prio2 { dimension: 10 },
@@ -1525,9 +1533,11 @@ mod test {
         .await;
     }
 
-    async_test_versions! { e2e_taskprov_prio2 }
+    async_test_versions! { e2e_taskprov_prio2_latest }
 
-    async fn e2e_taskprov_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(version: DapVersion) {
+    async fn e2e_taskprov_prio3_draft09_sum_vec_field64_multiproof_hmac_sha256_aes128(
+        version: DapVersion,
+    ) {
         e2e_taskprov(
             version,
             VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
@@ -1541,7 +1551,7 @@ mod test {
         .await;
     }
 
-    async_test_versions! { e2e_taskprov_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128 }
+    async_test_versions! { e2e_taskprov_prio3_draft09_sum_vec_field64_multiproof_hmac_sha256_aes128 }
 
     async fn e2e_taskprov_pine32_hmac_sha256_aes128(version: DapVersion) {
         use crate::{pine::PineParam, vdaf::pine::PineConfig};

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -1112,12 +1112,18 @@ macro_rules! assert_metrics_include {
 impl VdafConfig {
     pub fn gen_measurement(&self) -> Result<DapMeasurement, DapError> {
         match self {
-            Self::Prio2 { dimension } => Ok(DapMeasurement::U32Vec(vec![1; *dimension])),
+            Self::Prio2Draft09 { dimension } | Self::Prio2 { dimension } => {
+                Ok(DapMeasurement::U32Vec(vec![1; *dimension]))
+            }
             Self::Prio3Draft09(
                 crate::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
                     length, ..
                 },
-            ) => Ok(DapMeasurement::U64Vec(vec![0; *length])),
+            )
+            | Self::Prio3(crate::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                length,
+                ..
+            }) => Ok(DapMeasurement::U64Vec(vec![0; *length])),
             _ => Err(fatal_error!(
                 err = format!("gen_measurement_for currently does not support {self:?}")
             )),


### PR DESCRIPTION
Prio2 can use draft-13 or draft-09. This PR adds backwards compatible support for the latest draft.
It also contains a few missing tests for Prio3's backwards compatible support.