### PR TITLE
Unify VDAF dispatching logic

### DIFF
--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -532,7 +532,6 @@ impl Test {
             agg_job_state,
             agg_job_resp,
             self.metrics(),
-            task_config.version,
         )?;
 
         let aggregated_report_count = agg_share_span

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -841,10 +841,10 @@ mod test {
             let (invalid_public_share, mut invalid_input_shares) = self
                 .task_config
                 .vdaf
-                .produce_input_shares(
+                .shard(
                     measurement,
                     &report_id.0,
-                    &self.task_id,
+                    self.task_id,
                     self.task_config.version,
                 )
                 .unwrap();
@@ -872,10 +872,10 @@ mod test {
             let (mut invalid_public_share, invalid_input_shares) = self
                 .task_config
                 .vdaf
-                .produce_input_shares(
+                .shard(
                     measurement,
                     &report_id.0,
-                    &self.task_id,
+                    self.task_id,
                     self.task_config.version,
                 )
                 .unwrap();
@@ -903,10 +903,10 @@ mod test {
             let (invalid_public_share, mut invalid_input_shares) = self
                 .task_config
                 .vdaf
-                .produce_input_shares(
+                .shard(
                     measurement,
                     &report_id.0,
-                    &self.task_id,
+                    self.task_id,
                     self.task_config.version,
                 )
                 .unwrap();

--- a/crates/daphne/src/roles/helper.rs
+++ b/crates/daphne/src/roles/helper.rs
@@ -232,7 +232,6 @@ async fn finish_agg_job_and_aggregate(
             &report_status,
             part_batch_sel,
             initialized_reports,
-            task_config.version,
         )?;
 
         let put_shares_result = helper

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -341,13 +341,8 @@ async fn run_agg_job<A: DapLeader>(
             .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
 
     // Handle AggregationJobResp.
-    let agg_span = task_config.consume_agg_job_resp(
-        task_id,
-        agg_job_state,
-        agg_job_resp,
-        metrics,
-        task_config.version,
-    )?;
+    let agg_span =
+        task_config.consume_agg_job_resp(task_id, agg_job_state, agg_job_resp, metrics)?;
 
     let out_shares_count = agg_span.report_count() as u64;
     if out_shares_count == 0 {

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -223,7 +223,6 @@ impl AggregationJobTest {
                         self.replay_protection,
                     )
                     .unwrap(),
-                self.task_config.version,
             )
             .unwrap()
     }
@@ -242,7 +241,6 @@ impl AggregationJobTest {
                 leader_state,
                 agg_job_resp,
                 &self.leader_metrics,
-                self.task_config.version,
             )
             .unwrap()
     }
@@ -255,13 +253,7 @@ impl AggregationJobTest {
     ) -> DapError {
         let metrics = &self.leader_metrics;
         self.task_config
-            .consume_agg_job_resp(
-                &self.task_id,
-                leader_state,
-                agg_job_resp,
-                metrics,
-                self.task_config.version,
-            )
+            .consume_agg_job_resp(&self.task_id, leader_state, agg_job_resp, metrics)
             .expect_err("consume_agg_job_resp() succeeded; expected failure")
     }
 

--- a/crates/daphne/src/vdaf/mastic.rs
+++ b/crates/daphne/src/vdaf/mastic.rs
@@ -232,18 +232,19 @@ mod test {
 
     use super::*;
     use crate::{
-        hpke::HpkeKemId, test_versions, testing::AggregationJobTest, vdaf::VdafConfig,
-        DapAggregateResult, DapMeasurement, DapVersion,
+        hpke::HpkeKemId, testing::AggregationJobTest, vdaf::VdafConfig, DapAggregateResult,
+        DapMeasurement, DapVersion,
     };
 
-    fn roundtrip_count(version: DapVersion) {
+    #[test]
+    fn roundtrip_count() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Mastic {
                 input_size: 4,
                 weight_config: MasticWeightConfig::Count,
             },
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Latest,
         );
         let got = t.roundtrip(
             DapAggregationParam::Mastic(
@@ -279,6 +280,4 @@ mod test {
 
         assert_eq!(got, DapAggregateResult::U64Vec(vec![1, 2]));
     }
-
-    test_versions! { roundtrip_count }
 }

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -240,13 +240,14 @@ fn prep_init<F: FftFriendlyFieldElement, X: Xof<SEED_SIZE>, const SEED_SIZE: usi
 #[cfg(test)]
 mod test {
     use crate::{
-        hpke::HpkeKemId, pine::PineParam, test_versions, testing::AggregationJobTest,
-        vdaf::VdafConfig, DapAggregateResult, DapAggregationParam, DapMeasurement, DapVersion,
+        hpke::HpkeKemId, pine::PineParam, testing::AggregationJobTest, vdaf::VdafConfig,
+        DapAggregateResult, DapAggregationParam, DapMeasurement, DapVersion,
     };
 
     use super::PineConfig;
 
-    fn roundtrip_pine32_hmac_sha256_aes128(version: DapVersion) {
+    #[test]
+    fn roundtrip_pine32_hmac_sha256_aes128_draft09() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Pine(PineConfig::Field32HmacSha256Aes128 {
                 param: PineParam {
@@ -262,7 +263,7 @@ mod test {
                 },
             }),
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Draft09,
         );
         let DapAggregateResult::F64Vec(got) = t.roundtrip(
             DapAggregationParam::Empty,
@@ -282,9 +283,8 @@ mod test {
         }
     }
 
-    test_versions! { roundtrip_pine32_hmac_sha256_aes128 }
-
-    fn roundtrip_pine64_hmac_sha256_aes128(version: DapVersion) {
+    #[test]
+    fn roundtrip_pine64_hmac_sha256_aes128_draft09() {
         let mut t = AggregationJobTest::new(
             &VdafConfig::Pine(PineConfig::Field64HmacSha256Aes128 {
                 param: PineParam {
@@ -300,7 +300,7 @@ mod test {
                 },
             }),
             HpkeKemId::X25519HkdfSha256,
-            version,
+            DapVersion::Draft09,
         );
         let DapAggregateResult::F64Vec(got) = t.roundtrip(
             DapAggregationParam::Empty,
@@ -319,6 +319,4 @@ mod test {
             );
         }
     }
-
-    test_versions! { roundtrip_pine64_hmac_sha256_aes128 }
 }


### PR DESCRIPTION
Partially addresses #698.
Stacked on #749.

Add dispatchers for sharding, preparation, and unsharding to `VdafConfig`. Pass the DAP version to the dispatcher so that we can properly resolve supported VDAFs.

Remove support for the following, unspecified combinations:

* DAP-13/Pine32HmacSha256Aes128
* DAP-13/Pine64HmacSha256Aes128
* DAP-09/Mastic

Technically, since Mastic is still a shim at the moment and not a functional VDAF, we could support it in DAP-09 as well. When the implementation is complete (https://github.com/divviup/libprio-rs/issues/947), it will only be VDAF-13-compatible and thus only supported in DAP-13.