### PR TITLE
Refactor Prio3 dispatch logic, remove unneeded variants

### DIFF
--- a/crates/dapf/src/acceptance/load_testing.rs
+++ b/crates/dapf/src/acceptance/load_testing.rs
@@ -59,16 +59,16 @@ fn jobs_per_batch() -> impl Iterator<Item = usize> {
 fn vdaf_config_params() -> impl Iterator<Item = VdafConfig> {
     [
         VdafConfig::Prio2 { dimension: 99_992 },
-        VdafConfig::Prio3Draft09(
-            daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+        VdafConfig::Prio3(
+            daphne::vdaf::Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                 bits: 1,
                 length: 100_000,
                 chunk_length: 320,
                 num_proofs: 2,
             },
         ),
-        VdafConfig::Prio3Draft09(
-            daphne::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+        VdafConfig::Prio3(
+            daphne::vdaf::Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                 bits: 1,
                 length: 100_000,
                 chunk_length: 320,

--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -532,6 +532,7 @@ impl Test {
             agg_job_state,
             agg_job_resp,
             self.metrics(),
+            task_config.version,
         )?;
 
         let aggregated_report_count = agg_share_span

--- a/crates/dapf/src/cli_parsers.rs
+++ b/crates/dapf/src/cli_parsers.rs
@@ -58,22 +58,22 @@ impl DefaultVdafConfigs {
     fn into_vdaf_config(self) -> VdafConfig {
         match self {
             Self::Prio2Dimension99k => VdafConfig::Prio2 { dimension: 99_992 },
-            Self::Prio3Draft09NumProofs2 => {
-                VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+            Self::Prio3Draft09NumProofs2 => VdafConfig::Prio3(
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                     bits: 1,
                     length: 100_000,
                     chunk_length: 320,
                     num_proofs: 2,
-                })
-            }
-            Self::Prio3Draft09NumProofs3 => {
-                VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                },
+            ),
+            Self::Prio3Draft09NumProofs3 => VdafConfig::Prio3(
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                     bits: 1,
                     length: 100_000,
                     chunk_length: 320,
                     num_proofs: 3,
-                })
-            }
+                },
+            ),
         }
     }
 }

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -186,32 +186,36 @@ mod test_utils {
                 cmd.vdaf.bits,
                 cmd.vdaf.length,
                 cmd.vdaf.chunk_length,
+                cmd.vdaf.dimension,
             ) {
-                ("Prio3Count", None, None, None) => VdafConfig::Prio3Draft09(Prio3Config::Count),
-                ("Prio3Sum", Some(bits), None, None) => VdafConfig::Prio3Draft09(Prio3Config::Sum {
-                    bits: bits.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse bits for Prio3Config::Sum"))?,
+                ("Prio3Count", None, None, None, None) => VdafConfig::Prio3(Prio3Config::Count),
+                ("Prio3Sum", Some(max_measurement), None, None, None) => VdafConfig::Prio3(Prio3Config::Sum {
+                    max_measurement: max_measurement.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse bits for Prio3Config::Sum"))?,
                 }),
-                ("Prio3SumVec", Some(bits), Some(length), Some(chunk_length)) => {
-                    VdafConfig::Prio3Draft09(Prio3Config::SumVec {
+                ("Prio3SumVec", Some(bits), Some(length), Some(chunk_length), None) => {
+                    VdafConfig::Prio3(Prio3Config::SumVec {
                         bits: bits.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse bits for Prio3Config::SumVec"))?,
                         length: length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse length for Prio3Config::SumVec"))?,
                         chunk_length: chunk_length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse chunk_length for Prio3Config::SumVec"))?,
                     })
                 }
-                ("Prio3Histogram", None, Some(length), Some(chunk_length)) => {
-                    VdafConfig::Prio3Draft09(Prio3Config::Histogram {
+                ("Prio3Histogram", None, Some(length), Some(chunk_length), None) => {
+                    VdafConfig::Prio3(Prio3Config::Histogram {
                         length: length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse length for Prio3Config::Histogram"))?,
                         chunk_length: chunk_length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse chunk_length for Prio3Config::Histogram"))?,
                     })
                 }
-                ("Prio3SumVecField64MultiproofHmacSha256Aes128", Some(bits), Some(length), Some(chunk_length)) => {
-                    VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                ("Prio3SumVecField64MultiproofHmacSha256Aes128", Some(bits), Some(length), Some(chunk_length), None) => {
+                    VdafConfig::Prio3(Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                         bits: bits.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse bits for Prio3Config::SumVecField64MultiproofHmacSha256Aes128"))?,
                         length: length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse length for Prio3Config::SumVecField64MultiproofHmacSha256Aes128"))?,
                         chunk_length: chunk_length.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse chunk_length for Prio3Config::SumVecField64MultiproofHmacSha256Aes128"))?,
                         num_proofs: 2,
                     })
                 }
+                ("Prio2", None, None, None, Some(dimension)) => VdafConfig::Prio2 {
+                    dimension: dimension.parse().map_err(|e| fatal_error!(err = ?e, "failed to parse dimension for Prio2"))?,
+                },
                 _ => return Err(fatal_error!(err = "command failed: unrecognized VDAF")),
             };
 

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -151,7 +151,6 @@ async fn hpke_configs_are_cached(version: DapVersion) {
 
 async_test_versions! { hpke_configs_are_cached }
 
-// TODO draft02 cleanup: In draft09, the client is meant to PUT its report, not POST it.
 async fn leader_upload(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let mut rng = thread_rng();
@@ -171,7 +170,7 @@ async fn leader_upload(version: DapVersion) {
             &hpke_config_list,
             t.now,
             &t.task_id,
-            DapMeasurement::U64(23),
+            DapMeasurement::U32Vec(vec![1; 10]),
             version,
         )
         .unwrap();
@@ -202,7 +201,7 @@ async fn leader_upload(version: DapVersion) {
                 &hpke_config_list,
                 t.now,
                 &bad_id,
-                DapMeasurement::U64(999),
+                DapMeasurement::U32Vec(vec![1; 10]),
                 version,
             )
             .unwrap()
@@ -222,7 +221,7 @@ async fn leader_upload(version: DapVersion) {
             &hpke_config_list,
             t.now,
             &t.task_id,
-            DapMeasurement::U64(999),
+            DapMeasurement::U32Vec(vec![1; 10]),
             version,
         )
         .unwrap();
@@ -264,7 +263,7 @@ async fn leader_upload(version: DapVersion) {
             &hpke_config_list,
             t.task_config.not_after, // past the expiration date
             &t.task_id,
-            DapMeasurement::U64(23),
+            DapMeasurement::U32Vec(vec![1; 10]),
             version,
         )
         .unwrap();
@@ -352,7 +351,7 @@ async fn leader_back_compat_upload(version: DapVersion) {
             &hpke_config_list,
             t.now,
             &t.task_id,
-            DapMeasurement::U64(23),
+            DapMeasurement::U32Vec(vec![0; 10]),
             version,
         )
         .unwrap();
@@ -561,7 +560,7 @@ async fn internal_leader_process(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -641,7 +640,7 @@ async fn leader_collect_ok(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -707,7 +706,10 @@ async fn leader_collect_ok(version: DapVersion) {
         .unwrap();
     assert_eq!(
         agg_res,
-        DapAggregateResult::U128(u128::from(t.task_config.min_batch_size))
+        DapAggregateResult::U32Vec(vec![
+            u32::try_from(t.task_config.min_batch_size).unwrap();
+            10
+        ])
     );
 
     // Check that the time interval for the reports is correct.
@@ -739,7 +741,7 @@ async fn leader_collect_ok(version: DapVersion) {
     //      "upload",
     //      DapMediaType::Report,
     //      t.task_config.vdaf
-    //          .produce_report(&hpke_config_list, now, &t.task_id, DapMeasurement::U64(1))
+    //          .produce_report(&hpke_config_list, now, &t.task_id, DapMeasurement::U32Vec(vec![1; 10]))
     //          .unwrap()
     //          .get_encoded(),
     //      400,
@@ -779,7 +781,7 @@ async fn leader_collect_ok_interleaved(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -843,7 +845,7 @@ async fn leader_collect_not_ready_min_batch_size(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -936,7 +938,7 @@ async fn leader_collect_back_compat(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -1091,7 +1093,7 @@ async fn leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
                     &hpke_config_list,
                     now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -1187,7 +1189,7 @@ async fn leader_selected() {
                     &hpke_config_list,
                     t.now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()
@@ -1256,7 +1258,10 @@ async fn leader_selected() {
         .unwrap();
     assert_eq!(
         agg_res,
-        DapAggregateResult::U128(u128::from(t.task_config.min_batch_size))
+        DapAggregateResult::U32Vec(vec![
+            u32::try_from(t.task_config.min_batch_size).unwrap();
+            10
+        ])
     );
 
     // Collector: Poll the collect URI once more. Expect the response to be the same as the first,
@@ -1282,7 +1287,7 @@ async fn leader_selected() {
                     &hpke_config_list,
                     t.now,
                     &t.task_id,
-                    DapMeasurement::U64(1),
+                    DapMeasurement::U32Vec(vec![1; 10]),
                     version,
                 )
                 .unwrap()

--- a/crates/daphne-server/tests/e2e/test_runner.rs
+++ b/crates/daphne-server/tests/e2e/test_runner.rs
@@ -10,7 +10,7 @@ use daphne::{
         encode_base64url, taskprov::TaskprovAdvertisement, Base64Encode, BatchId, CollectionJobId,
         Duration, HpkeConfigList, Interval, TaskId,
     },
-    vdaf::{Prio3Config, VdafConfig},
+    vdaf::VdafConfig,
     DapBatchMode, DapGlobalConfig, DapLeaderProcessTelemetry, DapTaskConfig, DapVersion,
 };
 use daphne_service_utils::http_headers;
@@ -29,7 +29,8 @@ use std::{
 use tokio::time::timeout;
 use url::Url;
 
-const VDAF_CONFIG: &VdafConfig = &VdafConfig::Prio3Draft09(Prio3Config::Sum { bits: 10 });
+// Use a VDAF that is supported in all versions of DAP.
+const VDAF_CONFIG: &VdafConfig = &VdafConfig::Prio2 { dimension: 10 };
 pub(crate) const MIN_BATCH_SIZE: u64 = 10;
 pub(crate) const MAX_BATCH_SIZE: u32 = 12;
 pub(crate) const TIME_PRECISION: Duration = 3600; // seconds
@@ -167,10 +168,10 @@ impl TestRunner {
             encode_base64url(t.collector_hpke_receiver.config.get_encoded().unwrap());
 
         let vdaf = json!({
-            "type": "Prio3Sum",
-            "bits": assert_matches!(
+            "type": "Prio2",
+            "dimension": assert_matches!(
                 t.task_config.vdaf,
-                VdafConfig::Prio3Draft09(Prio3Config::Sum{ bits }) => format!("{bits}")
+                VdafConfig::Prio2{ dimension } => format!("{dimension}")
             ),
         });
 

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -30,34 +30,44 @@ pub struct InternalTestVdaf {
     pub length: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_length: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimension: Option<String>,
 }
 
 impl From<VdafConfig> for InternalTestVdaf {
     fn from(vdaf: VdafConfig) -> Self {
-        let (typ, bits, length, chunk_length) = match vdaf {
-            VdafConfig::Prio3Draft09(prio3) => match prio3 {
-                Prio3Config::Count => ("Prio3Draft09Count", None, None, None),
-                Prio3Config::Sum { bits } => ("Prio3Draft09Sum", Some(bits), None, None),
+        let (typ, bits, length, chunk_length, dimension) = match vdaf {
+            VdafConfig::Prio3(prio3) => match prio3 {
+                Prio3Config::Count => ("Prio3Count", None, None, None, None),
+                Prio3Config::Sum { max_measurement } => (
+                    "Prio3Sum",
+                    Some(usize::try_from(max_measurement).unwrap()),
+                    None,
+                    None,
+                    None,
+                ),
                 Prio3Config::Histogram {
                     length,
                     chunk_length,
                 } => (
-                    "Prio3Draft09Histogram",
+                    "Prio3Histogram",
                     None,
                     Some(length),
                     Some(chunk_length),
+                    None,
                 ),
                 Prio3Config::SumVec {
                     bits,
                     length,
                     chunk_length,
                 } => (
-                    "Prio3Draft09SumVec",
+                    "Prio3SumVec",
                     Some(bits),
                     Some(length),
                     Some(chunk_length),
+                    None,
                 ),
-                Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
                     bits,
                     length,
                     chunk_length,
@@ -67,34 +77,11 @@ impl From<VdafConfig> for InternalTestVdaf {
                     Some(bits),
                     Some(length),
                     Some(chunk_length),
+                    None,
                 ),
             },
-            VdafConfig::Prio3(prio3) => match prio3 {
-                Prio3Config::Count => ("Prio3Count", None, None, None),
-                Prio3Config::Sum { bits } => ("Prio3Sum", Some(bits), None, None),
-                Prio3Config::Histogram {
-                    length,
-                    chunk_length,
-                } => ("Prio3Histogram", None, Some(length), Some(chunk_length)),
-                Prio3Config::SumVec {
-                    bits,
-                    length,
-                    chunk_length,
-                } => ("Prio3SumVec", Some(bits), Some(length), Some(chunk_length)),
-                Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                    bits,
-                    length,
-                    chunk_length,
-                    num_proofs: _unimplemented,
-                } => (
-                    "Prio3SumVecField64MultiproofHmacSha256Aes128",
-                    Some(bits),
-                    Some(length),
-                    Some(chunk_length),
-                ),
-            },
-            VdafConfig::Prio2 { .. } => ("Prio2", None, None, None),
-            VdafConfig::Pine(_) => ("Pine", None, None, None),
+            VdafConfig::Prio2 { dimension } => ("Prio2", None, None, None, Some(dimension)),
+            VdafConfig::Pine(_) => ("Pine", None, None, None, None),
             #[cfg(feature = "experimental")]
             VdafConfig::Mastic { .. } => todo!(),
         };
@@ -103,6 +90,7 @@ impl From<VdafConfig> for InternalTestVdaf {
             bits: bits.map(|a| a.to_string()),
             length: length.map(|a| a.to_string()),
             chunk_length: chunk_length.map(|a| a.to_string()),
+            dimension: dimension.map(|a| a.to_string()),
         }
     }
 }

--- a/crates/daphne/benches/aggregation.rs
+++ b/crates/daphne/benches/aggregation.rs
@@ -37,18 +37,20 @@ fn consume_reports_vary_vdaf_dimension(c: &mut Criterion) {
     let mut test = AggregationJobTest::new(
         &VdafConfig::Prio2 { dimension: 0 },
         HpkeKemId::P256HkdfSha256,
-        DapVersion::Latest,
+        DapVersion::Draft09,
     );
     test.disable_replay_protection();
 
     let mut g = c.benchmark_group(function!());
     for vdaf_length in vdaf_lengths {
-        let vdaf = VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-            bits: 1,
-            length: vdaf_length,
-            chunk_length: 320,
-            num_proofs: 2,
-        });
+        let vdaf = VdafConfig::Prio3(
+            Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                bits: 1,
+                length: vdaf_length,
+                chunk_length: 320,
+                num_proofs: 2,
+            },
+        );
         test.change_vdaf(vdaf);
         let reports = test
             .produce_repeated_reports(vdaf.gen_measurement().unwrap())
@@ -66,15 +68,16 @@ fn consume_reports_vary_vdaf_dimension(c: &mut Criterion) {
 }
 
 fn consume_reports_vary_num_reports(c: &mut Criterion) {
-    const VDAF: VdafConfig =
-        VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
+    const VDAF: VdafConfig = VdafConfig::Prio3(
+        Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
             bits: 1,
             length: 1000,
             chunk_length: 320,
             num_proofs: 2,
-        });
+        },
+    );
 
-    let mut test = AggregationJobTest::new(&VDAF, HpkeKemId::P256HkdfSha256, DapVersion::Latest);
+    let mut test = AggregationJobTest::new(&VDAF, HpkeKemId::P256HkdfSha256, DapVersion::Draft09);
     test.disable_replay_protection();
 
     let mut g = c.benchmark_group(function!());

--- a/crates/daphne/src/protocol/client.rs
+++ b/crates/daphne/src/protocol/client.rs
@@ -7,7 +7,7 @@ use crate::{
     constants::DapAggregatorRole,
     hpke::{info_and_aad, HpkeConfig},
     messages::{Extension, PlaintextInputShare, Report, ReportId, ReportMetadata, TaskId, Time},
-    vdaf::{prio2::prio2_shard, prio3::prio3_shard, prio3_draft09::prio3_draft09_shard, VdafError},
+    vdaf::{prio2::prio2_shard, VdafError},
     DapError, DapMeasurement, DapVersion, VdafConfig,
 };
 use prio::codec::ParameterizedEncode;
@@ -45,7 +45,7 @@ impl VdafConfig {
         let mut rng = thread_rng();
         let report_id = ReportId(rng.gen());
         let (public_share, input_shares) = self
-            .produce_input_shares(measurement, &report_id.0, task_id)
+            .produce_input_shares(measurement, &report_id.0, task_id, version)
             .map_err(DapError::from_vdaf)?;
         Self::produce_report_with_extensions_for_shares(
             public_share,
@@ -122,13 +122,11 @@ impl VdafConfig {
         measurement: DapMeasurement,
         nonce: &[u8; 16],
         task_id: &TaskId,
+        version: DapVersion,
     ) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
         match self {
-            Self::Prio3Draft09(prio3_config) => {
-                Ok(prio3_draft09_shard(prio3_config, measurement, nonce)?)
-            }
             Self::Prio3(prio3_config) => {
-                Ok(prio3_shard(prio3_config, measurement, nonce, *task_id)?)
+                Ok(prio3_config.shard(version, measurement, nonce, *task_id)?)
             }
             Self::Prio2 { dimension } => Ok(prio2_shard(*dimension, measurement, nonce)?),
             #[cfg(feature = "experimental")]

--- a/crates/daphne/src/protocol/collector.rs
+++ b/crates/daphne/src/protocol/collector.rs
@@ -8,7 +8,7 @@ use crate::{
     fatal_error,
     hpke::{info_and_aad, HpkeDecrypter},
     messages::{BatchSelector, HpkeCiphertext, TaskId},
-    vdaf::{prio2::prio2_unshard, prio3::prio3_unshard, prio3_draft09::prio3_draft09_unshard},
+    vdaf::prio2::prio2_unshard,
     DapAggregateResult, DapAggregationParam, DapError, DapVersion, VdafConfig,
 };
 
@@ -73,10 +73,9 @@ impl VdafConfig {
 
         let num_measurements = usize::try_from(report_count).unwrap();
         match self {
-            Self::Prio3Draft09(prio3_config) => {
-                prio3_draft09_unshard(prio3_config, num_measurements, agg_shares)
+            Self::Prio3(prio3_config) => {
+                prio3_config.unshard(version, num_measurements, agg_shares)
             }
-            Self::Prio3(prio3_config) => prio3_unshard(prio3_config, num_measurements, agg_shares),
             Self::Prio2 { dimension } => prio2_unshard(*dimension, num_measurements, agg_shares),
             #[cfg(feature = "experimental")]
             Self::Mastic {

--- a/crates/daphne/src/protocol/report_init.rs
+++ b/crates/daphne/src/protocol/report_init.rs
@@ -10,10 +10,7 @@ use crate::{
         self, Extension, PlaintextInputShare, ReportError, ReportMetadata, ReportShare, TaskId,
     },
     protocol::{decode_ping_pong_framed, no_duplicates, PingPongMessageType},
-    vdaf::{
-        prio2::prio2_prep_init, prio3::prio3_prep_init, prio3_draft09::prio3_draft09_prep_init,
-        VdafConfig, VdafPrepShare, VdafPrepState,
-    },
+    vdaf::{prio2::prio2_prep_init, VdafConfig, VdafPrepShare, VdafPrepState},
     DapAggregationParam, DapError, DapTaskConfig,
 };
 use prio::codec::{CodecError, ParameterizedDecode as _};
@@ -197,16 +194,8 @@ impl<P> InitializedReport<P> {
             DapAggregatorRole::Helper => 1,
         };
         let res = match &task_config.vdaf {
-            VdafConfig::Prio3Draft09(ref prio3_config) => prio3_draft09_prep_init(
-                prio3_config,
-                &task_config.vdaf_verify_key,
-                agg_id,
-                &report_share.report_metadata.id.0,
-                &report_share.public_share,
-                &input_share,
-            ),
-            VdafConfig::Prio3(ref prio3_config) => prio3_prep_init(
-                prio3_config,
+            VdafConfig::Prio3(prio3_config) => prio3_config.prep_init(
+                task_config.version,
                 &task_config.vdaf_verify_key,
                 *task_id,
                 agg_id,

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -232,6 +232,7 @@ async fn finish_agg_job_and_aggregate(
             &report_status,
             part_batch_sel,
             initialized_reports,
+            task_config.version,
         )?;
 
         let put_shares_result = helper

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -341,8 +341,13 @@ async fn run_agg_job<A: DapLeader>(
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     // Handle AggregationJobResp.
-    let agg_span =
-        task_config.consume_agg_job_resp(task_id, agg_job_state, agg_job_resp, metrics)?;
+    let agg_span = task_config.consume_agg_job_resp(
+        task_id,
+        agg_job_state,
+        agg_job_resp,
+        metrics,
+        task_config.version,
+    )?;
 
     let out_shares_count = agg_span.report_count() as u64;
     if out_shares_count == 0 {

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -223,6 +223,7 @@ impl AggregationJobTest {
                         self.replay_protection,
                     )
                     .unwrap(),
+                self.task_config.version,
             )
             .unwrap()
     }
@@ -241,6 +242,7 @@ impl AggregationJobTest {
                 leader_state,
                 agg_job_resp,
                 &self.leader_metrics,
+                self.task_config.version,
             )
             .unwrap()
     }
@@ -253,7 +255,13 @@ impl AggregationJobTest {
     ) -> DapError {
         let metrics = &self.leader_metrics;
         self.task_config
-            .consume_agg_job_resp(&self.task_id, leader_state, agg_job_resp, metrics)
+            .consume_agg_job_resp(
+                &self.task_id,
+                leader_state,
+                agg_job_resp,
+                metrics,
+                self.task_config.version,
+            )
             .expect_err("consume_agg_job_resp() succeeded; expected failure")
     }
 
@@ -1113,9 +1121,10 @@ impl VdafConfig {
     pub fn gen_measurement(&self) -> Result<DapMeasurement, DapError> {
         match self {
             Self::Prio2 { dimension } => Ok(DapMeasurement::U32Vec(vec![1; *dimension])),
-            Self::Prio3Draft09(
-                crate::vdaf::Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                    length, ..
+            Self::Prio3(
+                crate::vdaf::Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    length,
+                    ..
                 },
             ) => Ok(DapMeasurement::U64Vec(vec![0; *length])),
             _ => Err(fatal_error!(

--- a/crates/daphne/src/vdaf/prio3.rs
+++ b/crates/daphne/src/vdaf/prio3.rs
@@ -6,8 +6,8 @@
 use crate::{
     fatal_error,
     messages::TaskId,
-    vdaf::{VdafError, VdafVerifyKey},
-    DapAggregateResult, DapMeasurement, Prio3Config, VdafAggregateShare, VdafPrepShare,
+    vdaf::{prio3_draft09, VdafError, VdafVerifyKey},
+    DapAggregateResult, DapMeasurement, DapVersion, Prio3Config, VdafAggregateShare, VdafPrepShare,
     VdafPrepState,
 };
 
@@ -25,385 +25,542 @@ use prio::{
 
 const CTX_STRING_PREFIX: &[u8] = b"dap-13";
 
-/// Split the given measurement into a sequence of encoded input shares.
-pub(crate) fn prio3_shard(
-    config: &Prio3Config,
-    measurement: DapMeasurement,
-    nonce: &[u8; 16],
-    task_id: TaskId,
-) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
-    match (config, measurement) {
-        (Prio3Config::Count, DapMeasurement::U64(measurement)) if measurement < 2 => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            shard_then_encode(&vdaf, task_id, &(measurement != 0), nonce)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            DapMeasurement::U64(measurement),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 Histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let m: usize = measurement.try_into().unwrap();
-            shard_then_encode(&vdaf, task_id, &m, nonce)
-        }
-        (Prio3Config::Sum { .. }, DapMeasurement::U64(_)) => {
-            Err(VdafError::Dap(fatal_error!(err = "Sum unimplemented")))
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            DapMeasurement::U128Vec(measurement),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            shard_then_encode(&vdaf, task_id, &measurement, nonce)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 { .. },
-            DapMeasurement::U64Vec(_),
-        ) => Err(VdafError::Dap(fatal_error!(
-            err = format!(
-                "prio3_shard: SumVecField64MultiproofHmacSha256Aes128 is not defined for VDAF-13"
-            )
-        ))),
-        _ => Err(VdafError::Dap(fatal_error!(
-            err = format!("prio3_shard: unexpected VDAF config {config:?}")
-        ))),
-    }
-}
-
-/// Consume an input share and return the corresponding VDAF step and message.
-pub(crate) fn prio3_prep_init(
-    config: &Prio3Config,
-    verify_key: &VdafVerifyKey,
-    task_id: TaskId,
-    agg_id: usize,
-    nonce: &[u8; 16],
-    public_share_data: &[u8],
-    input_share_data: &[u8],
-) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-    return match (&config, verify_key) {
-        (Prio3Config::Count, VdafVerifyKey::L32(verify_key)) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 from num_aggregators(2)"),
-                )
-            })?;
-            let (state, share) = prep_init(
-                vdaf,
-                task_id,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Field64(state),
-                VdafPrepShare::Prio3Field64(share),
-            ))
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafVerifyKey::L32(verify_key),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let (state, share) = prep_init(
-                vdaf,
-                task_id,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Field128(state),
-                VdafPrepShare::Prio3Field128(share),
-            ))
-        }
-        (Prio3Config::Sum { .. }, VdafVerifyKey::L32(_)) => {
-            Err(VdafError::Dap(fatal_error!(err = "sum unimplemented")))
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafVerifyKey::L32(verify_key),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let (state, share) = prep_init(
-                vdaf,
-                task_id,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Field128(state),
-                VdafPrepShare::Prio3Field128(share),
-            ))
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-            ..},
-            VdafVerifyKey::L32(_),
-        ) => {
-            Err(VdafError::Dap(fatal_error!(err = format!("prio3_shard: SumVecField64MultiproofHmacSha256Aes128 is not defined for VDAF-13"))))
-        },
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = "unhandled config and verify key combination",
-            )))
-        }
-
-    };
-
-    type Prio3Prepared<T, const SEED_SIZE: usize> = (
-        Prio3PrepareState<<T as Type>::Field, SEED_SIZE>,
-        Prio3PrepareShare<<T as Type>::Field, SEED_SIZE>,
-    );
-
-    fn prep_init<T, P, const SEED_SIZE: usize>(
-        vdaf: Prio3<T, P, SEED_SIZE>,
+impl Prio3Config {
+    pub(crate) fn shard(
+        &self,
+        version: DapVersion,
+        measurement: DapMeasurement,
+        nonce: &[u8; 16],
         task_id: TaskId,
-        verify_key: &[u8; SEED_SIZE],
+    ) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
+        match (version, self, measurement) {
+            (DapVersion::Latest, Prio3Config::Count, DapMeasurement::U64(measurement))
+                if measurement < 2 =>
+            {
+                let vdaf = Prio3::new_count(2).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                shard_then_encode(&vdaf, task_id, &(measurement != 0), nonce)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Sum { max_measurement },
+                DapMeasurement::U64(measurement),
+            ) => {
+                let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                shard_then_encode(&vdaf, task_id, &measurement, nonce)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Histogram {
+                    length,
+                    chunk_length,
+                },
+                DapMeasurement::U64(measurement),
+            ) => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let m: usize = measurement.try_into().unwrap();
+                shard_then_encode(&vdaf, task_id, &m, nonce)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+                DapMeasurement::U128Vec(measurement),
+            ) => {
+                let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                shard_then_encode(&vdaf, task_id, &measurement, nonce)
+            }
+            (
+                DapVersion::Draft09,
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits,
+                    length,
+                    chunk_length,
+                    num_proofs,
+                },
+                DapMeasurement::U64Vec(measurement),
+            ) => {
+                let vdaf = prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+                    *bits,
+                    *length,
+                    *chunk_length,
+                    *num_proofs,
+                )?;
+                super::shard_then_encode_draft09(&vdaf, &measurement, nonce)
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err =
+                    format!("unexpected measurement or {self:?} is not supported in DAP {version}")
+            ))),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prep_init(
+        &self,
+        version: DapVersion,
+        verify_key: &VdafVerifyKey,
+        task_id: TaskId,
         agg_id: usize,
         nonce: &[u8; 16],
         public_share_data: &[u8],
         input_share_data: &[u8],
-    ) -> Result<Prio3Prepared<T, SEED_SIZE>, VdafError>
-    where
-        T: Type,
-        P: Xof<SEED_SIZE>,
-    {
-        // Parse the public share.
-        let public_share = Prio3PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
+    ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
+        return match (version, self, verify_key) {
+            (DapVersion::Latest, Prio3Config::Count, VdafVerifyKey::L32(verify_key)) => {
+                let vdaf = Prio3::new_count(2).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (state, share) = prep_init(
+                    vdaf,
+                    task_id,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Prio3Field64(state),
+                    VdafPrepShare::Prio3Field64(share),
+                ))
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Sum { max_measurement },
+                VdafVerifyKey::L32(verify_key),
+            ) => {
+                let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (state, share) = prep_init(
+                    vdaf,
+                    task_id,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Prio3Field64(state),
+                    VdafPrepShare::Prio3Field64(share),
+                ))
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Histogram {
+                    length,
+                    chunk_length,
+                },
+                VdafVerifyKey::L32(verify_key),
+            ) => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (state, share) = prep_init(
+                    vdaf,
+                    task_id,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Prio3Field128(state),
+                    VdafPrepShare::Prio3Field128(share),
+                ))
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+                VdafVerifyKey::L32(verify_key),
+            ) => {
+                let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (state, share) = prep_init(
+                    vdaf,
+                    task_id,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Prio3Field128(state),
+                    VdafPrepShare::Prio3Field128(share),
+                ))
+            }
+            (
+                DapVersion::Draft09,
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits,
+                    length,
+                    chunk_length,
+                    num_proofs,
+                },
+                VdafVerifyKey::L32(verify_key),
+            ) => {
+                let vdaf = prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+                    *bits,
+                    *length,
+                    *chunk_length,
+                    *num_proofs,
+                )?;
+                let (state, share) = prio3_draft09::prep_init_draft09(
+                    vdaf,
+                    verify_key,
+                    agg_id,
+                    nonce,
+                    public_share_data,
+                    input_share_data,
+                )?;
+                Ok((
+                    VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
+                    VdafPrepShare::Prio3Draft09Field64HmacSha256Aes128(share),
+                ))
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err =
+                    format!("unexpected verify key or {self:?} is not supported in DAP {version}")
+            ))),
+        };
 
-        // Parse the input share.
-        let input_share =
-            Prio3InputShare::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
+        type Prio3Prepared<T, const SEED_SIZE: usize> = (
+            Prio3PrepareState<<T as Type>::Field, SEED_SIZE>,
+            Prio3PrepareShare<<T as Type>::Field, SEED_SIZE>,
+        );
 
-        let mut ctx = [0; CTX_STRING_PREFIX.len() + 32];
-        ctx[..CTX_STRING_PREFIX.len()].copy_from_slice(CTX_STRING_PREFIX);
-        ctx[CTX_STRING_PREFIX.len()..].copy_from_slice(&task_id.0);
-        // Run the prepare-init algorithm, returning the initial state.
-        Ok(vdaf.prepare_init(
-            verify_key,
-            &ctx,
-            agg_id,
-            &(),
-            nonce,
-            &public_share,
-            &input_share,
-        )?)
+        fn prep_init<T, P, const SEED_SIZE: usize>(
+            vdaf: Prio3<T, P, SEED_SIZE>,
+            task_id: TaskId,
+            verify_key: &[u8; SEED_SIZE],
+            agg_id: usize,
+            nonce: &[u8; 16],
+            public_share_data: &[u8],
+            input_share_data: &[u8],
+        ) -> Result<Prio3Prepared<T, SEED_SIZE>, VdafError>
+        where
+            T: Type,
+            P: Xof<SEED_SIZE>,
+        {
+            // Parse the public share.
+            let public_share = Prio3PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
+
+            // Parse the input share.
+            let input_share =
+                Prio3InputShare::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
+
+            let mut ctx = [0; CTX_STRING_PREFIX.len() + 32];
+            ctx[..CTX_STRING_PREFIX.len()].copy_from_slice(CTX_STRING_PREFIX);
+            ctx[CTX_STRING_PREFIX.len()..].copy_from_slice(&task_id.0);
+            // Run the prepare-init algorithm, returning the initial state.
+            Ok(vdaf.prepare_init(
+                verify_key,
+                &ctx,
+                agg_id,
+                &(),
+                nonce,
+                &public_share,
+                &input_share,
+            )?)
+        }
     }
-}
 
-/// Consume the prep shares and return our output share and the prep message.
-pub(crate) fn prio3_prep_finish_from_shares(
-    config: &Prio3Config,
-    agg_id: usize,
-    task_id: TaskId,
-    host_state: VdafPrepState,
-    host_share: VdafPrepShare,
-    peer_share_data: &[u8],
-) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
-    let (agg_share, outbound) = match (&config, host_state, host_share) {
-        (
-            Prio3Config::Count,
-            VdafPrepState::Prio3Field64(state),
-            VdafPrepShare::Prio3Field64(share),
-        ) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count num_aggregators(2)"),
+    pub(crate) fn prep_finish_from_shares(
+        &self,
+        version: DapVersion,
+        agg_id: usize,
+        task_id: TaskId,
+        host_state: VdafPrepState,
+        host_share: VdafPrepShare,
+        peer_share_data: &[u8],
+    ) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
+        let (agg_share, outbound) = match (version, self, host_state, host_share) {
+            (
+                DapVersion::Latest,
+                Prio3Config::Count,
+                VdafPrepState::Prio3Field64(state),
+                VdafPrepShare::Prio3Field64(share),
+            ) => {
+                let vdaf = Prio3::new_count(2).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (out_share, outbound) =
+                    prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
+                let agg_share = VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?);
+                (agg_share, outbound)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Sum { max_measurement },
+                VdafPrepState::Prio3Field64(state),
+                VdafPrepShare::Prio3Field64(share),
+            ) => {
+                let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (out_share, outbound) =
+                    prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
+                let agg_share = VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?);
+                (agg_share, outbound)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Histogram {
+                    length,
+                    chunk_length,
+                },
+                VdafPrepState::Prio3Field128(state),
+                VdafPrepShare::Prio3Field128(share),
+            ) => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (out_share, outbound) =
+                    prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
+                let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
+                (agg_share, outbound)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+                VdafPrepState::Prio3Field128(state),
+                VdafPrepShare::Prio3Field128(share),
+            ) => {
+                let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let (out_share, outbound) =
+                    prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
+                let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
+                (agg_share, outbound)
+            }
+            (
+                DapVersion::Draft09,
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits,
+                    length,
+                    chunk_length,
+                    num_proofs,
+                },
+                VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
+                VdafPrepShare::Prio3Draft09Field64HmacSha256Aes128(share),
+            ) => {
+                let vdaf = prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+                    *bits,
+                    *length,
+                    *chunk_length,
+                    *num_proofs,
+                )?;
+                let (out_share, outbound) = super::prep_finish_from_shares_draft09(
+                    &vdaf,
+                    agg_id,
+                    state,
+                    share,
+                    peer_share_data,
+                )?;
+                let agg_share = VdafAggregateShare::Field64Draft09(
+                    prio_draft09::vdaf::Aggregator::aggregate(&vdaf, &(), [out_share])?,
+                );
+                (agg_share, outbound)
+            }
+            _ => {
+                return Err(VdafError::Dap(fatal_error!(
+                    err = format!(
+                    "unexpected prep state or share or {self:?} is not supported in DAP {version}"
                 )
-            })?;
-            let (out_share, outbound) =
-                prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Field128(state),
-            VdafPrepShare::Prio3Field128(share),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let (out_share, outbound) =
-                prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::Sum { .. },
-            VdafPrepState::Prio3Field128(_),
-            VdafPrepShare::Prio3Field128(_),
-        ) => Err(VdafError::Dap(fatal_error!(err = "Prio3Sum is not supported in VDAF-13")))?,
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Field128(state),
-            VdafPrepShare::Prio3Field128(share),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let (out_share, outbound) =
-                prep_finish_from_shares(&vdaf, task_id, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-            ..
-        },
-            VdafPrepState::Prio3Field64HmacSha256Aes128(_),
-            VdafPrepShare::Prio3Field64HmacSha256Aes128(_),
-        ) => {
-            return Err(VdafError::Dap(fatal_error!(err = format!("prio3_prep_finish_from_shares: SumVecField64MultiproofHmacSha256Aes128 is not defined for VDAF-13"))))
-        }
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = format!("prio3_prep_finish_from_shares: unexpected field type for step or message")
-            )))
-        }
-    };
+                )))
+            }
+        };
 
-    Ok((agg_share, outbound))
-}
+        Ok((agg_share, outbound))
+    }
 
-/// Consume the prep message and output our output share.
-pub(crate) fn prio3_prep_finish(
-    config: &Prio3Config,
-    host_state: VdafPrepState,
-    peer_message_data: &[u8],
-    task_id: TaskId,
-) -> Result<VdafAggregateShare, VdafError> {
-    let agg_share = match (&config, host_state) {
-        (Prio3Config::Count, VdafPrepState::Prio3Field64(state)) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
-            VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Field128(state),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
-            VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
-        }
-        (Prio3Config::Sum { .. }, VdafPrepState::Prio3Field128(_)) => {
-            Err(VdafError::Dap(fatal_error!(err = "sum unimplemented")))?
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Field128(state),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
-            VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-            ..
-            },
-            VdafPrepState::Prio3Field64HmacSha256Aes128(_),
-        ) => {
+    pub(crate) fn prep_finish(
+        &self,
+        host_state: VdafPrepState,
+        peer_message_data: &[u8],
+        task_id: TaskId,
+        version: DapVersion,
+    ) -> Result<VdafAggregateShare, VdafError> {
+        let agg_share = match (version, self, host_state) {
+            (DapVersion::Latest, Prio3Config::Count, VdafPrepState::Prio3Field64(state)) => {
+                let vdaf = Prio3::new_count(2).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
+                VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Sum { max_measurement },
+                VdafPrepState::Prio3Field64(state),
+            ) => {
+                let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
+                VdafAggregateShare::Field64(vdaf.aggregate(&(), [out_share])?)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Histogram {
+                    length,
+                    chunk_length,
+                },
+                VdafPrepState::Prio3Field128(state),
+            ) => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
+                VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+                VdafPrepState::Prio3Field128(state),
+            ) => {
+                let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+                let out_share = prep_finish(&vdaf, task_id, state, peer_message_data)?;
+                VdafAggregateShare::Field128(vdaf.aggregate(&(), [out_share])?)
+            }
+            (
+                DapVersion::Draft09,
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits,
+                    length,
+                    chunk_length,
+                    num_proofs,
+                },
+                VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
+            ) => {
+                let vdaf = prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+                    *bits,
+                    *length,
+                    *chunk_length,
+                    *num_proofs,
+                )?;
+                let out_share = super::prep_finish_draft09(&vdaf, state, peer_message_data)?;
+                VdafAggregateShare::Field64Draft09(prio_draft09::vdaf::Aggregator::aggregate(
+                    &vdaf,
+                    &(),
+                    [out_share],
+                )?)
+            }
+            _ => {
+                return Err(VdafError::Dap(fatal_error!(
+                    err = format!(
+                        "unexpected prep state or {self:?} is not supported in DAP {version}"
+                    )
+                )))
+            }
+        };
 
-            return Err(VdafError::Dap(fatal_error!(err = format!("prio3_prep_finish: SumVecField64MultiproofHmacSha256Aes128 is not defined for VDAF-13"))))
-        }
+        Ok(agg_share)
+    }
 
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = format!("prio3_prep_finish: unexpected field type for step or message")
-            )))
-        }
-    };
+    pub(crate) fn unshard<M: IntoIterator<Item = Vec<u8>>>(
+        &self,
+        version: DapVersion,
+        num_measurements: usize,
+        agg_shares: M,
+    ) -> Result<DapAggregateResult, VdafError> {
+        match (version, self) {
+            (DapVersion::Latest, Prio3Config::Count) => {
+                let vdaf = Prio3::new_count(2).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
 
-    Ok(agg_share)
-}
+                let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::U64(agg_res))
+            }
+            (DapVersion::Latest, Prio3Config::Sum { max_measurement }) => {
+                let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
 
-/// Interpret `agg_shares` as a sequence of encoded aggregate shares and unshard them.
-pub(crate) fn prio3_unshard<M: IntoIterator<Item = Vec<u8>>>(
-    config: &Prio3Config,
-    num_measurements: usize,
-    agg_shares: M,
-) -> Result<DapAggregateResult, VdafError> {
-    match config {
-        Prio3Config::Count => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U64(agg_res))
-        }
-        Prio3Config::Histogram {
-            length,
-            chunk_length,
-        } => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U128Vec(agg_res))
-        }
-        Prio3Config::Sum { .. } => Err(VdafError::Dap(fatal_error!(err = "sum unimplemented"))),
-        Prio3Config::SumVec {
-            bits,
-            length,
-            chunk_length,
-        } => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U128Vec(agg_res))
-        }
-        Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-        ..
-        } => {
-            Err(VdafError::Dap(fatal_error!(err = format!("prio3_prep_finish: SumVecField64MultiproofHmacSha256Aes128 is not defined for VDAF-13"))))
+                let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::U64(agg_res))
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::Histogram {
+                    length,
+                    chunk_length,
+                },
+            ) => {
+                let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+
+                let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::U128Vec(agg_res))
+            }
+            (
+                DapVersion::Latest,
+                Prio3Config::SumVec {
+                    bits,
+                    length,
+                    chunk_length,
+                },
+            ) => {
+                let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
+                    VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
+                })?;
+
+                let agg_res = unshard(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::U128Vec(agg_res))
+            }
+            (
+                DapVersion::Draft09,
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits,
+                    length,
+                    chunk_length,
+                    num_proofs,
+                },
+            ) => {
+                let vdaf = prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+                    *bits,
+                    *length,
+                    *chunk_length,
+                    *num_proofs,
+                )?;
+                let agg_res = super::unshard_draft09(&vdaf, num_measurements, agg_shares)?;
+                Ok(DapAggregateResult::U64Vec(agg_res))
+            }
+            _ => Err(VdafError::Dap(fatal_error!(
+                err = format!("{version} does not support {self:?}")
+            ))),
         }
     }
 }
@@ -413,17 +570,17 @@ mod test {
 
     use crate::{
         hpke::HpkeKemId,
-        test_versions,
         testing::AggregationJobTest,
         vdaf::{Prio3Config, VdafConfig},
         DapAggregateResult, DapAggregationParam, DapMeasurement, DapVersion,
     };
 
-    fn roundtrip_count(version: DapVersion) {
+    #[test]
+    fn roundtrip_count() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::Count),
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Latest,
         );
         let got = t.roundtrip(
             DapAggregationParam::Empty,
@@ -438,9 +595,30 @@ mod test {
         assert_eq!(got, DapAggregateResult::U64(3));
     }
 
-    test_versions! { roundtrip_count }
+    #[test]
+    fn roundtrip_sum() {
+        let mut t = AggregationJobTest::new(
+            &VdafConfig::Prio3(Prio3Config::Sum {
+                max_measurement: 1337,
+            }),
+            HpkeKemId::X25519HkdfSha256,
+            DapVersion::Latest,
+        );
+        let got = t.roundtrip(
+            DapAggregationParam::Empty,
+            vec![
+                DapMeasurement::U64(0),
+                DapMeasurement::U64(1),
+                DapMeasurement::U64(1337),
+                DapMeasurement::U64(4),
+                DapMeasurement::U64(0),
+            ],
+        );
+        assert_eq!(got, DapAggregateResult::U64(1342));
+    }
 
-    fn roundtrip_sum_vec(version: DapVersion) {
+    #[test]
+    fn roundtrip_sum_vec() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::SumVec {
                 bits: 23,
@@ -448,7 +626,7 @@ mod test {
                 chunk_length: 1,
             }),
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Latest,
         );
         let got = t.roundtrip(
             DapAggregationParam::Empty,
@@ -461,16 +639,15 @@ mod test {
         assert_eq!(got, DapAggregateResult::U128Vec(vec![1338, 1338]));
     }
 
-    test_versions! { roundtrip_sum_vec }
-
-    fn roundtrip_histogram(version: DapVersion) {
+    #[test]
+    fn roundtrip_histogram() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Prio3(Prio3Config::Histogram {
                 length: 3,
                 chunk_length: 1,
             }),
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Latest,
         );
         let got = t.roundtrip(
             DapAggregationParam::Empty,
@@ -484,6 +661,4 @@ mod test {
         );
         assert_eq!(got, DapAggregateResult::U128Vec(vec![1, 1, 3]));
     }
-
-    test_versions! { roundtrip_histogram }
 }

--- a/crates/daphne/src/vdaf/prio3_draft09.rs
+++ b/crates/daphne/src/vdaf/prio3_draft09.rs
@@ -4,16 +4,8 @@
 //! Parameters for the [Prio3 VDAF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-vdaf/09/).
 
 use crate::{
-    fatal_error,
-    messages::taskprov::VDAF_TYPE_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMAC_SHA256_AES128,
-    vdaf::{VdafError, VdafVerifyKey},
-    DapAggregateResult, DapMeasurement, Prio3Config, VdafAggregateShare, VdafPrepShare,
-    VdafPrepState,
-};
-
-use super::{
-    prep_finish_draft09, prep_finish_from_shares_draft09, shard_then_encode_draft09,
-    unshard_draft09,
+    fatal_error, messages::taskprov::VDAF_TYPE_PRIO3_SUM_VEC_FIELD64_MULTIPROOF_HMAC_SHA256_AES128,
+    vdaf::VdafError,
 };
 
 use prio_draft09::{
@@ -31,12 +23,10 @@ use prio_draft09::{
     },
 };
 
-const ERR_FIELD_TYPE: &str = "unexpected field type for step or message";
-
 type Prio3SumVecField64MultiproofHmacSha256Aes128 =
     Prio3<SumVec<Field64, ParallelSum<Field64, Mul<Field64>>>, XofHmacSha256Aes128, 32>;
 
-fn new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
+pub(crate) fn new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
     bits: usize,
     length: usize,
     chunk_length: usize,
@@ -56,458 +46,31 @@ fn new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
     .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3")))
 }
 
-/// Split the given measurement into a sequence of encoded input shares.
-pub(crate) fn prio3_draft09_shard(
-    config: &Prio3Config,
-    measurement: DapMeasurement,
-    nonce: &[u8; 16],
-) -> Result<(Vec<u8>, [Vec<u8>; 2]), VdafError> {
-    match (config, measurement) {
-        (Prio3Config::Count, DapMeasurement::U64(measurement)) if measurement < 2 => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            shard_then_encode_draft09(&vdaf, &(measurement != 0), nonce)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            DapMeasurement::U64(measurement),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 Histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let m: usize = measurement.try_into().unwrap();
-            shard_then_encode_draft09(&vdaf, &m, nonce)
-        }
-        (Prio3Config::Sum { bits }, DapMeasurement::U64(measurement)) => {
-            let vdaf =
-                Prio3::new_sum(2, *bits).map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum from num_aggregators(2), bits({bits})")))?;
-            shard_then_encode_draft09(&vdaf, &u128::from(measurement), nonce)
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            DapMeasurement::U128Vec(measurement),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            shard_then_encode_draft09(&vdaf, &measurement, nonce)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                bits,
-                length,
-                chunk_length,
-                num_proofs,
-            },
-            DapMeasurement::U64Vec(measurement),
-        ) => {
-            let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
-                *bits,
-                *length,
-                *chunk_length,
-                *num_proofs,
-            )?;
-            shard_then_encode_draft09(&vdaf, &measurement, nonce)
-        }
-        _ => Err(VdafError::Dap(fatal_error!(
-            err = format!("prio3_shard: unexpected VDAF config {config:?}")
-        ))),
-    }
-}
+type Prio3Draft09Prepared<T, const SEED_SIZE: usize> = (
+    Prio3PrepareState<<T as Type>::Field, SEED_SIZE>,
+    Prio3PrepareShare<<T as Type>::Field, SEED_SIZE>,
+);
 
-/// Consume an input share and return the corresponding VDAF step and message.
-pub(crate) fn prio3_draft09_prep_init(
-    config: &Prio3Config,
-    verify_key: &VdafVerifyKey,
+pub(crate) fn prep_init_draft09<T, P, const SEED_SIZE: usize>(
+    vdaf: Prio3<T, P, SEED_SIZE>,
+    verify_key: &[u8; SEED_SIZE],
     agg_id: usize,
     nonce: &[u8; 16],
     public_share_data: &[u8],
     input_share_data: &[u8],
-) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-    return match (&config, verify_key) {
-        (Prio3Config::Count, VdafVerifyKey::L16(verify_key)) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 from num_aggregators(2)"),
-                )
-            })?;
-            let (state, share) = prep_init_draft09(
-                vdaf,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Draft09Field64(state),
-                VdafPrepShare::Prio3Draft09Field64(share),
-            ))
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafVerifyKey::L16(verify_key),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let (state, share) = prep_init_draft09(
-                vdaf,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Draft09Field128(state),
-                VdafPrepShare::Prio3Draft09Field128(share),
-            ))
-        }
-        (Prio3Config::Sum { bits }, VdafVerifyKey::L16(verify_key)) => {
-            let vdaf =
-                Prio3::new_sum(2, *bits).map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum from num_aggregators(2), bits({bits})")))?;
-            let (state, share) = prep_init_draft09(
-                vdaf,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Draft09Field128(state),
-                VdafPrepShare::Prio3Draft09Field128(share),
-            ))
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafVerifyKey::L16(verify_key),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let (state, share) = prep_init_draft09(
-                vdaf,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Draft09Field128(state),
-                VdafPrepShare::Prio3Draft09Field128(share),
-            ))
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                bits,
-                length,
-                chunk_length,
-                num_proofs,
-            },
-            VdafVerifyKey::L32(verify_key),
-        ) => {
-            let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
-                *bits,
-                *length,
-                *chunk_length,
-                *num_proofs,
-            )?;
-            let (state, share) = prep_init_draft09(
-                vdaf,
-                verify_key,
-                agg_id,
-                nonce,
-                public_share_data,
-                input_share_data,
-            )?;
-            Ok((
-                VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
-                VdafPrepShare::Prio3Draft09Field64HmacSha256Aes128(share),
-            ))
-        }
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = "unhandled config and verify key combination",
-            )))
-        }
-    };
+) -> Result<Prio3Draft09Prepared<T, SEED_SIZE>, VdafError>
+where
+    T: Type,
+    P: Xof<SEED_SIZE>,
+{
+    // Parse the public share.
+    let public_share = Prio3PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
 
-    type Prio3Draft09Prepared<T, const SEED_SIZE: usize> = (
-        Prio3PrepareState<<T as Type>::Field, SEED_SIZE>,
-        Prio3PrepareShare<<T as Type>::Field, SEED_SIZE>,
-    );
+    // Parse the input share.
+    let input_share = Prio3InputShare::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
 
-    fn prep_init_draft09<T, P, const SEED_SIZE: usize>(
-        vdaf: Prio3<T, P, SEED_SIZE>,
-        verify_key: &[u8; SEED_SIZE],
-        agg_id: usize,
-        nonce: &[u8; 16],
-        public_share_data: &[u8],
-        input_share_data: &[u8],
-    ) -> Result<Prio3Draft09Prepared<T, SEED_SIZE>, VdafError>
-    where
-        T: Type,
-        P: Xof<SEED_SIZE>,
-    {
-        // Parse the public share.
-        let public_share = Prio3PublicShare::get_decoded_with_param(&vdaf, public_share_data)?;
-
-        // Parse the input share.
-        let input_share =
-            Prio3InputShare::get_decoded_with_param(&(&vdaf, agg_id), input_share_data)?;
-
-        // Run the prepare-init algorithm, returning the initial state.
-        Ok(vdaf.prepare_init(verify_key, agg_id, &(), nonce, &public_share, &input_share)?)
-    }
-}
-
-/// Consume the prep shares and return our output share and the prep message.
-pub(crate) fn prio3_draft09_prep_finish_from_shares(
-    config: &Prio3Config,
-    agg_id: usize,
-    host_state: VdafPrepState,
-    host_share: VdafPrepShare,
-    peer_share_data: &[u8],
-) -> Result<(VdafAggregateShare, Vec<u8>), VdafError> {
-    let (agg_share, outbound) = match (&config, host_state, host_share) {
-        (
-            Prio3Config::Count,
-            VdafPrepState::Prio3Draft09Field64(state),
-            VdafPrepShare::Prio3Draft09Field64(share),
-        ) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count num_aggregators(2)"),
-                )
-            })?;
-            let (out_share, outbound) =
-                prep_finish_from_shares_draft09(&vdaf, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field64Draft09(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Draft09Field128(state),
-            VdafPrepShare::Prio3Draft09Field128(share),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let (out_share, outbound) =
-                prep_finish_from_shares_draft09(&vdaf, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::Sum { bits },
-            VdafPrepState::Prio3Draft09Field128(state),
-            VdafPrepShare::Prio3Draft09Field128(share),
-        ) => {
-            let vdaf =
-                Prio3::new_sum(2, *bits).map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum from num_aggregators(2), bits({bits})")))?;
-            let (out_share, outbound) =
-                prep_finish_from_shares_draft09(&vdaf, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Draft09Field128(state),
-            VdafPrepShare::Prio3Draft09Field128(share),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let (out_share, outbound) =
-                prep_finish_from_shares_draft09(&vdaf, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                bits,
-                length,
-                chunk_length,
-                num_proofs,
-            },
-            VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
-            VdafPrepShare::Prio3Draft09Field64HmacSha256Aes128(share),
-        ) => {
-            let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
-                *bits,
-                *length,
-                *chunk_length,
-                *num_proofs,
-            )?;
-            let (out_share, outbound) =
-                prep_finish_from_shares_draft09(&vdaf, agg_id, state, share, peer_share_data)?;
-            let agg_share = VdafAggregateShare::Field64Draft09(vdaf.aggregate(&(), [out_share])?);
-            (agg_share, outbound)
-        }
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = format!("prio3_prep_finish_from_shares: {ERR_FIELD_TYPE}")
-            )))
-        }
-    };
-
-    Ok((agg_share, outbound))
-}
-
-/// Consume the prep message and output our output share.
-pub(crate) fn prio3_draft09_prep_finish(
-    config: &Prio3Config,
-    host_state: VdafPrepState,
-    peer_message_data: &[u8],
-) -> Result<VdafAggregateShare, VdafError> {
-    let agg_share = match (&config, host_state) {
-        (Prio3Config::Count, VdafPrepState::Prio3Draft09Field64(state)) => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            let out_share = prep_finish_draft09(&vdaf, state, peer_message_data)?;
-            VdafAggregateShare::Field64Draft09(vdaf.aggregate(&(), [out_share])?)
-        }
-        (
-            Prio3Config::Histogram {
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Draft09Field128(state),
-        ) => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let out_share = prep_finish_draft09(&vdaf, state, peer_message_data)?;
-            VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?)
-        }
-        (Prio3Config::Sum { bits }, VdafPrepState::Prio3Draft09Field128(state)) => {
-            let vdaf =
-                Prio3::new_sum(2, *bits).map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum from num_aggregators(2), bits({bits})")))?;
-            let out_share = prep_finish_draft09(&vdaf, state, peer_message_data)?;
-            VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?)
-        }
-        (
-            Prio3Config::SumVec {
-                bits,
-                length,
-                chunk_length,
-            },
-            VdafPrepState::Prio3Draft09Field128(state),
-        ) => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let out_share = prep_finish_draft09(&vdaf, state, peer_message_data)?;
-            VdafAggregateShare::Field128Draft09(vdaf.aggregate(&(), [out_share])?)
-        }
-        (
-            Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                bits,
-                length,
-                chunk_length,
-                num_proofs,
-            },
-            VdafPrepState::Prio3Draft09Field64HmacSha256Aes128(state),
-        ) => {
-            let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
-                *bits,
-                *length,
-                *chunk_length,
-                *num_proofs,
-            )?;
-            let out_share = prep_finish_draft09(&vdaf, state, peer_message_data)?;
-            VdafAggregateShare::Field64Draft09(vdaf.aggregate(&(), [out_share])?)
-        }
-
-        _ => {
-            return Err(VdafError::Dap(fatal_error!(
-                err = format!("prio3_prep_finish: {ERR_FIELD_TYPE}")
-            )))
-        }
-    };
-
-    Ok(agg_share)
-}
-
-/// Interpret `agg_shares` as a sequence of encoded aggregate shares and unshard them.
-pub(crate) fn prio3_draft09_unshard<M: IntoIterator<Item = Vec<u8>>>(
-    config: &Prio3Config,
-    num_measurements: usize,
-    agg_shares: M,
-) -> Result<DapAggregateResult, VdafError> {
-    match config {
-        Prio3Config::Count => {
-            let vdaf = Prio3::new_count(2).map_err(|e| {
-                VdafError::Dap(
-                    fatal_error!(err = ?e, "failed to create prio3 count from num_aggregators(2)"),
-                )
-            })?;
-            let agg_res = unshard_draft09(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U64(agg_res))
-        }
-        Prio3Config::Histogram {
-            length,
-            chunk_length,
-        } => {
-            let vdaf = Prio3::new_histogram(2, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 histogram from num_aggregators(2), length({length}), chunk_length({chunk_length})")))?;
-            let agg_res = unshard_draft09(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U128Vec(agg_res))
-        }
-        Prio3Config::Sum { bits } => {
-            let vdaf =
-                Prio3::new_sum(2, *bits).map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum from num_aggregators(2), bits({bits})")))?;
-            let agg_res = unshard_draft09(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U128(agg_res))
-        }
-        Prio3Config::SumVec {
-            bits,
-            length,
-            chunk_length,
-        } => {
-            let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length)
-                .map_err(|e| VdafError::Dap(fatal_error!(err = ?e, "failed to create prio3 sum vec from num_aggregators(2), bits({bits}), length({length}), chunk_length({chunk_length})")))?;
-            let agg_res = unshard_draft09(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U128Vec(agg_res))
-        }
-        Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-            bits,
-            length,
-            chunk_length,
-            num_proofs,
-        } => {
-            let vdaf = new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
-                *bits,
-                *length,
-                *chunk_length,
-                *num_proofs,
-            )?;
-            let agg_res = unshard_draft09(&vdaf, num_measurements, agg_shares)?;
-            Ok(DapAggregateResult::U64Vec(agg_res))
-        }
-    }
+    // Run the prepare-init algorithm, returning the initial state.
+    Ok(vdaf.prepare_init(verify_key, agg_id, &(), nonce, &public_share, &input_share)?)
 }
 
 #[cfg(test)]
@@ -517,7 +80,6 @@ mod test {
 
     use crate::{
         hpke::HpkeKemId,
-        test_versions,
         testing::AggregationJobTest,
         vdaf::{
             prio3_draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128, Prio3Config,
@@ -526,105 +88,19 @@ mod test {
         DapAggregateResult, DapAggregationParam, DapMeasurement, DapVersion,
     };
 
-    fn roundtrip_count(version: DapVersion) {
+    #[test]
+    fn roundtrip_sum_vec_field64_multiproof_hmac_sha256_aes128_draft09() {
         let mut t = AggregationJobTest::new(
-            &VdafConfig::Prio3Draft09(Prio3Config::Count),
+            &VdafConfig::Prio3(
+                Prio3Config::Draft09SumVecField64MultiproofHmacSha256Aes128 {
+                    bits: 23,
+                    length: 2,
+                    chunk_length: 1,
+                    num_proofs: 4,
+                },
+            ),
             HpkeKemId::X25519HkdfSha256,
-            version,
-        );
-        let got = t.roundtrip(
-            DapAggregationParam::Empty,
-            vec![
-                DapMeasurement::U64(0),
-                DapMeasurement::U64(1),
-                DapMeasurement::U64(1),
-                DapMeasurement::U64(1),
-                DapMeasurement::U64(0),
-            ],
-        );
-        assert_eq!(got, DapAggregateResult::U64(3));
-    }
-
-    test_versions! { roundtrip_count }
-
-    fn roundtrip_sum(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
-            &VdafConfig::Prio3Draft09(Prio3Config::Sum { bits: 23 }),
-            HpkeKemId::X25519HkdfSha256,
-            version,
-        );
-        let got = t.roundtrip(
-            DapAggregationParam::Empty,
-            vec![
-                DapMeasurement::U64(0),
-                DapMeasurement::U64(1),
-                DapMeasurement::U64(1337),
-                DapMeasurement::U64(4),
-                DapMeasurement::U64(0),
-            ],
-        );
-        assert_eq!(got, DapAggregateResult::U128(1342));
-    }
-
-    test_versions! { roundtrip_sum }
-
-    fn roundtrip_sum_vec(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
-            &VdafConfig::Prio3Draft09(Prio3Config::SumVec {
-                bits: 23,
-                length: 2,
-                chunk_length: 1,
-            }),
-            HpkeKemId::X25519HkdfSha256,
-            version,
-        );
-        let got = t.roundtrip(
-            DapAggregationParam::Empty,
-            vec![
-                DapMeasurement::U128Vec(vec![1337, 0]),
-                DapMeasurement::U128Vec(vec![0, 1337]),
-                DapMeasurement::U128Vec(vec![1, 1]),
-            ],
-        );
-        assert_eq!(got, DapAggregateResult::U128Vec(vec![1338, 1338]));
-    }
-
-    test_versions! { roundtrip_sum_vec }
-
-    fn roundtrip_histogram(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
-            &VdafConfig::Prio3Draft09(Prio3Config::Histogram {
-                length: 3,
-                chunk_length: 1,
-            }),
-            HpkeKemId::X25519HkdfSha256,
-            version,
-        );
-        let got = t.roundtrip(
-            DapAggregationParam::Empty,
-            vec![
-                DapMeasurement::U64(0),
-                DapMeasurement::U64(1),
-                DapMeasurement::U64(2),
-                DapMeasurement::U64(2),
-                DapMeasurement::U64(2),
-            ],
-        );
-        assert_eq!(got, DapAggregateResult::U128Vec(vec![1, 1, 3]));
-    }
-
-    test_versions! { roundtrip_histogram }
-
-    fn roundtrip_sum_vec_field64_multiproof_hmac_sha256_aes128(version: DapVersion) {
-        let mut t = AggregationJobTest::new(
-            &VdafConfig::Prio3Draft09(Prio3Config::SumVecField64MultiproofHmacSha256Aes128 {
-                bits: 23,
-                length: 2,
-                chunk_length: 1,
-                num_proofs: 4,
-            }),
-            HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Draft09,
         );
         let got = t.roundtrip(
             DapAggregationParam::Empty,
@@ -636,8 +112,6 @@ mod test {
         );
         assert_eq!(got, DapAggregateResult::U64Vec(vec![1338, 1338]));
     }
-
-    test_versions! { roundtrip_sum_vec_field64_multiproof_hmac_sha256_aes128 }
 
     #[test]
     fn test_vec_sum_vec_field64_multiproof_hmac_sha256_aes128() {


### PR DESCRIPTION
Partially addresses #698.
Alternative to #748.

Move sharding, preparation, and unsharding dispatchers to `Prio3Config`.
Not all variants are supported by all DAP versions, so pass the version
to each dispatcher in order to resolve DAP and Prio3 version
compatibility. (Note Prio3 is not API-compatible across versions.)

The following variants are supported in DAP-13:

* Prio3Count
* Prio3Sum
* Prio3SumVec
* Prio3Histogram

The following variants are supported in DAP-09:

* Prio3SumVecField64MultiproofHmacSha256Aes128

Modify the taskprov provisioning logic accordingly, by removing support
for the following VDAFs in DAP-13:

* Prio3SumVecField64MultiproofHmacSha256Aes128
* Pine32HmacSha256Aes128
* Pine64HmacSha256Aes128

These VDAFs need to be upgraded for VDAF-13 compatibility.