### PR TITLE
taskprov: Ensure the task ID matches the advertised config

### DIFF
--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -575,7 +575,7 @@ impl DapTaskParameters {
         let task_id = taskprov_advertisement.compute_task_id(self.version);
 
         // Compute the DAP task config.
-        let task_config = taskprov::DapTaskConfigNeedsOptIn::try_from_taskprov(
+        let task_config = taskprov::DapTaskConfigNeedsOptIn::try_from_taskprov_advertisement(
             self.version,
             &task_id,
             taskprov_advertisement.clone(),

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -107,7 +107,7 @@ async fn resolve_task_config(
             }
             .into());
         };
-        let task_config = DapTaskConfigNeedsOptIn::try_from_taskprov(
+        let task_config = DapTaskConfigNeedsOptIn::try_from_taskprov_advertisement(
             req.version,
             &req.task_id,
             taskprov_advertisement.clone(),


### PR DESCRIPTION
Closes #710.

Add a unit test that ensures
`TaskprovAdvertisement::parse_taskprov_advertisement()` fails if the task ID doesn't match the advertised task config. Along the way, adjust some variable names to make the code easier to read.