### PR TITLE
fix: use subtle for constant-time comparison

### DIFF
--- a/crates/daphne/src/messages/mod.rs
+++ b/crates/daphne/src/messages/mod.rs
@@ -22,6 +22,7 @@ use std::{
     fmt,
     io::{Cursor, Read},
 };
+use subtle::ConstantTimeEq;
 
 // Batch modes
 const BATCH_MODE_TIME_INTERVAL: u8 = 0x01;
@@ -1485,18 +1486,8 @@ impl ParameterizedDecode<DapVersion> for PlaintextInputShare {
     }
 }
 
-// NOTE ring provides a similar function, but as of version 0.16.20, it doesn't compile to
-// wasm32-unknown-unknown.
 pub fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    if left.len() != right.len() {
-        return false;
-    }
-
-    let mut r = 0;
-    for (x, y) in left.iter().zip(right) {
-        r |= x ^ y;
-    }
-    r == 0
+    bool::from(left.ct_eq(right))
 }
 
 pub(crate) fn encode_u16_bytes(bytes: &mut Vec<u8>, input: &[u8]) -> Result<(), CodecError> {
@@ -1703,6 +1694,14 @@ mod test {
                 .unwrap_err(),
             CodecError::BytesLeftOver(..)
         ));
+    }
+
+    #[test]
+    fn constant_time_eq_matches_slice_equality() {
+        assert!(constant_time_eq(b"", b""));
+        assert!(constant_time_eq(b"same bytes", b"same bytes"));
+        assert!(!constant_time_eq(b"same bytes", b"same bytez"));
+        assert!(!constant_time_eq(b"short", b"shorter"));
     }
 
     fn partial_batch_selector_encode_decode(version: DapVersion) {

--- a/crates/daphne/src/vdaf/prio3.rs
+++ b/crates/daphne/src/vdaf/prio3.rs
@@ -22,6 +22,7 @@ use prio::{
     },
 };
 use std::io::Cursor;
+use subtle::ConstantTimeEq;
 
 impl Prio3Config {
     pub(crate) fn shard(
@@ -35,10 +36,11 @@ impl Prio3Config {
             (DapVersion::Latest, Prio3Config::Count, DapMeasurement::U64(measurement))
                 if measurement < 2 =>
             {
+                let measurement = bool::from(measurement.ct_eq(&1));
                 let vdaf = Prio3::new_count(2).map_err(|e| {
                     VdafError::Dap(fatal_error!(err = ?e, "initializing {self:?} failed"))
                 })?;
-                shard_then_encode(&vdaf, task_id, &(measurement != 0), nonce)
+                shard_then_encode(&vdaf, task_id, &measurement, nonce)
             }
             (
                 DapVersion::Latest,
@@ -610,6 +612,18 @@ mod test {
             ],
         );
         assert_eq!(got, DapAggregateResult::U64(3));
+    }
+
+    #[test]
+    fn count_rejects_non_binary_measurement() {
+        let got = Prio3Config::Count.shard(
+            DapVersion::Latest,
+            DapMeasurement::U64(2),
+            &[0; 16],
+            crate::messages::TaskId([0; 32]),
+        );
+
+        assert!(got.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replace Daphne's hand-rolled `constant_time_eq()` helper with `subtle::ConstantTimeEq`, which is already available through the workspace and `daphne` crate dependencies. The public helper keeps the same `&[u8] -> bool` API, so existing bearer-token and request-body comparison call sites do not need to change.

This also addresses the related Prio3 count TODO by converting valid count measurements to `bool` with `ConstantTimeEq` before sharding. Non-binary count measurements still follow the existing rejection path.

## Tests

- `cargo fmt --check`
- `cargo test -p daphne constant_time_eq_matches_slice_equality`
- `cargo test -p daphne count_rejects_non_binary_measurement`
- `cargo test -p daphne --lib`
- `git diff --check`

Closes #247.
