### PR TITLE
daphne: Remove 16-byte `VdafVerifyKey` variant

### DIFF
--- a/crates/daphne/src/vdaf/mastic.rs
+++ b/crates/daphne/src/vdaf/mastic.rs
@@ -70,17 +70,11 @@ pub(crate) fn mastic_shard(
 pub(crate) fn mastic_prep_init(
     input_size: usize,
     weight_config: MasticWeightConfig,
-    verify_key: &VdafVerifyKey,
+    _verify_key: &VdafVerifyKey,
     agg_param: &DapAggregationParam,
     public_share_bytes: &[u8],
     input_share_bytes: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-    let VdafVerifyKey::L16(_verify_key) = verify_key else {
-        return Err(VdafError::Dap(fatal_error!(
-            err = "mastic: unexpected verify key type"
-        )));
-    };
-
     match (weight_config, agg_param) {
         (MasticWeightConfig::Count, DapAggregationParam::Mastic(agg_param)) => {
             // Simulate Mastic, insecurely. The public share encodes the plaintext input; the input

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -81,14 +81,14 @@ impl PineConfig {
 
     pub(crate) fn prep_init(
         &self,
-        verify_key: &VdafVerifyKey,
+        VdafVerifyKey(verify_key): &VdafVerifyKey,
         agg_id: usize,
         nonce: &[u8; 16],
         public_share_data: &[u8],
         input_share_data: &[u8],
     ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-        match (self, verify_key) {
-            (PineConfig::Field32HmacSha256Aes128 { param }, VdafVerifyKey::L32(verify_key)) => {
+        match self {
+            PineConfig::Field32HmacSha256Aes128 { param } => {
                 let vdaf = pine32_hmac_sha256_aes128(param)?;
                 let (state, share) = prep_init(
                     vdaf,
@@ -103,7 +103,7 @@ impl PineConfig {
                     VdafPrepShare::Pine32HmacSha256Aes128(share),
                 ))
             }
-            (PineConfig::Field64HmacSha256Aes128 { param }, VdafVerifyKey::L32(verify_key)) => {
+            PineConfig::Field64HmacSha256Aes128 { param } => {
                 let vdaf = pine64_hmac_sha256_aes128(param)?;
                 let (state, share) = prep_init(
                     vdaf,
@@ -118,9 +118,6 @@ impl PineConfig {
                     VdafPrepShare::Pine64HmacSha256Aes128(share),
                 ))
             }
-            _ => Err(VdafError::Dap(fatal_error!(
-                err = "unhandled config and verify key combination",
-            ))),
         }
     }
 

--- a/crates/daphne/src/vdaf/prio2.rs
+++ b/crates/daphne/src/vdaf/prio2.rs
@@ -55,18 +55,12 @@ pub(crate) fn prio2_shard(
 /// Consume an input share and return the corresponding prep state and share.
 pub(crate) fn prio2_prep_init(
     dimension: usize,
-    verify_key: &VdafVerifyKey,
+    VdafVerifyKey(verify_key): &VdafVerifyKey,
     agg_id: usize,
     nonce: &[u8; 16],
     public_share_data: &[u8],
     input_share_data: &[u8],
 ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-    let VdafVerifyKey::L32(verify_key) = verify_key else {
-        return Err(VdafError::Dap(fatal_error!(
-            err = "unhandled verify key type"
-        )));
-    };
-
     let vdaf = Prio2::new(dimension).map_err(|e| {
         VdafError::Dap(fatal_error!(err = ?e, "failed to create prio2 from {dimension}"))
     })?;

--- a/crates/daphne/src/vdaf/prio3.rs
+++ b/crates/daphne/src/vdaf/prio3.rs
@@ -111,15 +111,15 @@ impl Prio3Config {
     pub(crate) fn prep_init(
         &self,
         version: DapVersion,
-        verify_key: &VdafVerifyKey,
+        VdafVerifyKey(verify_key): &VdafVerifyKey,
         task_id: TaskId,
         agg_id: usize,
         nonce: &[u8; 16],
         public_share_data: &[u8],
         input_share_data: &[u8],
     ) -> Result<(VdafPrepState, VdafPrepShare), VdafError> {
-        return match (version, self, verify_key) {
-            (DapVersion::Latest, Prio3Config::Count, VdafVerifyKey::L32(verify_key)) => {
+        return match (version, self) {
+            (DapVersion::Latest, Prio3Config::Count) => {
                 let vdaf = Prio3::new_count(2).map_err(|e| {
                     VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
                 })?;
@@ -137,11 +137,7 @@ impl Prio3Config {
                     VdafPrepShare::Prio3Field64(share),
                 ))
             }
-            (
-                DapVersion::Latest,
-                Prio3Config::Sum { max_measurement },
-                VdafVerifyKey::L32(verify_key),
-            ) => {
+            (DapVersion::Latest, Prio3Config::Sum { max_measurement }) => {
                 let vdaf = Prio3::new_sum(2, *max_measurement).map_err(|e| {
                     VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
                 })?;
@@ -165,7 +161,6 @@ impl Prio3Config {
                     length,
                     chunk_length,
                 },
-                VdafVerifyKey::L32(verify_key),
             ) => {
                 let vdaf = Prio3::new_histogram(2, *length, *chunk_length).map_err(|e| {
                     VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
@@ -191,7 +186,6 @@ impl Prio3Config {
                     length,
                     chunk_length,
                 },
-                VdafVerifyKey::L32(verify_key),
             ) => {
                 let vdaf = Prio3::new_sum_vec(2, *bits, *length, *chunk_length).map_err(|e| {
                     VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
@@ -218,7 +212,6 @@ impl Prio3Config {
                     chunk_length,
                     num_proofs,
                 },
-                VdafVerifyKey::L32(verify_key),
             ) => {
                 let vdaf = draft09::new_prio3_sum_vec_field64_multiproof_hmac_sha256_aes128(
                     *bits,


### PR DESCRIPTION
This length was required for Prio3 by VDAF-09. However, we only support variants of Prio3 in VDAF-09 that use the custom XOF, which has a 32-byte key.

Also, once Mastic support is fully implemented, it will also use a 32-byte key.