### PR TITLE
DAP-13: Reject reports with timestamps before task start time

### DIFF
--- a/crates/daphne-server/src/router/extractor.rs
+++ b/crates/daphne-server/src/router/extractor.rs
@@ -675,10 +675,8 @@ mod test {
             min_batch_size: 1,
             query_config: daphne::messages::taskprov::QueryConfig::TimeInterval,
             lifetime: match version {
-                DapVersion::Draft09 => {
-                    daphne::messages::taskprov::TaskLifetime::Draft09 { expiration: 1 }
-                }
-                DapVersion::Latest => daphne::messages::taskprov::TaskLifetime::Latest {
+                DapVersion::Draft09 => daphne::DapTaskLifetime::Draft09 { expiration: 1 },
+                DapVersion::Latest => daphne::DapTaskLifetime::Latest {
                     start: 0,
                     duration: 1,
                 },

--- a/crates/daphne-server/tests/e2e/e2e.rs
+++ b/crates/daphne-server/tests/e2e/e2e.rs
@@ -598,7 +598,7 @@ async fn internal_leader_process(version: DapVersion) {
     // Upload a number of reports (a few more than the aggregation rate).
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size + 3 {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         t.leader_request_expect_ok(
             client,
             &path,
@@ -676,7 +676,7 @@ async fn leader_collect_ok(version: DapVersion) {
     let mut time_min = u64::MAX;
     let mut time_max = 0u64;
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         time_min = min(time_min, now);
         time_max = max(time_max, now);
         t.leader_request_expect_ok(
@@ -785,7 +785,7 @@ async fn leader_collect_ok(version: DapVersion) {
     // to avoid sharding ReportsProcessed by batch bucket, which is not feasilbe for fixed-size
     // tasks.
     //
-    //  let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+    //  let now = rng.gen_range(t.report_interval(&batch_interval));
     //  t.leader_post_expect_abort(
     //      &client,
     //      None, // dap_auth_token
@@ -819,7 +819,7 @@ async fn leader_collect_ok_interleaved(version: DapVersion) {
     // The reports are uploaded ...
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         t.leader_request_expect_ok(
             client,
             &path,
@@ -883,7 +883,7 @@ async fn leader_collect_not_ready_min_batch_size(version: DapVersion) {
     // A number of reports are uploaded, but not enough to meet the minimum batch requirement.
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size - 1 {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         t.leader_request_expect_ok(
             client,
             &path,
@@ -974,7 +974,7 @@ async fn leader_collect_back_compat(version: DapVersion) {
     let mut time_min = u64::MAX;
     let mut time_max = 0u64;
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         time_min = min(time_min, now);
         time_max = max(time_max, now);
         t.leader_request_expect_ok(
@@ -1129,7 +1129,7 @@ async fn leader_collect_abort_overlapping_batch_interval(version: DapVersion) {
     // The reports are uploaded in the background.
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         t.leader_request_expect_ok(
             client,
             &path,
@@ -1433,7 +1433,7 @@ async fn leader_collect_taskprov_ok(version: DapVersion) {
     let mut rng = thread_rng();
     for _ in 0..t.task_config.min_batch_size {
         let extensions = vec![Extension::Taskprov];
-        let now = rng.gen_range(TestRunner::report_interval(&batch_interval));
+        let now = rng.gen_range(t.report_interval(&batch_interval));
         t.leader_request_expect_ok(
             client,
             &path,

--- a/crates/daphne-service-utils/src/compute_offload/compute_offload.capnp
+++ b/crates/daphne-service-utils/src/compute_offload/compute_offload.capnp
@@ -44,13 +44,14 @@ struct HpkeReceiverConfig @0xeec9b4a50458edb7 {
     privateKey @1 :Data;
 }
 
-struct PartialDapTaskConfig @0xdcc9bf18fc62d406 {
+struct PartialDapTaskConfig @0xb11c76132b15968a {
 
     version             @0  :Base.DapVersion;
     methodIsTaskprov    @1  :Bool;
-    notAfter            @2  :Base.Time;
-    vdaf                @3  :VdafConfig;
-    vdafVerifyKey       @4  :VdafVerifyKey;
+    notBefore           @2  :Base.Time;
+    notAfter            @3  :Base.Time;
+    vdaf                @4  :VdafConfig;
+    vdafVerifyKey       @5  :VdafVerifyKey;
 }
 
 struct PublicExtensionsList @0x8b3c98c0ddd0043e {

--- a/crates/daphne-service-utils/src/compute_offload/mod.rs
+++ b/crates/daphne-service-utils/src/compute_offload/mod.rs
@@ -203,12 +203,14 @@ impl CapnprotoPayloadEncode for PartialDapTaskConfigForReportInit<'_> {
 
     fn encode_to_builder(&self, mut builder: Self::Builder<'_>) {
         let PartialDapTaskConfigForReportInit {
+            not_before,
             not_after,
             method_is_taskprov,
             version,
             vdaf,
             vdaf_verify_key,
         } = self;
+        builder.set_not_before(*not_before);
         builder.set_not_after(*not_after);
         builder.set_method_is_taskprov(*method_is_taskprov);
         builder.set_version((*version).into());
@@ -227,6 +229,7 @@ impl CapnprotoPayloadDecode for PartialDapTaskConfigForReportInit<'static> {
         Self: Sized,
     {
         Ok(Self {
+            not_before: reader.get_not_before(),
             not_after: reader.get_not_after(),
             method_is_taskprov: reader.get_method_is_taskprov(),
             version: reader.get_version()?.into(),

--- a/crates/daphne-service-utils/src/test_route_types.rs
+++ b/crates/daphne-service-utils/src/test_route_types.rs
@@ -7,8 +7,9 @@
 
 use daphne::{
     constants::DapAggregatorRole,
-    messages::{Duration, TaskId, Time},
+    messages::{Duration, TaskId},
     vdaf::{Prio3Config, VdafConfig},
+    DapTaskLifetime,
 };
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
@@ -113,5 +114,7 @@ pub struct InternalTestAddTask {
     pub max_batch_size: Option<NonZeroU32>,
     pub time_precision: Duration,
     pub collector_hpke_config: String, // base64url
-    pub task_expiration: Time,
+    // TODO(cjpatton) Align this with draft-dcook-ppm-dap-interop-test-design once it's updated to
+    // DAP-13. I'm pretty sure we won't need to be backwards compatible.
+    pub lifetime: DapTaskLifetime,
 }

--- a/crates/daphne-worker-test/wrangler.aggregator.toml
+++ b/crates/daphne-worker-test/wrangler.aggregator.toml
@@ -95,6 +95,7 @@ preview_id = "24c4dc92d5cf4680e508fe18eb8f0281"
 name = "daphne-leader-aggregator"
 
 [env.leader.vars]
+DAP_TRACING="debug"
 DAP_DEPLOYMENT = "dev"
 DAP_WORKER_MODE = "aggregator"
 DAP_DURABLE_HELPER_STATE_STORE_GC_AFTER_SECS = "30"

--- a/crates/daphne-worker/src/aggregator/roles/mod.rs
+++ b/crates/daphne-worker/src/aggregator/roles/mod.rs
@@ -114,7 +114,7 @@ mod test_utils {
         messages::decode_base64url_vec,
         roles::DapAggregator as _,
         vdaf::{Prio3Config, VdafConfig},
-        DapBatchMode, DapError, DapTaskConfig, DapVersion,
+        DapBatchMode, DapError, DapTaskConfig, DapTaskLifetime, DapVersion,
     };
     use daphne_service_utils::{
         bearer_token::BearerToken,
@@ -279,6 +279,19 @@ mod test_utils {
                 }
             };
 
+            let (not_before, not_after) = match cmd.lifetime {
+                DapTaskLifetime::Latest { start, duration } => {
+                    (start, start.saturating_add(duration))
+                }
+                // draft09 compatibility: Previously the task start time was not conveyed by the
+                // taskprov advertisement, so just use the current time.
+                DapTaskLifetime::Draft09 { expiration } => (self.get_current_time(), expiration),
+            };
+
+            if not_before >= not_after {
+                tracing::warn!("task has empty validity interval: not_before={not_before}; not_after={not_after}");
+            }
+
             if self
                 .kv()
                 .put_if_not_exists_with_expiration::<kv::prefix::TaskConfig>(
@@ -288,8 +301,8 @@ mod test_utils {
                         leader_url: cmd.leader,
                         helper_url: cmd.helper,
                         time_precision: cmd.time_precision,
-                        not_before: self.get_current_time(),
-                        not_after: cmd.task_expiration,
+                        not_before,
+                        not_after,
                         min_batch_size: cmd.min_batch_size,
                         query,
                         vdaf,
@@ -298,7 +311,7 @@ mod test_utils {
                         method: Default::default(),
                         num_agg_span_shards: NonZeroUsize::new(4).unwrap(),
                     },
-                    cmd.task_expiration,
+                    not_after,
                 )
                 .await
                 .map_err(|e| fatal_error!(err = ?e, "failed to put task config in kv"))?

--- a/crates/daphne-worker/src/aggregator/router/extractor.rs
+++ b/crates/daphne-worker/src/aggregator/router/extractor.rs
@@ -731,10 +731,8 @@ mod test {
             min_batch_size: 1,
             query_config: daphne::messages::taskprov::QueryConfig::TimeInterval,
             lifetime: match version {
-                DapVersion::Draft09 => {
-                    daphne::messages::taskprov::TaskLifetime::Draft09 { expiration: 1 }
-                }
-                DapVersion::Latest => daphne::messages::taskprov::TaskLifetime::Latest {
+                DapVersion::Draft09 => daphne::DapTaskLifetime::Draft09 { expiration: 1 },
+                DapVersion::Latest => daphne::DapTaskLifetime::Latest {
                     start: 0,
                     duration: 1,
                 },

--- a/crates/daphne/src/protocol/aggregator.rs
+++ b/crates/daphne/src/protocol/aggregator.rs
@@ -176,12 +176,14 @@ impl DapTaskConfig {
                     ..
                 } => {
                     // Skip report that can't be processed any further.
+                    tracing::warn!("produce_agg_job_req: rejected report: {failure:?}");
                     metrics.report_inc_by(ReportStatus::Rejected(failure), 1);
                     continue;
                 }
             }
         }
 
+        tracing::debug!("produce_agg_job_req: reports count: {}", prep_inits.len());
         Ok((
             DapAggregationJobState {
                 seq: states,
@@ -252,6 +254,10 @@ impl DapTaskConfig {
                 task_id: *task_id,
             })?;
         }
+        tracing::debug!(
+            "consume_agg_job_req: reports count: {}",
+            agg_job_init_req.prep_inits.len()
+        );
 
         agg_job_init_req
             .prep_inits
@@ -413,6 +419,7 @@ impl DapTaskConfig {
 
                 // Skip report that can't be processed any further.
                 TransitionVar::Failed(err) => {
+                    tracing::warn!("report rejected by Helper: {err:?}");
                     metrics.report_inc_by(ReportStatus::Rejected(*err), 1);
                     continue;
                 }

--- a/crates/daphne/src/protocol/mod.rs
+++ b/crates/daphne/src/protocol/mod.rs
@@ -401,12 +401,15 @@ mod test {
 
         let agg_job_init_req = {
             // Temporarily overwrite the valid report time range so that the Leader accepts the
-            // out-of-range report and produces the request.
-            let tmp = t.valid_report_range.clone();
+            // out-of-range report and produces the request. Likewise for the task start time.
+            let tmp_valid_time_range = t.valid_report_range.clone();
+            let tmp_not_before = t.task_config.not_before;
             t.valid_report_range = 0..u64::MAX;
+            t.task_config.not_before = 0;
             let (_, agg_job_init_req) =
                 t.produce_agg_job_req(&DapAggregationParam::Empty, reports.clone());
-            t.valid_report_range = tmp;
+            t.valid_report_range = tmp_valid_time_range;
+            t.task_config.not_before = tmp_not_before;
             agg_job_init_req
         };
         let (_agg_span, agg_job_resp) = t.handle_agg_job_req(agg_job_init_req);

--- a/crates/daphne/src/roles/leader/mod.rs
+++ b/crates/daphne/src/roles/leader/mod.rs
@@ -378,6 +378,7 @@ async fn run_agg_job<A: DapLeader>(
         task_config.consume_agg_job_resp(task_id, agg_job_state, agg_job_resp, metrics)?;
 
     let out_shares_count = agg_span.report_count() as u64;
+    debug!("computed {out_shares_count} output shares");
     if out_shares_count == 0 {
         return Ok(0);
     }


### PR DESCRIPTION
Partially addresses #698.
Replaces #755.

Related changes:

* Adjust the bound checks slightly: we should accept a timestamp this
  equal to either the start time or end time.

* Check the report validity window (for replay protection) before task
  validity. This isn't strictly necessary, but it simplifies some unit
  tests.

* Update the representation of the `InternalTestAddTask` struct to
  include the task duration in DAP-13. Note that the format of this
  struct is specified by draft-dcook-ppm-dap-interop-test-design, which
  has not yet been updated for DAP-13. We may need to revise the format
  at a later date.

* Update the report interval computation in the end-to-end tests to
  avoid using a timestamp that precedes the task start time.

* Add more tracing for debugging.