### PR TITLE
Bump `prio` and adjust Prio3 key size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "prio"
 version = "0.17.0-alpha.0"
-source = "git+https://github.com/divviup/libprio-rs.git?rev=937e8a61c51019671232dee2d28dbe72413cdadc#937e8a61c51019671232dee2d28dbe72413cdadc"
+source = "git+https://github.com/divviup/libprio-rs.git?rev=c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1#c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ matchit = "0.7.3"
 p256 = { version = "0.13.2", features = ["ecdsa-core", "ecdsa", "pem"] }
 paste = "1.0.15"
 prio_draft09 = { package = "prio", version = "0.16.7" }
-prio = { git = "https://github.com/divviup/libprio-rs.git", rev = "937e8a61c51019671232dee2d28dbe72413cdadc" }
+prio = { git = "https://github.com/divviup/libprio-rs.git", rev = "c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1" }
 prometheus = "0.13.4"
 rand = "0.8.5"
 rayon = "1.10.0"

--- a/crates/daphne/src/vdaf/prio3.rs
+++ b/crates/daphne/src/vdaf/prio3.rs
@@ -103,7 +103,7 @@ pub(crate) fn prio3_prep_init(
     input_share_data: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
     return match (&config, verify_key) {
-        (Prio3Config::Count, VdafVerifyKey::L16(verify_key)) => {
+        (Prio3Config::Count, VdafVerifyKey::L32(verify_key)) => {
             let vdaf = Prio3::new_count(2).map_err(|e| {
                 VdafError::Dap(
                     fatal_error!(err = ?e, "failed to create prio3 from num_aggregators(2)"),
@@ -128,7 +128,7 @@ pub(crate) fn prio3_prep_init(
                 length,
                 chunk_length,
             },
-            VdafVerifyKey::L16(verify_key),
+            VdafVerifyKey::L32(verify_key),
         ) => {
             let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
                 .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
@@ -146,7 +146,7 @@ pub(crate) fn prio3_prep_init(
                 VdafPrepShare::Prio3Field128(share),
             ))
         }
-        (Prio3Config::Sum { .. }, VdafVerifyKey::L16(_)) => {
+        (Prio3Config::Sum { .. }, VdafVerifyKey::L32(_)) => {
             Err(VdafError::Dap(fatal_error!(err = "sum unimplemented")))
         }
         (
@@ -155,7 +155,7 @@ pub(crate) fn prio3_prep_init(
                 length,
                 chunk_length,
             },
-            VdafVerifyKey::L16(verify_key),
+            VdafVerifyKey::L32(verify_key),
         ) => {
             let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
                 .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;


### PR DESCRIPTION
Partially addresses #698.
cc @jhoyla 

As VDAF-13, the seed size for XofTurboShake128 is 32 bytes. Upstream has been adjusted accordingly as of 
c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1.