### PR TITLE
Add support for public extensions in Reports.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "prio 0.17.0-alpha.0",
  "prometheus",
  "rand",
+ "rayon",
  "rcgen",
  "reqwest",
  "serde",
@@ -952,6 +953,7 @@ dependencies = [
  "prio 0.17.0-alpha.0",
  "rand",
  "serde",
+ "serde_json",
  "url",
 ]
 
@@ -1003,10 +1005,12 @@ dependencies = [
 name = "daphne-worker-test"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
  "cap",
  "cfg-if",
  "console_error_panic_hook",
  "daphne-worker",
+ "futures",
  "prometheus",
  "tracing",
  "worker",

--- a/crates/dapf/src/acceptance/load_testing.rs
+++ b/crates/dapf/src/acceptance/load_testing.rs
@@ -448,6 +448,7 @@ pub async fn execute_single_combination_from_env(
                             &measurment,
                             VERSION,
                             system_now.0,
+                            Some(vec![]),
                             vec![messages::Extension::Taskprov],
                             t.replay_reports,
                         )

--- a/crates/dapf/src/acceptance/mod.rs
+++ b/crates/dapf/src/acceptance/mod.rs
@@ -655,6 +655,10 @@ impl Test {
                         measurement.as_ref(),
                         version,
                         now.0,
+                        match version {
+                            DapVersion::Draft09 => None,
+                            DapVersion::Latest => Some(vec![]),
+                        },
                         vec![messages::Extension::Taskprov],
                         self.replay_reports,
                     )

--- a/crates/daphne-service-utils/src/compute_offload/compute_offload.capnp
+++ b/crates/daphne-service-utils/src/compute_offload/compute_offload.capnp
@@ -53,10 +53,24 @@ struct PartialDapTaskConfig @0xdcc9bf18fc62d406 {
     vdafVerifyKey       @4  :VdafVerifyKey;
 }
 
+struct PublicExtensionsList @0x8b3c98c0ddd0043e {
+
+    union {
+	# Each extension is encoded according to the DAP spec in
+	# tag-length-value form.
+        list @0 :List(Data);
+
+	# draft09 compatibility: Previously DAP had no extensions in the
+	# report.
+	none @1 :Void;
+    }
+}
+
 struct ReportMetadata @0xefba178ad4584bc4 {
 
-    id   @0 :Base.ReportId;
-    time @1 :Base.Time;
+    id               @0 :Base.ReportId;
+    time             @1 :Base.Time;
+    publicExtensions @2 :PublicExtensionsList;
 }
 
 struct PrepareInit @0x8192568cb3d03f59 {

--- a/crates/daphne/src/hpke.rs
+++ b/crates/daphne/src/hpke.rs
@@ -612,6 +612,10 @@ mod test {
             report_metadata: &ReportMetadata {
                 id: ReportId(rand::random()),
                 time: rand::random(),
+                public_extensions: match version {
+                    DapVersion::Draft09 => None,
+                    DapVersion::Latest => Some(Vec::new()),
+                },
             },
         };
         let plaintext = b"plaintext";
@@ -703,6 +707,10 @@ mod test {
         let report_metadata = &ReportMetadata {
             id: ReportId(rand::random()),
             time: rand::random(),
+            public_extensions: match version {
+                DapVersion::Draft09 => None,
+                DapVersion::Latest => Some(Vec::new()),
+            },
         };
         let public_share = &vec![rand::random(); (0..100).choose(&mut rand::thread_rng()).unwrap()];
 

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use super::{
-    no_duplicates,
+    check_no_duplicates,
     report_init::{InitializedReport, WithPeerPrepShare},
 };
 use crate::{
@@ -241,7 +241,7 @@ impl DapTaskConfig {
             DapAggregationParam::get_decoded_with_param(&self.vdaf, &agg_job_init_req.agg_param)
                 .map_err(|e| DapAbort::from_codec_error(e, *task_id))?;
         if replay_protection.enabled() {
-            no_duplicates(
+            check_no_duplicates(
                 agg_job_init_req
                     .prep_inits
                     .iter()

--- a/crates/daphne/src/roles/helper/handle_agg_job.rs
+++ b/crates/daphne/src/roles/helper/handle_agg_job.rs
@@ -179,7 +179,7 @@ impl HandleAggJob<WithTaskConfig> {
     > {
         let task_id = self.state.request.task_id;
         if replay_protection.enabled() {
-            crate::protocol::no_duplicates(
+            crate::protocol::check_no_duplicates(
                 self.state
                     .request
                     .payload

--- a/crates/daphne/src/testing/report_generator.rs
+++ b/crates/daphne/src/testing/report_generator.rs
@@ -45,7 +45,8 @@ impl ReportGenerator {
         measurement: &DapMeasurement,
         version: DapVersion,
         now: Time,
-        extensions: Vec<messages::Extension>,
+        public_extensions: Option<Vec<messages::Extension>>,
+        private_extensions: Vec<messages::Extension>,
         replay_reports: bool,
     ) -> Self {
         let (tx, rx) = mpsc::channel();
@@ -78,7 +79,8 @@ impl ReportGenerator {
                                     report_time_dist.sample(&mut thread_rng()),
                                     &task_id,
                                     measurement.clone(),
-                                    extensions.clone(),
+                                    public_extensions.clone(),
+                                    private_extensions.clone(),
                                     version,
                                 )
                                 .expect("we have to panic here since we can't return the error")
@@ -90,7 +92,8 @@ impl ReportGenerator {
                             report_time_dist.sample(&mut thread_rng()),
                             &task_id,
                             measurement.clone(),
-                            extensions.clone(),
+                            public_extensions.clone(),
+                            private_extensions.clone(),
                             version,
                         )?
                     };


### PR DESCRIPTION
Draft 13 adds mandatory support for public extensions in the ReportMetadata, but doesn't define any (Taskprov is ([for now](https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap-taskprov/pull/98/files)) a private extension). This PR adds support for rejecting unknown extensions, which is all of them.