### PR TITLE
Add support for the Mastic VDAF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "prio"
 version = "0.17.0-alpha.0"
-source = "git+https://github.com/divviup/libprio-rs.git?rev=c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1#c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1"
+source = "git+https://github.com/divviup/libprio-rs.git?rev=e5e8a47ee4567f7588d0b5c8d20f75dde4061b2f#e5e8a47ee4567f7588d0b5c8d20f75dde4061b2f"
 dependencies = [
  "aes",
  "bitvec",
@@ -2536,7 +2536,6 @@ dependencies = [
  "ctr",
  "fiat-crypto",
  "fixed",
- "getrandom",
  "hex",
  "hmac",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ matchit = "0.7.3"
 p256 = { version = "0.13.2", features = ["ecdsa-core", "ecdsa", "pem"] }
 paste = "1.0.15"
 prio_draft09 = { package = "prio", version = "0.16.7" }
-prio = { git = "https://github.com/divviup/libprio-rs.git", rev = "c50bb9a47b396ad6a08a3fec36b98bcc2d9217a1" }
+# TODO Point to version `0.17.0` once release. This revision is one commit ahead of `0.17.0-alpha.0`.
+prio = { git = "https://github.com/divviup/libprio-rs.git", rev = "e5e8a47ee4567f7588d0b5c8d20f75dde4061b2f" }
 prometheus = "0.13.4"
 rand = "0.8.5"
 rayon = "1.10.0"

--- a/crates/daphne/src/hpke.rs
+++ b/crates/daphne/src/hpke.rs
@@ -505,7 +505,7 @@ pub mod info_and_aad {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct AggregateShare<'s> {
         // info
         pub version: DapVersion,

--- a/crates/daphne/src/lib.rs
+++ b/crates/daphne/src/lib.rs
@@ -70,7 +70,7 @@ use error::FatalDapError;
 use hpke::{HpkeConfig, HpkeKemId};
 use messages::taskprov::TaskprovAdvertisement;
 #[cfg(feature = "experimental")]
-use prio::{codec::Decode, vdaf::poplar1::Poplar1AggregationParam};
+use prio::{codec::Decode, vdaf::mastic::MasticAggregationParam};
 use prio::{
     codec::{CodecError, Encode, ParameterizedDecode},
     vdaf::Aggregatable as AggregatableTrait,
@@ -813,11 +813,11 @@ pub enum DapMeasurement {
 }
 
 /// An aggregation parameter.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DapAggregationParam {
     Empty,
     #[cfg(feature = "experimental")]
-    Mastic(Poplar1AggregationParam),
+    Mastic(MasticAggregationParam),
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -877,7 +877,7 @@ impl ParameterizedDecode<VdafConfig> for DapAggregationParam {
         let _ = bytes;
         match vdaf_config {
             #[cfg(feature = "experimental")]
-            VdafConfig::Mastic { .. } => Ok(Self::Mastic(Poplar1AggregationParam::decode(bytes)?)),
+            VdafConfig::Mastic(_) => Ok(Self::Mastic(MasticAggregationParam::decode(bytes)?)),
             _ => Ok(Self::Empty),
         }
     }

--- a/crates/daphne/src/testing/mod.rs
+++ b/crates/daphne/src/testing/mod.rs
@@ -209,22 +209,26 @@ impl AggregationJobTest {
         &self,
         agg_job_init_req: AggregationJobInitReq,
     ) -> (DapAggregateSpan<DapAggregateShare>, AggregationJobResp) {
+        let part_batch_sel = agg_job_init_req.part_batch_sel.clone();
+        let (agg_param, initialized_reports) = self
+            .task_config
+            .consume_agg_job_req(
+                &self.helper_hpke_receiver_config,
+                self.valid_report_time_range(),
+                &self.task_id,
+                agg_job_init_req,
+                self.replay_protection,
+            )
+            .unwrap();
+
         let (span, resp) = self
             .task_config
             .produce_agg_job_resp(
                 self.task_id,
+                &agg_param,
                 &HashMap::default(),
-                &agg_job_init_req.part_batch_sel.clone(),
-                &self
-                    .task_config
-                    .consume_agg_job_req(
-                        &self.helper_hpke_receiver_config,
-                        self.valid_report_time_range(),
-                        &self.task_id,
-                        agg_job_init_req,
-                        self.replay_protection,
-                    )
-                    .unwrap(),
+                &part_batch_sel,
+                &initialized_reports,
             )
             .unwrap();
         (span, resp.into())

--- a/crates/daphne/src/vdaf/draft09.rs
+++ b/crates/daphne/src/vdaf/draft09.rs
@@ -97,7 +97,6 @@ where
 
 pub(crate) fn prep_finish_from_shares<V, const VERIFY_KEY_SIZE: usize, const NONCE_SIZE: usize>(
     vdaf: &V,
-    agg_id: usize,
     host_state: V::PrepareState,
     host_share: V::PrepareShare,
     peer_share_data: &[u8],
@@ -105,18 +104,11 @@ pub(crate) fn prep_finish_from_shares<V, const VERIFY_KEY_SIZE: usize, const NON
 where
     V: Vdaf<AggregationParam = ()> + Aggregator<VERIFY_KEY_SIZE, NONCE_SIZE>,
 {
-    // Decode the Helper's inbound message.
+    // Decode the peer's inbound message.
     let peer_share = V::PrepareShare::get_decoded_with_param(&host_state, peer_share_data)?;
 
     // Preprocess the inbound messages.
-    let message = vdaf.prepare_shares_to_prepare_message(
-        &(),
-        if agg_id == 0 {
-            [host_share, peer_share]
-        } else {
-            [peer_share, host_share]
-        },
-    )?;
+    let message = vdaf.prepare_shares_to_prepare_message(&(), [peer_share, host_share])?;
     let message_data = message.get_encoded()?;
 
     // Compute the host's output share.

--- a/crates/daphne/src/vdaf/pine.rs
+++ b/crates/daphne/src/vdaf/pine.rs
@@ -123,7 +123,6 @@ impl PineConfig {
 
     pub(crate) fn prep_finish_from_shares(
         &self,
-        agg_id: usize,
         host_state: VdafPrepState,
         host_share: VdafPrepShare,
         peer_share_data: &[u8],
@@ -136,7 +135,7 @@ impl PineConfig {
             ) => {
                 let vdaf = pine32_hmac_sha256_aes128(param)?;
                 let (out_share, outbound) =
-                    draft09::prep_finish_from_shares(&vdaf, agg_id, state, share, peer_share_data)?;
+                    draft09::prep_finish_from_shares(&vdaf, state, share, peer_share_data)?;
                 let agg_share = VdafAggregateShare::Field32Draft09(AggregateShare::from(
                     OutputShare::from(out_share.0),
                 ));
@@ -149,7 +148,7 @@ impl PineConfig {
             ) => {
                 let vdaf = pine64_hmac_sha256_aes128(param)?;
                 let (out_share, outbound) =
-                    draft09::prep_finish_from_shares(&vdaf, agg_id, state, share, peer_share_data)?;
+                    draft09::prep_finish_from_shares(&vdaf, state, share, peer_share_data)?;
                 let agg_share = VdafAggregateShare::Field64Draft09(AggregateShare::from(
                     OutputShare::from(out_share.0),
                 ));


### PR DESCRIPTION
Mastic (https://datatracker.ietf.org/doc/draft-mouris-cfrg-mastic/) is a
VDAF that enables a richer set of functionalities than the VDAFs we
support so so far. The `daphne::vdaf::mastic` module contains a "dummy"
version of Mastic intended to exercise the DAP protocol logic we would
need in order to fully support this VDAF. The `prio` crate now
implements Mastic, so upgrade to a version of the crate that supports it
and replace the dummy VDAF with the real one.

In addition, to complete aggregation of a report, it is necessary to
know the aggregation parameter, which currently is only plumbed to
report initialization. In particular,
`DapTaskConfig::produce_agg_job_resp()` needs the aggregation parameter
from the aggregation job request message. (Likewise,
`ToInitializedReportsTransition::with_initialized_reports()` needs the
aggregation parameter.)

Finally, clean up some API cruft in `daphne::vdaf`:

1. Encapsulate variants of Mastic behind a `MasticConfig` as we've done
   for other VDAFs.

2. Modify `prep_finish_from_shares()` to not take the aggregator ID.
   This is a relic of when we supported DAP-02, when this method may
   have been called by either the Leader or the Helper. Now it's always
   called by the Helper.

3. Implement state encoding for Mastic, as required by the new async
   Helper implementation.

4. Generalize the `prep_init()` function in `daphne::prio3` to be used
   for Mastic as well.