### PR TITLE
Reject reports earlier than task_config.not_before

### DIFF
--- a/crates/dapf/src/main.rs
+++ b/crates/dapf/src/main.rs
@@ -907,6 +907,10 @@ async fn handle_test_routes(action: TestAction, http_client: HttpClient) -> anyh
                         || 604_800u64,
                         "task should expire in",
                     )?,
+                task_commencement: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
             };
 
             print_json(&internal_task);

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -111,7 +111,6 @@ mod test_utils {
         fatal_error,
         hpke::{HpkeConfig, HpkeReceiverConfig},
         messages::decode_base64url_vec,
-        roles::DapAggregator,
         vdaf::{Prio3Config, VdafConfig},
         DapBatchMode, DapError, DapTaskConfig, DapVersion,
     };
@@ -306,7 +305,7 @@ mod test_utils {
                         leader_url: cmd.leader,
                         helper_url: cmd.helper,
                         time_precision: cmd.time_precision,
-                        not_before: self.get_current_time(),
+                        not_before: cmd.task_commencement,
                         not_after: cmd.task_expiration,
                         min_batch_size: cmd.min_batch_size,
                         query,

--- a/crates/daphne-server/src/roles/mod.rs
+++ b/crates/daphne-server/src/roles/mod.rs
@@ -296,6 +296,7 @@ mod test_utils {
                 }
             };
 
+            tracing::warn!("Add task: {}..{}", cmd.task_commencement, cmd.task_expiration);
             if self
                 .kv()
                 .put_if_not_exists_with_expiration::<kv::prefix::TaskConfig>(

--- a/crates/daphne-server/src/router/test_routes.rs
+++ b/crates/daphne-server/src/router/test_routes.rs
@@ -14,7 +14,7 @@ use daphne::{
     constants::DapAggregatorRole,
     hpke::HpkeReceiverConfig,
     messages::{Base64Encode, TaskId},
-    roles::{leader, DapLeader},
+    roles::{leader, DapAggregator, DapLeader},
     DapVersion,
 };
 use daphne_service_utils::test_route_types::{InternalTestAddTask, InternalTestEndpointForTask};
@@ -129,6 +129,9 @@ async fn add_task(
     Path(version): Path<DapVersion>,
     Json(cmd): Json<InternalTestAddTask>,
 ) -> impl IntoResponse {
+    tracing::warn!("TaskID: {:?}", cmd.task_id);
+    tracing::warn!("task conf range: {}..{}", cmd.task_commencement, cmd.task_expiration);
+    tracing::warn!("Valid time range: {:?}", app.valid_report_time_range());
     match app.internal_add_task(version, cmd).await {
         Ok(()) => (
             StatusCode::OK,

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -1423,6 +1423,12 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     )
     .unwrap();
 
+    println!("Now - not_before: {}", t.now - task_config.not_before);
+    println!(
+        "Now - batch_interval.start: {}",
+        t.now - batch_interval.start
+    );
+    println!("t.now: {}", t.now);
     let path = TestRunner::upload_path_for_task(&task_id);
     let method = match version {
         DapVersion::Draft09 => &Method::PUT,
@@ -1433,7 +1439,9 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
         let extensions = vec![Extension::Taskprov];
+        println!("Report interval: {:?}", TestRunner::report_interval(&batch_interval));
         let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        println!("\tnow: {}", now);
         t.leader_request_expect_ok(
             client,
             &path,

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -1402,9 +1402,6 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let t = TestRunner::default_with_version(version).await;
     let batch_interval = t.batch_interval();
 
-    let client = t.http_client();
-    let hpke_config_list = t.get_hpke_configs(version, client).await.unwrap();
-
     let (task_config, task_id, taskprov_advertisement) = DapTaskParameters {
         version,
         min_batch_size: 10,
@@ -1423,6 +1420,13 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     )
     .unwrap();
 
+    t.setup_endpoints(&task_id, version).await;
+
+    let client = &t.http_client();
+    let hpke_config_list = t.get_hpke_configs_task_id(version, client, &task_id).await.unwrap();
+    println!("Generated TaskID: {}",t.task_id);
+
+    println!("TaskID: {:?}", task_id);
     println!("Now - not_before: {}", t.now - task_config.not_before);
     println!(
         "Now - batch_interval.start: {}",
@@ -1559,7 +1563,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     assert_eq!(resp.status(), 200);
     assert_eq!(
         resp.bytes().await.unwrap(),
-        collection.get_encoded_with_param(&t.version).unwrap()
+        collection.get_encoded_with_param(&version).unwrap()
     );
 }
 

--- a/crates/daphne-server/tests/e2e/test_runner.rs
+++ b/crates/daphne-server/tests/e2e/test_runner.rs
@@ -116,7 +116,7 @@ impl TestRunner {
             version,
             leader_url: leader_url.clone(),
             helper_url: helper_url.clone(),
-            not_before: now,
+            not_before: now - (now % TIME_PRECISION) - 1,
             not_after: now + 604_800, // one week from now
             time_precision: TIME_PRECISION,
             min_batch_size: MIN_BATCH_SIZE,
@@ -241,6 +241,7 @@ impl TestRunner {
             "time_precision": t.task_config.time_precision,
             "collector_hpke_config": collector_hpke_config_base64url.clone(),
             "task_expiration": t.task_config.not_after,
+            "task_commencement": t.task_config.not_before,
         });
         let add_task_path = format!("{}/internal/test/add_task", version.as_ref());
         let res: InternalTestCommandResult = t
@@ -268,6 +269,7 @@ impl TestRunner {
             "time_precision": t.task_config.time_precision,
             "collector_hpke_config": collector_hpke_config_base64url.clone(),
             "task_expiration": t.task_config.not_after,
+            "task_commencement": t.task_config.not_before,
         });
         let res: InternalTestCommandResult = t
             .helper_post_internal(&add_task_path, &helper_add_task_cmd)

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -113,5 +113,6 @@ pub struct InternalTestAddTask {
     pub max_batch_size: Option<NonZeroU32>,
     pub time_precision: Duration,
     pub collector_hpke_config: String, // base64url
+    pub task_commencement: Time,
     pub task_expiration: Time,
 }

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -596,7 +596,7 @@ impl DapTaskParameters {
         )
         .unwrap()
         .into_opted_in(&taskprov::OptInParam {
-            not_before: now,
+            not_before: now - (now % self.time_precision) - 1,
             num_agg_span_shards: self.num_agg_span_shards,
         });
 

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -586,6 +586,7 @@ impl DapTaskParameters {
         };
 
         let task_id = taskprov_advertisement.compute_task_id(self.version);
+        println!("Computed TaskID: {}", task_id);
 
         // Compute the DAP task config.
         let task_config = taskprov::DapTaskConfigNeedsOptIn::try_from_taskprov_advertisement(

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -100,6 +100,7 @@ impl DapTaskConfig {
     where
         S: Iterator<Item = Report>,
     {
+        tracing::warn!("DapTaskConfig times:{}..{}", self.not_before, self.not_after);
         let (report_count_hint, _upper_bound) = reports.size_hint();
 
         let mut states = Vec::with_capacity(report_count_hint);

--- a/crates/daphne/src/protocol/report_init.rs
+++ b/crates/daphne/src/protocol/report_init.rs
@@ -63,11 +63,13 @@ impl InitializedReport<()> {
         report_share: ReportShare,
         agg_param: &DapAggregationParam,
     ) -> Result<Self, DapError> {
+        let tc: PartialDapTaskConfigForReportInit = task_config.into().clone();
+        tracing::warn!("DapTaskConfig times:{}..{}", tc.not_before, tc.not_after);
         Self::initialize(
             decrypter,
             valid_report_range,
             task_id,
-            task_config,
+            tc.clone(),
             report_share,
             (),
             agg_param,
@@ -123,6 +125,7 @@ impl<'s> From<&'s PartialDapTaskConfigForReportInit<'_>> for PartialDapTaskConfi
     }
 }
 
+#[derive(Clone)]
 pub struct PartialDapTaskConfigForReportInit<'s> {
     pub not_before: messages::Time,
     pub not_after: messages::Time,
@@ -156,7 +159,10 @@ impl<P> InitializedReport<P> {
             };
         }
 
+        tracing::info!("report timestamp: {}", report_share.report_metadata.time);
         tracing::info!("valid_report_range: {}..{}", valid_report_range.start, valid_report_range.end);
+        tracing::info!("task_config.range: {}..{}", task_config.not_before, task_config.not_after);
+
         match report_share.report_metadata.time {
             t if t >= task_config.not_after => reject!(TaskExpired),
             t if t < task_config.not_before => {tracing::warn!("Reject TaskNotStarted"); reject!(TaskNotStarted)},

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -543,6 +543,7 @@ pub async fn process<A: DapLeader>(
 
     tracing::debug!("RUNNING read_work_stream");
 
+    tracing::warn!("Aggregator valid time range: {:?}", aggregator.valid_report_time_range());
     let mut agg_jobs = HashMap::new();
     let mut pending_coll_jobs = Vec::new();
     for work_item in aggregator.dequeue_work(num_items).await? {
@@ -565,6 +566,7 @@ pub async fn process<A: DapLeader>(
                         return Ok(0);
                     }
 
+                    tracing::warn!("Retrieved time range: {}..{}", task_config.not_before, task_config.not_after);
                     tracing::debug!(
                         "RUNNING run_agg_job FOR TID {task_id} AND {part_batch_sel:?} AND {host}"
                     );

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -216,7 +216,6 @@ pub async fn handle_upload_req<A: DapLeader>(
         .into());
     }
 
-    // Check that the report was generated after the task's `not_before` time.
     if report.report_metadata.time
         < task_config.as_ref().not_before - task_config.as_ref().time_precision
     {
@@ -225,6 +224,13 @@ pub async fn handle_upload_req<A: DapLeader>(
         }
         .into());
     }
+
+    // Check that the report was generated after the task's `not_before` time.
+    println!(
+        "report_metadata.time - task_config.not_before: {}",
+        report.report_metadata.time as i128 - task_config.as_ref().not_before as i128
+    );
+    println!("report_metadata.time: {}", report.report_metadata.time);
 
     if let Some(public_extensions) = &report.report_metadata.public_extensions {
         // We can be sure at this point that the ReportMetadata is well formed

--- a/crates/daphne/src/roles/mod.rs
+++ b/crates/daphne/src/roles/mod.rs
@@ -1545,7 +1545,7 @@ mod test {
         }
         .to_config_with_taskprov(
             b"cool task".to_vec(),
-            t.now,
+            t.now + 1,
             t.leader.get_taskprov_config().unwrap(),
         )
         .unwrap();

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -679,7 +679,7 @@ impl DapAggregator for InMemoryAggregator {
     ) -> Result<DapTaskConfig, DapError> {
         // Always opt-in with four shards.
         Ok(task_config.into_opted_in(&taskprov::OptInParam {
-            not_before: self.get_current_time(),
+            not_before: self.get_current_time() - 60,
             num_agg_span_shards: NonZeroUsize::new(4).unwrap(),
         }))
     }

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -689,6 +689,7 @@ impl DapAggregator for InMemoryAggregator {
         task_id: &TaskId,
         task_config: DapTaskConfig,
     ) -> Result<(), DapError> {
+        tracing::warn!("Put taskprov config");
         let mut tasks = self.tasks.lock().expect("tasks: lock failed");
         tasks.deref_mut().insert(*task_id, task_config);
         Ok(())


### PR DESCRIPTION
draft-13 changes how time is described in the draft, but the only externally visible change is rejecting reports earlier than task_config.not_before. This PR implements that behaviour, but doesn't adjust our internal representation.