### PR TITLE
pine: Add encoding for `PinePrepState`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "subtle",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.118"
 serde_yaml = "0.9.33"
 strum = { version = "0.26.3", features = ["derive"] }
+subtle = "2.6.1"
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"

--- a/crates/daphne/Cargo.toml
+++ b/crates/daphne/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 url.workspace = true
 tokio = { workspace = true, optional = true }
 rayon = { workspace = true }
+subtle = { workspace = true }
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
Decoding requires the instance of `Pine` and an indication of whether the aggregator is the leader or helper. Note that the encoding is not standardized anywhere.